### PR TITLE
[CHORE] Swagger 설정

### DIFF
--- a/src/main/java/org/sopt/solply_server/global/config/SwaggerConfig.java
+++ b/src/main/java/org/sopt/solply_server/global/config/SwaggerConfig.java
@@ -3,6 +3,8 @@ package org.sopt.solply_server.global.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,10 +19,23 @@ public class SwaggerConfig {
                 .description("SOPT 앱잼 - SOLPLY API입니다")
                 .version("1.0");
 
+        // 모든 엔드포인트에 JWT 인증 요구사항 적용 (추후 다시 고려. 필요에 따라 개별 API에 @SecurityRequirement 적용 가능)
+        String jwtSchemeName = "JWTToken";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+
+        // JWT 인증을 위한 SecurityScheme 추가
+        SecurityScheme bearerAuth = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization");
+
         return new OpenAPI()
                 .addServersItem(new Server().url("/"))
                 .info(info)
-                .components(new Components());
+                .addSecurityItem(securityRequirement)
+                .components(new Components().addSecuritySchemes(jwtSchemeName, bearerAuth));
 
     }
 

--- a/src/main/java/org/sopt/solply_server/global/config/SwaggerConfig.java
+++ b/src/main/java/org/sopt/solply_server/global/config/SwaggerConfig.java
@@ -1,0 +1,27 @@
+package org.sopt.solply_server.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI SOLPLY_API(){
+        Info info=new Info()
+                .title("솔플리_API")
+                .description("SOPT 앱잼 - SOLPLY API입니다")
+                .version("1.0");
+
+        return new OpenAPI()
+                .addServersItem(new Server().url("/"))
+                .info(info)
+                .components(new Components());
+
+    }
+
+}


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #5 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- 스웨거(SpringDoc OpenAPI) 설정을 추가하여 API 문서화를 자동화했습니다.
- JWT 토큰을 이용한 인증/인가 테스트가 가능하도록 SecurityScheme을 정의하고 OpenAPI 전역에 보안 요구사항을 적용했습니다.
- API의 기본 정보(제목, 설명, 버전 등)를 설정했습니다.


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 현재는 모든 엔드포인트에 JWT 인증 요구사항을 전역적으로 적용하도록 했지만, 로그인/회원가입 등 인증이 필요 없는 API의 경우 향후 `@SecurityRequirement` 어노테이션을 개별 API에 적용하도록 고려할 수 있을 것 같습니다.
- Spring Security 설정에서 /swagger-ui/**, /v3/api-docs/** 경로에 대한 접근 허용이 필요합니다. 따로 허용을 해주지 않아도 된다고 알고있기도 해서 우선은 추후 SecurityConfig 생성 후 재고려해보려 합니다.

<br/>

## 🚀 알게된 점 (선택)

---

- `Components`: 재사용 가능한 스키마, 응답, 보안 스키마 등을 정의
- `OpenAPI`: 전체 OpenAPI 문서의 루트 객체
- `Info`: API의 제목, 설명, 버전 등의 기본 정보 정의
- `SecurityRequirement`: 특정 보안 스키마를 요구하는 API 엔드포인트를 지정
- `SecurityScheme`: 인증 방식 (예: JWT, OAuth2) 정의
- `Server`: API 서버의 URL 정의

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 