### PR TITLE
[FEAT] s3 연결 세팅, 읽기용 presignedurl 발급, 공개 이미지 접근 url 발급

### DIFF
--- a/src/main/java/org/sopt/solply_server/global/config/AwsConfig.java
+++ b/src/main/java/org/sopt/solply_server/global/config/AwsConfig.java
@@ -1,0 +1,47 @@
+package org.sopt.solply_server.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class AwsConfig {
+
+    @Value("${aws.accessKey}")
+    private String accessKey;
+
+    @Value("${aws.secretKey}")
+    private String secretKey;
+
+    @Value("${aws.region}")
+    private String region;
+
+    private AwsCredentials getCredentials() {
+        return AwsBasicCredentials.create(accessKey, secretKey);
+    }
+
+    // 파일 업로드, 다운로드, 삭제 등의 작업을 하는 객체를 빈으로 등록
+    @Bean
+    public S3Client S3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(this::getCredentials)
+                .build();
+    }
+
+    // presigned URL을 생성하는 객체를 빈으로 등록
+    @Bean
+    public S3Presigner S3Presigner() {
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(this::getCredentials)
+                .build();
+    }
+
+}

--- a/src/main/java/org/sopt/solply_server/global/util/InputValidator.java
+++ b/src/main/java/org/sopt/solply_server/global/util/InputValidator.java
@@ -1,0 +1,14 @@
+package org.sopt.solply_server.global.util;
+
+public class InputValidator {
+
+    public static boolean isNull(final Object object) {
+        if (object == null) {
+            return false;
+        }
+        if (object instanceof String) {
+            return !((String) object).isEmpty();
+        }
+        return true;
+    }
+}

--- a/src/main/java/org/sopt/solply_server/global/util/s3/ImageUrlProvider.java
+++ b/src/main/java/org/sopt/solply_server/global/util/s3/ImageUrlProvider.java
@@ -1,0 +1,23 @@
+package org.sopt.solply_server.global.util.s3;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.solply_server.global.util.InputValidator;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ImageUrlProvider {
+
+    @Value("${aws.cloudfront.domain}")
+    private String cloudfrontDomain;
+
+    // 공개 이미지 파일용 URL 생성기
+    public String getImageUrl(String fileKey) {
+        if (InputValidator.isNull(fileKey)) return null;
+
+        // cloudfront를 통해 s3에 저장된 이미지 파일에 접근하는 url 생성
+        return String.format("https://%s/%s", cloudfrontDomain, fileKey);
+    }
+
+}

--- a/src/main/java/org/sopt/solply_server/global/util/s3/PresignedUrlProvider.java
+++ b/src/main/java/org/sopt/solply_server/global/util/s3/PresignedUrlProvider.java
@@ -1,0 +1,34 @@
+package org.sopt.solply_server.global.util.s3;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.sopt.solply_server.global.util.InputValidator;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+
+@Component
+@RequiredArgsConstructor
+public class PresignedUrlProvider {
+
+    @Value("${aws.s3.bucket}")
+    private String bucketName;
+
+    private final S3Presigner s3Presigner;
+
+    public String generatePresignedUrlToRead(final String fileKey) {
+        if (InputValidator.isNull(fileKey)) return null;
+
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofHours(1))
+                .getObjectRequest(req -> req
+                        .bucket(bucketName)
+                        .key(fileKey)
+                        .build())
+                .build();
+
+        return s3Presigner.presignGetObject(presignRequest).url().toExternalForm();
+    }
+
+}


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #26 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->
- filekey에 해당하는 이미지가 s3에 올라가있는지 체크하고 presignedurl을 발급해야 하나 고민을 했는데, 결론은 매번 PresignedUrl을 생성할 때마다 이미지 존재 여부를 검증을 하게 되면, N+1 문제도 발생할 수 있고 s3 api가 과도하게 호출되는 문제가 있을 것 같더라구요. <br> 그래서 잘못된 presignedurl이 클라에게 전송되더라도 누락된(기본) 이미지 처리를 해주는 것이 더 나을 것 같다는 생각에 이런 식으로 구현을 했습니다.
- s3 버킷은 기본적으로 퍼블릭 엑세스를 차단하도록 해놨습니다. 그런데, 사실 장소 이미지 같은 것들은 민감한 정보도 아니고, 굳이 presignedurl을 발급해줘야 하나라는 생각이 들더라구요! 그래서, cloudfront라는 aws cdn 서비스를 이용해서 presignedurl 없이도 s3 검증을 우회하여 접근할 수 있는 url을 생성하는 메서드(`getImageUrl`)을 따로 만들게 됐습니다.


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- presignedurl 관련 api를 만들만한 부분이 따로 없더라구요. 그래서, 나중에 업로드 기능을 구현해야 될 때 구현하면 될 것 같아요. <br>pr에 작성한 코드들은 추후에 장소 데이터를 조회하거나 할 때 사용할 유틸 클래스들이라고 보시면 됩니다!
- cloudfront가 무엇인지 가볍게 찾아보셔도 좋을 것 같습니다!

<br/>

## 🚀 알게된 점 (선택)

---

-

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 