### PR TITLE
[FEAT] 닉네임 중복 검사 API 구현

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/user/controller/UserController.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/controller/UserController.java
@@ -1,0 +1,40 @@
+package org.sopt.solply_server.domain.user.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.RequiredArgsConstructor;
+import org.sopt.solply_server.domain.user.dto.response.NicknameCheckResponse;
+import org.sopt.solply_server.domain.user.service.UserService;
+import org.sopt.solply_server.global.dto.CustomApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "User", description = "사용자 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+@Validated
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "닉네임 중복 검사", description = "닉네임 사용 가능 여부를 확인합니다.")
+    @GetMapping("/check-nickname")
+    public ResponseEntity<CustomApiResponse<NicknameCheckResponse>> checkNickname(
+            @Parameter(description = "확인할 닉네임", required = true)
+            @RequestParam("nickname")
+            @NotBlank(message = "닉네임은 필수입니다")
+            @Size(min = 2, max = 8, message = "닉네임은 2자 이상 8자 이하여야 합니다")
+            String nickname
+    ) {
+        NicknameCheckResponse response = userService.checkNickname(nickname);
+        return CustomApiResponse.success("닉네임 중복검사에 성공했습니다", response);
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/user/dto/response/NicknameCheckResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/dto/response/NicknameCheckResponse.java
@@ -1,0 +1,9 @@
+package org.sopt.solply_server.domain.user.dto.response;
+
+public record NicknameCheckResponse(
+        boolean isDuplicated
+) {
+    public static NicknameCheckResponse of(boolean isDuplicated) {
+        return new NicknameCheckResponse(isDuplicated);
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/user/entity/Persona.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/entity/Persona.java
@@ -1,0 +1,16 @@
+package org.sopt.solply_server.domain.user.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Persona {
+    HEALING("REST", "조용한 공간에 오래 머물고 싶어요"),
+    EXPLORER("EXPLORER", "이곳저곳 둘러보고 싶어요"),
+    MOODING("MOODING", "취향이 담긴 곳을 찾고싶어요"),
+    NATURAL("NATURAL", "자연을 감상하며 쉬고 싶어요");
+
+    private final String code;
+    private final String description;
+}

--- a/src/main/java/org/sopt/solply_server/domain/user/entity/User.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/entity/User.java
@@ -1,11 +1,6 @@
 package org.sopt.solply_server.domain.user.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -24,19 +19,32 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(unique = true, length = 30)
     private String nickname;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String email;
 
     @Column(nullable = false)
     private boolean isNewUser;
+
+    private String favoriteTowns;
+
+    @Enumerated(EnumType.STRING)
+    private Persona persona;
 
     public static User create(String email) {
         return User.builder()
                 .email(email)
                 .isNewUser(true)
                 .build();
+    }
+
+    public void updateOnboardingInfo(String nickname, String favoriteTowns, Persona persona) {
+        this.nickname = nickname;
+        this.favoriteTowns = favoriteTowns;
+        this.persona = persona;
+        this.isNewUser = false; // 온보딩 완료
     }
 
 }

--- a/src/main/java/org/sopt/solply_server/domain/user/entity/User.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/entity/User.java
@@ -31,7 +31,7 @@ public class User {
     private String favoriteTowns;
 
     @Enumerated(EnumType.STRING)
-    private Persona persona;
+    private UserPersona userPersona;
 
     public static User create(String email) {
         return User.builder()
@@ -40,10 +40,10 @@ public class User {
                 .build();
     }
 
-    public void updateOnboardingInfo(String nickname, String favoriteTowns, Persona persona) {
+    public void updateOnboardingInfo(String nickname, String favoriteTowns, UserPersona userPersona) {
         this.nickname = nickname;
         this.favoriteTowns = favoriteTowns;
-        this.persona = persona;
+        this.userPersona = userPersona;
         this.isNewUser = false; // 온보딩 완료
     }
 

--- a/src/main/java/org/sopt/solply_server/domain/user/entity/UserPersona.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/entity/UserPersona.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum Persona {
+public enum UserPersona {
     HEALING("REST", "조용한 공간에 오래 머물고 싶어요"),
     EXPLORER("EXPLORER", "이곳저곳 둘러보고 싶어요"),
     MOODING("MOODING", "취향이 담긴 곳을 찾고싶어요"),

--- a/src/main/java/org/sopt/solply_server/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/repository/UserRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     User findByEmail(String email);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
@@ -3,6 +3,7 @@ package org.sopt.solply_server.domain.user.service;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.sopt.solply_server.domain.auth.constant.SocialPlatform;
+import org.sopt.solply_server.domain.user.dto.response.NicknameCheckResponse;
 import org.sopt.solply_server.domain.user.entity.SocialUserInfo;
 import org.sopt.solply_server.domain.user.entity.User;
 import org.sopt.solply_server.domain.user.repository.SocialUserInfoRepository;
@@ -15,5 +16,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class UserService {
 
+    private final UserRepository userRepository;
+
+    public NicknameCheckResponse checkNickname(String nickname) {
+        boolean isDuplicated = userRepository.existsByNickname(nickname);
+
+        return NicknameCheckResponse.of(isDuplicated);
+    }
 
 }

--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
@@ -1,11 +1,7 @@
 package org.sopt.solply_server.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
-import org.sopt.solply_server.domain.auth.constant.SocialPlatform;
 import org.sopt.solply_server.domain.user.dto.response.NicknameCheckResponse;
-import org.sopt.solply_server.domain.user.entity.SocialUserInfo;
-import org.sopt.solply_server.domain.user.entity.User;
-import org.sopt.solply_server.domain.user.repository.SocialUserInfoRepository;
 import org.sopt.solply_server.domain.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/org/sopt/solply_server/global/exception/ErrorCode.java
+++ b/src/main/java/org/sopt/solply_server/global/exception/ErrorCode.java
@@ -18,12 +18,13 @@ public enum ErrorCode {
     INVALID_REQUEST_BODY(HttpStatus.BAD_REQUEST, "COMMON-001", "요청 입력값이 올바르지 않습니다."),
     INVALID_ARGUMENT_TYPE(HttpStatus.BAD_REQUEST, "COMMON-002", "잘못된 매개변수 타입입니다."),
     INVALID_JSON_FORMAT(HttpStatus.BAD_REQUEST, "COMMON-003", "요청 JSON 형식이 올바르지 않습니다."),
-    NOT_FOUND_ENTITY(HttpStatus.NOT_FOUND, "COMMON-004", "요청한 데이터를 찾을 수 없습니다."),
-    NOT_FOUND_ENDPOINT(HttpStatus.NOT_FOUND, "COMMON-005", "요청한 API 엔드포인트를 찾을 수 없습니다."),
-    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON-006", "지원하지 않는 HTTP 메소드입니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON-007", "서버 내부 오류가 발생했습니다."),
-    REDIS_SERIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON-008", "Redis 직렬화에 실패했습니다."),
-    REDIS_OPERATION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "COMMON-009", "Redis 캐시 연산에 실패했습니다."),
+    MISSING_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "COMMON-004", "필수 파라미터가 누락되었습니다."),
+    NOT_FOUND_ENTITY(HttpStatus.NOT_FOUND, "COMMON-005", "요청한 데이터를 찾을 수 없습니다."),
+    NOT_FOUND_ENDPOINT(HttpStatus.NOT_FOUND, "COMMON-006", "요청한 API 엔드포인트를 찾을 수 없습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON-007", "지원하지 않는 HTTP 메소드입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON-008", "서버 내부 오류가 발생했습니다."),
+    REDIS_SERIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON-009", "Redis 직렬화에 실패했습니다."),
+    REDIS_OPERATION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "COMMON-0010", "Redis 캐시 연산에 실패했습니다."),
 
 
 

--- a/src/main/java/org/sopt/solply_server/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/solply_server/global/handler/GlobalExceptionHandler.java
@@ -100,13 +100,32 @@ public class GlobalExceptionHandler {
     // 400: 필수 RequestParam이 누락된 경우
     @ExceptionHandler(MissingServletRequestParameterException.class)
     public ResponseEntity<CustomApiResponse<Void>> handleMissingRequestParameterException(
-            final MissingServletRequestParameterException e) {
+            final MissingServletRequestParameterException e,
+            final HttpServletRequest request) {
         log.error("Missing request parameter: {} (type: {})", e.getParameterName(), e.getParameterType());
+
+        // 요청에 포함된 파라미터들 확인
+        String receivedParams = getReceivedParameterNames(request);
+
         Map<String, String> details = new HashMap<>();
-        details.put("parameter", e.getParameterName());
-        details.put("type", e.getParameterType());
-        details.put("message", e.getParameterName() + "은(는) 필수 파라미터입니다");
-        return CustomApiResponse.error(ErrorCode.INVALID_REQUEST_BODY, details);
+        details.put("missingParameter", e.getParameterName());
+        details.put("parameterType", e.getParameterType());
+        details.put("receivedParameters", receivedParams);
+
+        // 파라미터 오타 가능성 체크
+        if (!receivedParams.isEmpty()) {
+            details.put("suggestion", "파라미터 이름을 확인해주세요. 필요한 파라미터: " + e.getParameterName());
+        }
+
+        return CustomApiResponse.error(ErrorCode.MISSING_REQUIRED_PARAMETER, details);
+    }
+
+    // 요청에 포함된 파라미터 이름들을 추출하는 헬퍼 메서드
+    private String getReceivedParameterNames(HttpServletRequest request) {
+        if (request.getParameterMap().isEmpty()) {
+            return "없음";
+        }
+        return String.join(", ", request.getParameterMap().keySet());
     }
 
     // 400: JSON 파싱 자체가 실패한 경우

--- a/src/main/java/org/sopt/solply_server/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/solply_server/global/handler/GlobalExceptionHandler.java
@@ -5,6 +5,9 @@ import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.HashMap;
 import java.util.Map;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.solply_server.global.dto.CustomApiResponse;
 import org.sopt.solply_server.global.exception.BusinessException;
@@ -17,6 +20,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -50,6 +54,23 @@ public class GlobalExceptionHandler {
         return CustomApiResponse.error(ErrorCode.INVALID_REQUEST_BODY, details);
     }
 
+    // 400: RequestParam/PathVariable 검증 실패 (@Validated 어노테이션)
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<CustomApiResponse<Void>> handleConstraintViolationException(
+            final ConstraintViolationException e) {
+        log.error("RequestParam/PathVariable validation failed: {}", e.getMessage());
+        Map<String, String> details = new HashMap<>();
+
+        for (ConstraintViolation<?> violation : e.getConstraintViolations()) {
+            String propertyPath = violation.getPropertyPath().toString();
+            // "methodName.parameterName" 형태에서 parameterName만 추출
+            String fieldName = propertyPath.substring(propertyPath.lastIndexOf('.') + 1);
+            details.put(fieldName, violation.getMessage());
+        }
+
+        return CustomApiResponse.error(ErrorCode.INVALID_REQUEST_BODY, details);
+    }
+
     // 400: 특정 파라미터의 타입이 잘못된 경우
     /**
      * {
@@ -74,6 +95,18 @@ public class GlobalExceptionHandler {
         details.put("invalidValue", String.valueOf(e.getValue()));
         details.put("expectedType", e.getRequiredType() != null ? e.getRequiredType().getSimpleName() : "Unknown");
         return CustomApiResponse.error(ErrorCode.INVALID_ARGUMENT_TYPE, details);
+    }
+
+    // 400: 필수 RequestParam이 누락된 경우
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<CustomApiResponse<Void>> handleMissingRequestParameterException(
+            final MissingServletRequestParameterException e) {
+        log.error("Missing request parameter: {} (type: {})", e.getParameterName(), e.getParameterType());
+        Map<String, String> details = new HashMap<>();
+        details.put("parameter", e.getParameterName());
+        details.put("type", e.getParameterType());
+        details.put("message", e.getParameterName() + "은(는) 필수 파라미터입니다");
+        return CustomApiResponse.error(ErrorCode.INVALID_REQUEST_BODY, details);
     }
 
     // 400: JSON 파싱 자체가 실패한 경우


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #39 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- GET /api/users/check-nickname?nickname={nickname} API 엔드포인트 구현
- RequestParam으로 닉네임을 받아 DB에서 중복 여부 확인
- UserRepository.existsByNickname() 메서드로 중복 검사 수행
- 응답으로 { "isDuplicated": true/false } 형태의 boolean 값 반환
- Bean Validation으로 입력값 검증 (null 불가능, 2-8자 허용)


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- Validation 어노테이션 조합: @NotBlank, @Size의 적절한 사용 여부
- GlobalExceptionHandler: RequestParam 검증 실패 시 예외 처리 로직을 추가했습니다.
- @Validated vs @Valid: 컨트롤러 레벨의 @Validated 어노테이션 사용
- DB 설계: User 엔티티의 nickname 컬럼 설정 (length=30, unique=true)
- 한글, 영문, 숫자만 허용하는 검증을 구현하려면 정규식을 사용해야하는데 이건 클라이언트에서 처리되는 부분이기도 하고 불필요하다고 판단해서 구현하지 않았습니다. 다들 어떻게 생각하시는지 의견주세용

<br/>

## 🚀 알게된 점 (선택)

---

- RequestParam validation: @Validated를 컨트롤러에 붙여야 RequestParam 검증이 작동함
- Exception hierarchy: ConstraintViolationException과 MissingServletRequestParameterException의 차이
- @Size는 문자 단위로 계산

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- https://docs.spring.io/spring-boot/reference/io/validation.html#io.validation
- https://beanvalidation.org/2.0/spec/