### PR TITLE
[FEAT] 코스 상세 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/course/controller/CourseController.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/controller/CourseController.java
@@ -1,0 +1,34 @@
+package org.sopt.solply_server.domain.course.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.sopt.solply_server.domain.course.dto.response.CourseDetailGetResponse;
+import org.sopt.solply_server.domain.course.service.CourseService;
+import org.sopt.solply_server.global.annotation.CurrentUserId;
+import org.sopt.solply_server.global.dto.CustomApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "코스 API", description = "코스 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/courses")
+public class CourseController {
+
+    private final CourseService courseService;
+
+    @Operation(summary = "코스 상세 조회", description = "코스 ID를 통해 코스의 상세 정보를 조회합니다.")
+    @GetMapping("/{courseId}")
+    public ResponseEntity<CustomApiResponse<CourseDetailGetResponse>> findCourseDetailsById(
+            @CurrentUserId Long userId,
+            @PathVariable Long courseId) {
+        return CustomApiResponse.success(
+                "코스 상세 조회에 성공했습니다.",
+                courseService.findCourseDetailsById(userId, courseId)
+        );
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/course/dto/CoursePlaceDetailDto.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/dto/CoursePlaceDetailDto.java
@@ -1,0 +1,37 @@
+package org.sopt.solply_server.domain.course.dto;
+
+import lombok.Builder;
+import org.sopt.solply_server.domain.place.entity.Place;
+import org.sopt.solply_server.domain.tag.entity.TagName;
+
+@Builder
+public record CoursePlaceDetailDto (
+        Long placeId,
+        String placeName,
+        String thumbnailUrl,
+        TagName primaryTag,
+        String address,
+        boolean isBookmarked,
+        int placeOrder,
+        String latitude,
+        String longitude,
+        String placeType,
+        Long placeDefaultId
+){
+    public static CoursePlaceDetailDto of(Place place, String thumbnailUrl, TagName primaryTag,
+                                          boolean isBookmarked, int placeOrder) {
+        return CoursePlaceDetailDto.builder()
+                .placeId(place.getId())
+                .placeName(place.getName())
+                .thumbnailUrl(thumbnailUrl)
+                .primaryTag(primaryTag)
+                .address(place.getAddress())
+                .isBookmarked(isBookmarked)
+                .placeOrder(placeOrder)
+                .latitude(String.valueOf(place.getLatitude()))
+                .longitude(String.valueOf(place.getLongitude()))
+                .placeType(place.getPlaceType())
+                .placeDefaultId(place.getPlaceDefaultId())
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/course/dto/CoursePlaceDetailsDto.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/dto/CoursePlaceDetailsDto.java
@@ -5,7 +5,7 @@ import org.sopt.solply_server.domain.place.entity.Place;
 import org.sopt.solply_server.domain.tag.entity.TagName;
 
 @Builder
-public record CoursePlaceDetailDto (
+public record CoursePlaceDetailsDto(
         Long placeId,
         String placeName,
         String thumbnailUrl,
@@ -18,9 +18,9 @@ public record CoursePlaceDetailDto (
         String placeType,
         Long placeDefaultId
 ){
-    public static CoursePlaceDetailDto of(Place place, String thumbnailUrl, TagName primaryTag,
-                                          boolean isBookmarked, int placeOrder) {
-        return CoursePlaceDetailDto.builder()
+    public static CoursePlaceDetailsDto of(Place place, String thumbnailUrl, TagName primaryTag,
+                                           boolean isBookmarked, int placeOrder) {
+        return CoursePlaceDetailsDto.builder()
                 .placeId(place.getId())
                 .placeName(place.getName())
                 .thumbnailUrl(thumbnailUrl)

--- a/src/main/java/org/sopt/solply_server/domain/course/dto/response/CourseDetailGetResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/dto/response/CourseDetailGetResponse.java
@@ -1,0 +1,25 @@
+package org.sopt.solply_server.domain.course.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+import org.sopt.solply_server.domain.course.dto.CoursePlaceDetailDto;
+import org.sopt.solply_server.domain.course.entity.Course;
+
+@Builder
+public record CourseDetailGetResponse(
+        Long courseId,
+        String courseName,
+        String introduction,
+        boolean isBookmarked,
+        List<CoursePlaceDetailDto> places
+) {
+    public static CourseDetailGetResponse of(Course course, boolean isBookmarked, List<CoursePlaceDetailDto> places) {
+        return CourseDetailGetResponse.builder()
+                .courseId(course.getId())
+                .courseName(course.getName())
+                .introduction(course.getIntroduction())
+                .isBookmarked(isBookmarked)
+                .places(places)
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/course/dto/response/CourseDetailGetResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/dto/response/CourseDetailGetResponse.java
@@ -2,7 +2,7 @@ package org.sopt.solply_server.domain.course.dto.response;
 
 import java.util.List;
 import lombok.Builder;
-import org.sopt.solply_server.domain.course.dto.CoursePlaceDetailDto;
+import org.sopt.solply_server.domain.course.dto.CoursePlaceDetailsDto;
 import org.sopt.solply_server.domain.course.entity.Course;
 
 @Builder
@@ -11,9 +11,9 @@ public record CourseDetailGetResponse(
         String courseName,
         String introduction,
         boolean isBookmarked,
-        List<CoursePlaceDetailDto> places
+        List<CoursePlaceDetailsDto> places
 ) {
-    public static CourseDetailGetResponse of(Course course, boolean isBookmarked, List<CoursePlaceDetailDto> places) {
+    public static CourseDetailGetResponse of(Course course, boolean isBookmarked, List<CoursePlaceDetailsDto> places) {
         return CourseDetailGetResponse.builder()
                 .courseId(course.getId())
                 .courseName(course.getName())

--- a/src/main/java/org/sopt/solply_server/domain/course/entity/Course.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/entity/Course.java
@@ -26,7 +26,12 @@ import org.sopt.solply_server.global.entity.BaseTimeEntity;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Table(name = "courses")
+@Table(name = "courses",
+        indexes = {
+                @Index(name = "idx_course_town_id", columnList = "town_id"),
+                @Index(name = "idx_course_is_shared", columnList = "is_shared")
+        }
+)
 public class Course extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,6 +42,9 @@ public class Course extends BaseTimeEntity {
 
     @Column(nullable = false)
     private String introduction;
+
+    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
+    private boolean isShared;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "town_id", nullable = false)

--- a/src/main/java/org/sopt/solply_server/domain/course/entity/CourseBookmark.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/entity/CourseBookmark.java
@@ -1,0 +1,45 @@
+package org.sopt.solply_server.domain.course.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.solply_server.domain.user.entity.User;
+import org.sopt.solply_server.global.entity.BaseTimeEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "course_bookmark",
+        indexes = {
+                @Index(name = "idx_course_bookmark_user_course",
+                        columnList = "user_id, course_id",
+                        unique = true
+                )
+        }
+)
+public class CourseBookmark extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "course_id", nullable = false)
+    private Course course;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+}

--- a/src/main/java/org/sopt/solply_server/domain/course/entity/CoursePlace.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/entity/CoursePlace.java
@@ -10,10 +10,12 @@ import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.Getter;
 import org.sopt.solply_server.domain.place.entity.Place;
 import org.sopt.solply_server.global.entity.BaseTimeEntity;
 
 @Entity
+@Getter
 @Table(name = "course_place",
         indexes = {
                 @Index(name = "idx_course_place_course_id_place_id", columnList = "course_id, place_id", unique = true),

--- a/src/main/java/org/sopt/solply_server/domain/course/repository/CourseBookmarkRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/repository/CourseBookmarkRepository.java
@@ -1,0 +1,9 @@
+package org.sopt.solply_server.domain.course.repository;
+
+import org.sopt.solply_server.domain.course.entity.CourseBookmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CourseBookmarkRepository extends JpaRepository<CourseBookmark, Long> {
+
+    boolean existsByCourseIdAndUserId(Long courseId, Long userId);
+}

--- a/src/main/java/org/sopt/solply_server/domain/course/repository/CourseRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/repository/CourseRepository.java
@@ -1,0 +1,25 @@
+package org.sopt.solply_server.domain.course.repository;
+
+import org.sopt.solply_server.domain.course.entity.Course;
+import org.sopt.solply_server.domain.place.entity.Place;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CourseRepository extends JpaRepository<Course, Long> {
+
+    @Query("SELECT c FROM Course c " +
+            "JOIN FETCH c.coursePlaces cp " +
+            "JOIN FETCH cp.place p " +
+            "WHERE c.id = :courseId")
+    Optional<Course> findByIdWithPlaces(@Param("courseId") Long courseId);
+
+    @Query("SELECT p FROM Place p " +
+            "LEFT JOIN FETCH p.placeTags pt " +
+            "LEFT JOIN FETCH pt.tag " +
+            "WHERE p.id IN :placeIds")
+    List<Place> findPlacesWithTagsByIds(@Param("placeIds") List<Long> placeIds);
+}

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -58,7 +58,7 @@ public class CourseService {
         Map<Long, Boolean> placeBookmarkMap = getPlaceBookmarkMap(placeIds, userId);
 
         List<CoursePlaceDetailDto> coursePlaces = course.getCoursePlaces().stream()
-                .map(coursePlace -> convertToCoursePlaceDto(coursePlace, placeBookmarkMap, userId))
+                .map(coursePlace -> convertToCoursePlaceDto(coursePlace, placeBookmarkMap))
                 .toList();
 
         return CourseDetailGetResponse.of(course, isCourseBookmarked, coursePlaces);
@@ -69,7 +69,7 @@ public class CourseService {
             return Map.of();
         }
 
-        Set<Long> bookmarkedPlaceIds = placeBookmarkRepository.findBookmarkedPlaceIdsByUserIdAndPlaceIdIn(userId, placeIds);
+        Set<Long> bookmarkedPlaceIds = placeBookmarkRepository.findBookmarkedPlaceIdsByUserIdAndPlaceIds(userId, placeIds);
 
         return placeIds.stream()
                 .collect(Collectors.toMap(
@@ -81,7 +81,7 @@ public class CourseService {
     /**
      * CoursePlace를 CoursePlaceDetailDto로 변환
      */
-    private CoursePlaceDetailDto convertToCoursePlaceDto(CoursePlace coursePlace, Map<Long, Boolean> placeBookmarkMap, Long userId) {
+    private CoursePlaceDetailDto convertToCoursePlaceDto(CoursePlace coursePlace, Map<Long, Boolean> placeBookmarkMap) {
         Place place = coursePlace.getPlace();
 
         TagName primaryTag = getPrimaryTag(place);

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -1,0 +1,104 @@
+package org.sopt.solply_server.domain.course.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.solply_server.domain.course.dto.CoursePlaceDetailDto;
+import org.sopt.solply_server.domain.course.dto.response.CourseDetailGetResponse;
+import org.sopt.solply_server.domain.course.entity.Course;
+import org.sopt.solply_server.domain.course.entity.CoursePlace;
+import org.sopt.solply_server.domain.course.repository.CourseBookmarkRepository;
+import org.sopt.solply_server.domain.course.repository.CourseRepository;
+import org.sopt.solply_server.domain.place.entity.Place;
+import org.sopt.solply_server.domain.place.entity.PlaceImageInfo;
+import org.sopt.solply_server.domain.place.entity.PlaceTag;
+import org.sopt.solply_server.domain.place.repository.PlaceBookmarkRepository;
+import org.sopt.solply_server.domain.tag.entity.Tag;
+import org.sopt.solply_server.domain.tag.entity.TagName;
+import org.sopt.solply_server.domain.tag.entity.TagType;
+import org.sopt.solply_server.global.exception.BusinessException;
+import org.sopt.solply_server.global.exception.EntityNotFoundException;
+import org.sopt.solply_server.global.exception.ErrorCode;
+import org.sopt.solply_server.global.util.s3.ImageUrlProvider;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CourseService {
+
+    private final CourseRepository courseRepository;
+    private final CourseBookmarkRepository courseBookmarkRepository;
+    private final PlaceBookmarkRepository placeBookmarkRepository;
+    private final ImageUrlProvider imageUrlProvider;
+
+    /**
+     * 코스 상세 정보 조회
+     */
+    public CourseDetailGetResponse findCourseDetailsById(final Long userId, final Long courseId) {
+        Course course = courseRepository.findByIdWithPlaces(courseId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_ENTITY));
+
+        List<Long> placeIds = course.getCoursePlaces().stream()
+                .map(cp -> cp.getPlace().getId())
+                .toList();
+
+        if (!placeIds.isEmpty()) {
+            // 영속성 컨텍스트에 태그 정보 로드
+            courseRepository.findPlacesWithTagsByIds(placeIds);
+        }
+
+        boolean isCourseBookmarked = courseBookmarkRepository.existsByCourseIdAndUserId(courseId, userId);
+
+        List<CoursePlaceDetailDto> coursePlaces = course.getCoursePlaces().stream()
+                .map(coursePlace -> convertToCoursePlaceDto(coursePlace, userId))
+                .toList();
+
+        return CourseDetailGetResponse.of(course, isCourseBookmarked, coursePlaces);
+    }
+
+    /**
+     * CoursePlace를 CoursePlaceDetailDto로 변환
+     */
+    private CoursePlaceDetailDto convertToCoursePlaceDto(CoursePlace coursePlace, Long userId) {
+        Place place = coursePlace.getPlace();
+
+        TagName primaryTag = getPrimaryTag(place);
+
+        String thumbnailUrl = getThumbnailUrl(place);
+
+        boolean isPlaceBookmarked = placeBookmarkRepository.existsByPlaceIdAndUserId(place.getId(), userId);
+
+        return CoursePlaceDetailDto.of(
+                place,
+                thumbnailUrl,
+                primaryTag,
+                isPlaceBookmarked,
+                coursePlace.getPlaceOrder()
+        );
+    }
+
+    /**
+     * 장소의 1차 태그(MAIN) 추출
+     */
+    private TagName getPrimaryTag(Place place) {
+        return place.getPlaceTags().stream()
+                .map(PlaceTag::getTag)
+                .filter(tag -> tag.getType() == TagType.MAIN)
+                .findFirst()
+                .map(Tag::getName)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PLACE_TAG_REQUIRED));
+    }
+
+    /**
+     * 장소의 썸네일 이미지 URL 생성
+     */
+    private String getThumbnailUrl(Place place) {
+        return place.getPlaceImageInfos().stream()
+                .findFirst()
+                .map(PlaceImageInfo::getImageFileKey)
+                .map(imageUrlProvider::getImageUrl)
+                .orElse(null);
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -22,6 +22,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -51,24 +54,39 @@ public class CourseService {
 
         boolean isCourseBookmarked = courseBookmarkRepository.existsByCourseIdAndUserId(courseId, userId);
 
+        // 장소 북마크 상태를 한번에 조회
+        Map<Long, Boolean> placeBookmarkMap = getPlaceBookmarkMap(placeIds, userId);
+
         List<CoursePlaceDetailDto> coursePlaces = course.getCoursePlaces().stream()
-                .map(coursePlace -> convertToCoursePlaceDto(coursePlace, userId))
+                .map(coursePlace -> convertToCoursePlaceDto(coursePlace, placeBookmarkMap, userId))
                 .toList();
 
         return CourseDetailGetResponse.of(course, isCourseBookmarked, coursePlaces);
     }
 
+    private Map<Long, Boolean> getPlaceBookmarkMap(List<Long> placeIds, Long userId) {
+        if (placeIds.isEmpty()) {
+            return Map.of();
+        }
+
+        Set<Long> bookmarkedPlaceIds = placeBookmarkRepository.findBookmarkedPlaceIdsByUserIdAndPlaceIdIn(userId, placeIds);
+
+        return placeIds.stream()
+                .collect(Collectors.toMap(
+                        placeId -> placeId,
+                        bookmarkedPlaceIds::contains
+                ));
+    }
+
     /**
      * CoursePlace를 CoursePlaceDetailDto로 변환
      */
-    private CoursePlaceDetailDto convertToCoursePlaceDto(CoursePlace coursePlace, Long userId) {
+    private CoursePlaceDetailDto convertToCoursePlaceDto(CoursePlace coursePlace, Map<Long, Boolean> placeBookmarkMap, Long userId) {
         Place place = coursePlace.getPlace();
 
         TagName primaryTag = getPrimaryTag(place);
-
         String thumbnailUrl = getThumbnailUrl(place);
-
-        boolean isPlaceBookmarked = placeBookmarkRepository.existsByPlaceIdAndUserId(place.getId(), userId);
+        boolean isPlaceBookmarked = placeBookmarkMap.getOrDefault(place.getId(), false);
 
         return CoursePlaceDetailDto.of(
                 place,

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -1,7 +1,7 @@
 package org.sopt.solply_server.domain.course.service;
 
 import lombok.RequiredArgsConstructor;
-import org.sopt.solply_server.domain.course.dto.CoursePlaceDetailDto;
+import org.sopt.solply_server.domain.course.dto.CoursePlaceDetailsDto;
 import org.sopt.solply_server.domain.course.dto.response.CourseDetailGetResponse;
 import org.sopt.solply_server.domain.course.entity.Course;
 import org.sopt.solply_server.domain.course.entity.CoursePlace;
@@ -57,8 +57,8 @@ public class CourseService {
         // 장소 북마크 상태를 한번에 조회
         Map<Long, Boolean> placeBookmarkMap = getPlaceBookmarkMap(placeIds, userId);
 
-        List<CoursePlaceDetailDto> coursePlaces = course.getCoursePlaces().stream()
-                .map(coursePlace -> convertToCoursePlaceDto(coursePlace, placeBookmarkMap))
+        List<CoursePlaceDetailsDto> coursePlaces = course.getCoursePlaces().stream()
+                .map(coursePlace -> convertToCoursePlaceDetailsDto(coursePlace, placeBookmarkMap))
                 .toList();
 
         return CourseDetailGetResponse.of(course, isCourseBookmarked, coursePlaces);
@@ -81,14 +81,14 @@ public class CourseService {
     /**
      * CoursePlace를 CoursePlaceDetailDto로 변환
      */
-    private CoursePlaceDetailDto convertToCoursePlaceDto(CoursePlace coursePlace, Map<Long, Boolean> placeBookmarkMap) {
+    private CoursePlaceDetailsDto convertToCoursePlaceDetailsDto(CoursePlace coursePlace, Map<Long, Boolean> placeBookmarkMap) {
         Place place = coursePlace.getPlace();
 
         TagName primaryTag = getPrimaryTag(place);
         String thumbnailUrl = getThumbnailUrl(place);
         boolean isPlaceBookmarked = placeBookmarkMap.getOrDefault(place.getId(), false);
 
-        return CoursePlaceDetailDto.of(
+        return CoursePlaceDetailsDto.of(
                 place,
                 thumbnailUrl,
                 primaryTag,

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -43,18 +43,21 @@ public class CourseService {
         Course course = courseRepository.findByIdWithPlaces(courseId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_ENTITY));
 
+        // 코스 북마크 여부 확인 (TODO: Redis로 변경 필요)
+        boolean isCourseBookmarked = courseBookmarkRepository.existsByCourseIdAndUserId(courseId, userId);
+
+        if (course.getCoursePlaces().isEmpty()) {
+            return CourseDetailGetResponse.of(course, isCourseBookmarked, List.of());
+        }
+
         List<Long> placeIds = course.getCoursePlaces().stream()
                 .map(cp -> cp.getPlace().getId())
                 .toList();
 
-        if (!placeIds.isEmpty()) {
-            // 영속성 컨텍스트에 태그 정보 로드
-            courseRepository.findPlacesWithTagsByIds(placeIds);
-        }
+        // 장소 태그 정보를 영속성 컨텍스트에 로드
+        courseRepository.findPlacesWithTagsByIds(placeIds);
 
-        boolean isCourseBookmarked = courseBookmarkRepository.existsByCourseIdAndUserId(courseId, userId);
-
-        // 장소 북마크 상태를 한번에 조회
+        // 장소 북마크 상태를 한번에 조회 (TODO: Redis로 변경 필요)
         Map<Long, Boolean> placeBookmarkMap = getPlaceBookmarkMap(placeIds, userId);
 
         List<CoursePlaceDetailsDto> coursePlaces = course.getCoursePlaces().stream()
@@ -69,6 +72,7 @@ public class CourseService {
             return Map.of();
         }
 
+        // TODO: Redis 기반 북마크 조회로 변경 필요
         Set<Long> bookmarkedPlaceIds = placeBookmarkRepository.findBookmarkedPlaceIdsByUserIdAndPlaceIds(userId, placeIds);
 
         return placeIds.stream()
@@ -79,44 +83,25 @@ public class CourseService {
     }
 
     /**
-     * CoursePlace를 CoursePlaceDetailDto로 변환
+     * CoursePlace를 CoursePlaceDetailsDto로 변환
      */
     private CoursePlaceDetailsDto convertToCoursePlaceDetailsDto(CoursePlace coursePlace, Map<Long, Boolean> placeBookmarkMap) {
         Place place = coursePlace.getPlace();
 
-        TagName primaryTag = getPrimaryTag(place);
-        String thumbnailUrl = getThumbnailUrl(place);
-        boolean isPlaceBookmarked = placeBookmarkMap.getOrDefault(place.getId(), false);
-
         return CoursePlaceDetailsDto.of(
                 place,
-                thumbnailUrl,
-                primaryTag,
-                isPlaceBookmarked,
+                getThumbnailUrl(place),
+                place.getPrimaryTag(), // Place 엔티티 메서드 활용
+                placeBookmarkMap.getOrDefault(place.getId(), false),
                 coursePlace.getPlaceOrder()
         );
-    }
-
-    /**
-     * 장소의 1차 태그(MAIN) 추출
-     */
-    private TagName getPrimaryTag(Place place) {
-        return place.getPlaceTags().stream()
-                .map(PlaceTag::getTag)
-                .filter(tag -> tag.getType() == TagType.MAIN)
-                .findFirst()
-                .map(Tag::getName)
-                .orElseThrow(() -> new BusinessException(ErrorCode.PLACE_TAG_REQUIRED));
     }
 
     /**
      * 장소의 썸네일 이미지 URL 생성
      */
     private String getThumbnailUrl(Place place) {
-        return place.getPlaceImageInfos().stream()
-                .findFirst()
-                .map(PlaceImageInfo::getImageFileKey)
-                .map(imageUrlProvider::getImageUrl)
-                .orElse(null);
+        String fileKey = place.getThumbnailFileKey(); // Place 엔티티 메서드 활용
+        return fileKey != null ? imageUrlProvider.getImageUrl(fileKey) : null;
     }
 }

--- a/src/main/java/org/sopt/solply_server/domain/place/entity/Place.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/entity/Place.java
@@ -27,8 +27,13 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.sopt.solply_server.domain.tag.entity.Tag;
+import org.sopt.solply_server.domain.tag.entity.TagName;
+import org.sopt.solply_server.domain.tag.entity.TagType;
 import org.sopt.solply_server.domain.town.entity.Town;
 import org.sopt.solply_server.global.entity.BaseTimeEntity;
+import org.sopt.solply_server.global.exception.BusinessException;
+import org.sopt.solply_server.global.exception.ErrorCode;
 
 @Entity
 @Getter
@@ -52,7 +57,7 @@ public class Place extends BaseTimeEntity {
 
     private String address;
 
-    @OneToMany(mappedBy = "place", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "place", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<PlaceTag> placeTags = new ArrayList<>();
 
     @Column(columnDefinition = "TEXT")
@@ -92,5 +97,28 @@ public class Place extends BaseTimeEntity {
     @JoinColumn(name = "town_id", nullable = false)
     private Town town;
 
+    // === 편의 메서드 추가 ===
+
+    /**
+     * 장소의 1차 태그(MAIN) 추출
+     */
+    public TagName getPrimaryTag() {
+        return this.placeTags.stream()
+                .map(PlaceTag::getTag)
+                .filter(tag -> tag.getType() == TagType.MAIN)
+                .findFirst()
+                .map(Tag::getName)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PLACE_TAG_REQUIRED));
+    }
+
+    /**
+     * 썸네일 이미지 파일 키 추출 (첫 번째 이미지)
+     */
+    public String getThumbnailFileKey() {
+        return this.placeImageInfos.stream()
+                .findFirst()
+                .map(PlaceImageInfo::getImageFileKey)
+                .orElse(null);
+    }
 
 }

--- a/src/main/java/org/sopt/solply_server/domain/place/repository/PlaceBookmarkRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/repository/PlaceBookmarkRepository.java
@@ -1,14 +1,11 @@
 package org.sopt.solply_server.domain.place.repository;
 
-import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
 import org.sopt.solply_server.domain.place.entity.PlaceBookmark;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Set;
 
 public interface PlaceBookmarkRepository extends JpaRepository<PlaceBookmark, Long> {
@@ -21,8 +18,4 @@ public interface PlaceBookmarkRepository extends JpaRepository<PlaceBookmark, Lo
     boolean existsByUserIdAndPlaceId(Long userId, Long placeId);
 
     void deleteByUserIdAndPlaceId(Long userId, @Param("placeId") Long placeId);
-
-    @Modifying(clearAutomatically = true)
-    @Query("DELETE FROM PlaceBookmark pb WHERE pb.user.id = :userId AND pb.place.id IN :placeIds")
-    void deleteByUserIdAndPlaceIdInPlaceIdList(@Param("userId") Long userId, @Param("placeIds") List<Long> placeIdList);
 }

--- a/src/main/java/org/sopt/solply_server/domain/place/repository/PlaceBookmarkRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/repository/PlaceBookmarkRepository.java
@@ -2,8 +2,16 @@ package org.sopt.solply_server.domain.place.repository;
 
 import org.sopt.solply_server.domain.place.entity.PlaceBookmark;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Set;
 
 public interface PlaceBookmarkRepository extends JpaRepository<PlaceBookmark, Long> {
 
     boolean existsByPlaceIdAndUserId(Long placeId, Long placeId1);
+
+    @Query("SELECT pb.place.id FROM PlaceBookmark pb WHERE pb.user.id = :userId AND pb.place.id IN :placeIds")
+    Set<Long> findBookmarkedPlaceIdsByUserIdAndPlaceIdIn(@Param("userId") Long userId, @Param("placeIds") List<Long> placeIds);
 }

--- a/src/main/java/org/sopt/solply_server/domain/place/repository/PlaceBookmarkRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/repository/PlaceBookmarkRepository.java
@@ -13,5 +13,5 @@ public interface PlaceBookmarkRepository extends JpaRepository<PlaceBookmark, Lo
     boolean existsByPlaceIdAndUserId(Long placeId, Long placeId1);
 
     @Query("SELECT pb.place.id FROM PlaceBookmark pb WHERE pb.user.id = :userId AND pb.place.id IN :placeIds")
-    Set<Long> findBookmarkedPlaceIdsByUserIdAndPlaceIdIn(@Param("userId") Long userId, @Param("placeIds") List<Long> placeIds);
+    Set<Long> findBookmarkedPlaceIdsByUserIdAndPlaceIds(@Param("userId") Long userId, @Param("placeIds") List<Long> placeIds);
 }

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
@@ -8,18 +8,13 @@ import org.sopt.solply_server.domain.place.dto.PlaceThumbnailDto;
 import org.sopt.solply_server.domain.place.dto.response.PlaceAllGetResponse;
 import org.sopt.solply_server.domain.place.dto.response.PlaceFilterGetResponse;
 import org.sopt.solply_server.domain.place.entity.Place;
-import org.sopt.solply_server.domain.place.entity.PlaceImageInfo;
-import org.sopt.solply_server.domain.place.entity.PlaceTag;
 import org.sopt.solply_server.domain.place.repository.PlaceBookmarkRepository;
 import org.sopt.solply_server.domain.place.repository.PlaceRepository;
-import org.sopt.solply_server.domain.tag.entity.Tag;
-import org.sopt.solply_server.domain.tag.entity.TagName;
 import org.sopt.solply_server.domain.tag.entity.TagType;
 import org.sopt.solply_server.domain.tag.repository.TagRepository;
 import org.sopt.solply_server.domain.tag.util.TagValidator;
 import org.sopt.solply_server.domain.town.entity.Town;
 import org.sopt.solply_server.domain.town.repository.TownRepository;
-import org.sopt.solply_server.global.exception.BusinessException;
 import org.sopt.solply_server.global.exception.EntityNotFoundException;
 import org.sopt.solply_server.global.exception.ErrorCode;
 import org.sopt.solply_server.global.util.InputValidator;
@@ -37,7 +32,6 @@ public class PlaceService {
     private final PlaceBookmarkRepository placeBookmarkRepository;
     private final ImageUrlProvider imageUrlProvider;
     private final TownRepository townRepository;
-    private final TagRepository tagRepository;
     private final TagValidator tagValidator;
 
     /**
@@ -46,9 +40,6 @@ public class PlaceService {
     public PlaceAllGetResponse findPlaceDetailsById(final Long userId, final Long placeId) {
         Place place = placeRepository.findById(placeId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_ENTITY));
-
-        // MAIN에 해당하는 태그를 가져와서 저장
-        TagName primaryTag = getPrimaryTag(place);
 
         List<PlaceImageInfoDto> imageInfos = place.getPlaceImageInfos().stream()
                 .map(info -> PlaceImageInfoDto.of(
@@ -61,7 +52,7 @@ public class PlaceService {
 
         return PlaceAllGetResponse.of(
                 place,
-                primaryTag,
+                place.getPrimaryTag(),
                 imageInfos,
                 isBookmarked
         );
@@ -85,8 +76,8 @@ public class PlaceService {
                 .map(place -> PlaceThumbnailDto.of(
                         place.getId(),
                         place.getName(),
-                        imageUrlProvider.getImageUrl(getThumbnailFileKey(place)),
-                        getPrimaryTag(place),
+                        getThumbnailUrl(place),
+                        place.getPrimaryTag(),
                         placeBookmarkRepository.existsByPlaceIdAndUserId(place.getId(), userId)
                 ))
                 .toList();;
@@ -130,27 +121,16 @@ public class PlaceService {
         tagValidator.validateTagListRelation(mainTagId, subTagIdList);
     }
 
-    // 1차 태그를 가져오는 메서드
-    private static TagName getPrimaryTag(Place place) {
-        return place.getPlaceTags().stream()
-                .map(PlaceTag::getTag)
-                .filter(tag -> tag.getType() == TagType.MAIN)
-                .findFirst()
-                .map(Tag::getName)
-                .orElseThrow(() -> new BusinessException(ErrorCode.PLACE_TAG_REQUIRED));
-    }
-
     // 동네 ID를 통해 동네를 검증하고 가져오는 메서드
     private Town validateAndGetTown(Long townId) {
         return townRepository.findById(townId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_TOWN));
     }
 
-    // 썸네일 이미지 파일 키를 가져오는 메서드
-    public String getThumbnailFileKey(Place place) {
-        return place.getPlaceImageInfos().stream()
-                .findFirst()
-                .map(PlaceImageInfo::getImageFileKey)
-                .orElse(null);
+    // 썸네일 URL 생성
+    private String getThumbnailUrl(Place place) {
+        String fileKey = place.getThumbnailFileKey();
+        return fileKey != null ? imageUrlProvider.getImageUrl(fileKey) : null;
     }
+
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #63 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- MultipleBagFetchException 해결: 2개 이상의 컬렉션(@OneToMany)을 동시에 JOIN FETCH 할 때 발생하는 MultipleBagFetchException을 피하기 위해, 코스와 장소를 조회하는 쿼리와 장소와 태그를 조회하는 쿼리를 2개로 분리했습니다.
- N+1 쿼리 최적화: 코스에 속한 장소들의 북마크 상태를 확인할 때, 각 장소마다 개별적으로 exists 쿼리를 호출하는 대신 IN 절을 사용하여 북마크된 장소 ID 목록을 한 번의 쿼리로 가져오도록 개선했습니다.
- 성능 최적화: 조회된 장소 목록을 기반으로 findPlacesWithTagsByIds() 메서드를 호출하여, 필요한 태그 정보만 영속성 컨텍스트에 미리 로드했습니다. 이를 통해 DTO 변환 과정에서 추가적인 쿼리가 발생하지 않도록 합니다.
- 엔티티 설계: Course 엔티티에 isShared 필드를 추가하여, 추천 피드에 노출될 공유 코스와 사용자의 개인 코스를 명확하게 구분할 수 있게 하였습니다.
- Repository 개선: PlaceBookmarkRepository에 findBookmarkedPlaceIdsByUserIdAndPlaceIdIn 메서드를 추가하여 장소 북마크 정보 배치 조회를 구현하고 쿼리 수를 최적화했습니다.


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 쿼리 최적화 전략: MultipleBagFetchException을 피하기 위해 CourseRepository에서 findByIdWithPlaces와 findPlacesWithTagsByIds로 쿼리를 분리한 방식이 적절한지 확인 부탁드립니다.
- 북마크 배치 조회: CourseService에 추가된 getPlaceBookmarkMap() 메서드의 성능과 로직이 올바른지, Map을 활용하여 북마크 상태를 관리하는 방식에 대해 검토 부탁드립니다.
- 서비스 분리에 대해서 고민을 해봤는데, 현재는 CourseService가 코스 조회라는 명확한 책임만 가지기도 하고 애매하다고 판단되어 이후 다른 기능이 추가될 때 고려해보려 합니다!

<br/>

## 🚀 알게된 점 (선택)

---

- Hibernate MultipleBagFetchException: 2개 이상의 Collection을 동시에 JOIN FETCH할 때 발생하는 제약사항과 이를 쿼리 분리 또는 default_batch_fetch_size 설정으로 해결하는 방법을 학습했습니다.
- 배치 조회 패턴: N+1 문제를 해결하기 위해 IN 쿼리를 적극적으로 활용하고, 조회 결과를 Map으로 가공하여 메모리에서 효율적으로 상태를 관리하는 방식의 유용성을 확인했습니다.
- JPA 영속성 컨텍스트: 별도의 쿼리로 엔티티를 조회하더라도, 해당 엔티티들이 영속성 컨텍스트에 로드되면 기존에 조회된 다른 엔티티의 연관관계 컬렉션에 자동으로 반영되는 JPA의 동작 메커니즘을 더 깊이 이해했습니다.

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 