### PR TITLE
[FEAT] 추천 코스 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/course/controller/CourseController.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/controller/CourseController.java
@@ -1,22 +1,24 @@
 package org.sopt.solply_server.domain.course.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.sopt.solply_server.domain.course.dto.response.CourseDetailGetResponse;
+import org.sopt.solply_server.domain.course.dto.response.CourseRecommendGetResponse;
 import org.sopt.solply_server.domain.course.service.CourseService;
 import org.sopt.solply_server.global.annotation.CurrentUserId;
 import org.sopt.solply_server.global.dto.CustomApiResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "코스 API", description = "코스 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/courses")
+@Validated
 public class CourseController {
 
     private final CourseService courseService;
@@ -29,6 +31,20 @@ public class CourseController {
         return CustomApiResponse.success(
                 "코스 상세 조회에 성공했습니다.",
                 courseService.findCourseDetailsById(userId, courseId)
+        );
+    }
+
+    @Operation(summary = "추천 코스 목록 조회", description = "특정 동네의 공유된 코스 목록을 조회합니다.")
+    @GetMapping("/recommend")
+    public ResponseEntity<CustomApiResponse<CourseRecommendGetResponse>> findRecommendCourses(
+            @CurrentUserId Long userId,
+            @Parameter(description = "동네 ID", required = true)
+            @RequestParam("townId")
+            @NotNull(message = "동네 ID는 필수입니다")
+            Long townId) {
+        return CustomApiResponse.success(
+                "추천 코스 목록 조회에 성공했습니다.",
+                courseService.findRecommendCourses(userId, townId)
         );
     }
 }

--- a/src/main/java/org/sopt/solply_server/domain/course/dto/CourseRecommendDto.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/dto/CourseRecommendDto.java
@@ -1,0 +1,27 @@
+package org.sopt.solply_server.domain.course.dto;
+
+import lombok.Builder;
+import org.sopt.solply_server.domain.course.entity.Course;
+import org.sopt.solply_server.domain.tag.entity.TagName;
+
+import java.util.List;
+
+@Builder
+public record CourseRecommendDto(
+        Long courseId,
+        String title,
+        String thumbnailImage,
+        List<TagName> mainTags,
+        boolean isBookmarked
+) {
+    public static CourseRecommendDto of(Course course, String thumbnailImage,
+                                        List<TagName> mainTags, boolean isBookmarked) {
+        return CourseRecommendDto.builder()
+                .courseId(course.getId())
+                .title(course.getName())
+                .thumbnailImage(thumbnailImage)
+                .mainTags(mainTags)
+                .isBookmarked(isBookmarked)
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/course/dto/response/CourseRecommendGetResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/dto/response/CourseRecommendGetResponse.java
@@ -1,0 +1,17 @@
+package org.sopt.solply_server.domain.course.dto.response;
+
+import lombok.Builder;
+import org.sopt.solply_server.domain.course.dto.CourseRecommendDto;
+
+import java.util.List;
+
+@Builder
+public record CourseRecommendGetResponse(
+        List<CourseRecommendDto> courses
+) {
+    public static CourseRecommendGetResponse from(List<CourseRecommendDto> courses) {
+        return CourseRecommendGetResponse.builder()
+                .courses(courses)
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/course/repository/CourseRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/repository/CourseRepository.java
@@ -22,4 +22,17 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
             "LEFT JOIN FETCH pt.tag " +
             "WHERE p.id IN :placeIds")
     List<Place> findPlacesWithTagsByIds(@Param("placeIds") List<Long> placeIds);
+
+    /**
+     * 특정 동네의 공유된 코스 목록 조회 (코스 내 장소들과 태그까지 함께 조회)
+     */
+    @Query("SELECT DISTINCT c FROM Course c " +
+            "JOIN FETCH c.coursePlaces cp " +
+            "JOIN FETCH cp.place p " +
+            "LEFT JOIN FETCH p.placeTags pt " +
+            "LEFT JOIN FETCH pt.tag t " +
+            "WHERE c.town.id = :townId " +
+            "AND c.isShared = true " +
+            "ORDER BY c.createdAt DESC")
+    List<Course> findSharedCoursesByTownIdWithDetails(@Param("townId") Long townId);
 }

--- a/src/main/java/org/sopt/solply_server/domain/course/repository/CourseRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/repository/CourseRepository.java
@@ -11,12 +11,17 @@ import java.util.Optional;
 
 public interface CourseRepository extends JpaRepository<Course, Long> {
 
+    /**
+     * 코스 상세 조회 - 코스와 관련된 장소 목록 조회 (단계별 조회로 MultipleBagFetchException 해결)
+     * Course, CoursePlace, Place 모두 한 번에 로딩
+     */
     @Query("SELECT c FROM Course c " +
             "JOIN FETCH c.coursePlaces cp " +
             "JOIN FETCH cp.place p " +
             "WHERE c.id = :courseId")
     Optional<Course> findByIdWithPlaces(@Param("courseId") Long courseId);
 
+    // 필요한 Place들의 태그 정보 배치 로딩
     @Query("SELECT p FROM Place p " +
             "LEFT JOIN FETCH p.placeTags pt " +
             "LEFT JOIN FETCH pt.tag " +
@@ -24,15 +29,22 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
     List<Place> findPlacesWithTagsByIds(@Param("placeIds") List<Long> placeIds);
 
     /**
-     * 특정 동네의 공유된 코스 목록 조회 (코스 내 장소들과 태그까지 함께 조회)
+     * 특정 동네의 공유된 코스 목록 조회 (단계별 조회로 MultipleBagFetchException 해결)
+     * 코스와 코스 내 장소들 조회
      */
     @Query("SELECT DISTINCT c FROM Course c " +
             "JOIN FETCH c.coursePlaces cp " +
             "JOIN FETCH cp.place p " +
-            "LEFT JOIN FETCH p.placeTags pt " +
-            "LEFT JOIN FETCH pt.tag t " +
             "WHERE c.town.id = :townId " +
             "AND c.isShared = true " +
             "ORDER BY c.createdAt DESC")
-    List<Course> findSharedCoursesByTownIdWithDetails(@Param("townId") Long townId);
+    List<Course> findSharedCoursesByTownIdWithPlaces(@Param("townId") Long townId);
+
+    // 특정 코스들의 장소 태그 정보를 배치로 조회
+    @Query("SELECT DISTINCT p FROM Place p " +
+            "LEFT JOIN FETCH p.placeTags pt " +
+            "LEFT JOIN FETCH pt.tag t " +
+            "WHERE p.id IN " +
+            "(SELECT cp.place.id FROM CoursePlace cp WHERE cp.course.id IN :courseIds)")
+    List<Place> findPlacesWithTagsByCourseIds(@Param("courseIds") List<Long> courseIds);
 }

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -108,7 +108,7 @@ public class CourseService {
 
     //===Redis 활용 북마크 조회 메서드===//
 
-    private Map<Long, Boolean> getPlaceBookmarkMap(List<Long> placeIds, Long userId) {
+    private Map<Long, Boolean> getPlaceBookmarkMap(final List<Long> placeIds, final Long userId) {
         if (placeIds.isEmpty()) {
             return Map.of();
         }
@@ -144,7 +144,7 @@ public class CourseService {
     }
 
     // TODO: Redis 기반 북마크 조회로 변경, 배치 조회 메서드 추가 필요
-    private Map<Long, Boolean> getCourseBookmarkMap(List<Long> courseIds, Long userId) {
+    private Map<Long, Boolean> getCourseBookmarkMap(final List<Long> courseIds, final Long userId) {
         if (courseIds.isEmpty()) {
             return Map.of();
         }
@@ -175,7 +175,7 @@ public class CourseService {
         return bookmarkMap;
     }
 
-    private boolean isCourseBookmarked(Long userId, Long courseId) {
+    private boolean isCourseBookmarked(final Long userId, final Long courseId) {
         String bookmarkKey = generateCourseBookmarkKey(userId, courseId);
 
         try {
@@ -201,7 +201,8 @@ public class CourseService {
     /**
      * CoursePlace를 CoursePlaceDetailsDto로 변환
      */
-    private CoursePlaceDetailsDto convertToCoursePlaceDetailsDto(CoursePlace coursePlace, Map<Long, Boolean> placeBookmarkMap) {
+    private CoursePlaceDetailsDto convertToCoursePlaceDetailsDto(final CoursePlace coursePlace,
+                                                                 final Map<Long, Boolean> placeBookmarkMap) {
         Place place = coursePlace.getPlace();
 
         return CoursePlaceDetailsDto.of(
@@ -216,7 +217,8 @@ public class CourseService {
     /**
      * Course를 CourseRecommendDto로 변환
      */
-    private CourseRecommendDto convertToCourseRecommendDto(Course course, Map<Long, Boolean> courseBookmarkMap) {
+    private CourseRecommendDto convertToCourseRecommendDto(final Course course,
+                                                           final Map<Long, Boolean> courseBookmarkMap) {
         List<TagName> mainTags = extractMainTagsFromCourse(course);
 
         String thumbnailUrl = getCourseThumbnailUrl(course);
@@ -232,7 +234,7 @@ public class CourseService {
     /**
      * 코스에서 메인 태그들 추출 (중복 제거)
      */
-    private List<TagName> extractMainTagsFromCourse(Course course) {
+    private List<TagName> extractMainTagsFromCourse(final Course course) {
         return course.getCoursePlaces().stream()
                 .map(CoursePlace::getPlace)
                 .flatMap(place -> place.getPlaceTags().stream())
@@ -247,7 +249,7 @@ public class CourseService {
     /**
      * 코스의 썸네일 URL 생성 (첫 번째 장소의 썸네일 사용)
      */
-    private String getCourseThumbnailUrl(Course course) {
+    private String getCourseThumbnailUrl(final Course course) {
         return course.getCoursePlaces().stream()
                 .findFirst()
                 .map(CoursePlace::getPlace)
@@ -258,22 +260,22 @@ public class CourseService {
     /**
      * 장소의 썸네일 이미지 URL 생성
      */
-    private String getThumbnailUrl(Place place) {
+    private String getThumbnailUrl(final Place place) {
         String fileKey = place.getThumbnailFileKey(); // Place 엔티티 메서드 활용
         return fileKey != null ? imageUrlProvider.getImageUrl(fileKey) : null;
     }
 
     //===Helper 메서드===//
 
-    private String generatePlaceBookmarkKey(Long userId, Long placeId) {
+    private String generatePlaceBookmarkKey(final Long userId, final Long placeId) {
         return String.format("%s:%d:%d", PLACE_BOOKMARK_KEY_PREFIX, userId, placeId);
     }
 
-    private String generateCourseBookmarkKey(Long userId, Long courseId) {
+    private String generateCourseBookmarkKey(final Long userId, final Long courseId) {
         return String.format("%s:%d:%d", COURSE_BOOKMARK_KEY_PREFIX, userId, courseId);
     }
 
-    private void safeSetCache(String key, Object value) {
+    private void safeSetCache(final String key, final Object value) {
         try {
             cacheService.set(key, value, BOOKMARK_CACHE_TTL, TimeUnit.HOURS);
         } catch (Exception e) {

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -18,6 +18,7 @@ import org.sopt.solply_server.domain.tag.entity.Tag;
 import org.sopt.solply_server.domain.tag.entity.TagName;
 import org.sopt.solply_server.domain.tag.entity.TagType;
 import org.sopt.solply_server.domain.town.service.TownService;
+import org.sopt.solply_server.global.cache.CacheService;
 import org.sopt.solply_server.global.exception.BusinessException;
 import org.sopt.solply_server.global.exception.EntityNotFoundException;
 import org.sopt.solply_server.global.exception.ErrorCode;
@@ -25,10 +26,8 @@ import org.sopt.solply_server.global.util.s3.ImageUrlProvider;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -42,6 +41,12 @@ public class CourseService {
     private final PlaceBookmarkRepository placeBookmarkRepository;
     private final TownService townService;
     private final ImageUrlProvider imageUrlProvider;
+    private final CacheService cacheService;
+
+    // Redis 키 상수
+    private static final String PLACE_BOOKMARK_KEY_PREFIX = "bookmark";
+    private static final String COURSE_BOOKMARK_KEY_PREFIX = "course_bookmark";
+    private static final int BOOKMARK_CACHE_TTL = 1; // 1시간 TTL
 
     /**
      * 코스 상세 정보 조회
@@ -50,8 +55,7 @@ public class CourseService {
         Course course = courseRepository.findByIdWithPlaces(courseId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_ENTITY));
 
-        // 코스 북마크 여부 확인 (TODO: Redis로 변경 필요)
-        boolean isCourseBookmarked = courseBookmarkRepository.existsByCourseIdAndUserId(courseId, userId);
+        boolean isCourseBookmarked = isCourseBookmarked(userId, courseId);
 
         if (course.getCoursePlaces().isEmpty()) {
             return CourseDetailGetResponse.of(course, isCourseBookmarked, List.of());
@@ -64,7 +68,6 @@ public class CourseService {
         // 장소 태그 정보를 영속성 컨텍스트에 로드
         courseRepository.findPlacesWithTagsByIds(placeIds);
 
-        // 장소 북마크 상태를 한번에 조회 (TODO: Redis로 변경 필요)
         Map<Long, Boolean> placeBookmarkMap = getPlaceBookmarkMap(placeIds, userId);
 
         List<CoursePlaceDetailsDto> coursePlaces = course.getCoursePlaces().stream()
@@ -91,7 +94,6 @@ public class CourseService {
                 .map(Course::getId)
                 .toList();
 
-        // 코스 북마크 상태를 한번에 조회 (TODO: Redis로 변경 필요)
         Map<Long, Boolean> courseBookmarkMap = getCourseBookmarkMap(courseIds, userId);
 
         List<CourseRecommendDto> courseRecommendDtos = sharedCourses.stream()
@@ -101,36 +103,97 @@ public class CourseService {
         return CourseRecommendGetResponse.from(courseRecommendDtos);
     }
 
-    //===편의 메서드===//
+    //===Redis 활용 북마크 조회 메서드===//
 
     private Map<Long, Boolean> getPlaceBookmarkMap(List<Long> placeIds, Long userId) {
         if (placeIds.isEmpty()) {
             return Map.of();
         }
 
-        // TODO: Redis 기반 북마크 조회로 변경 필요
-        Set<Long> bookmarkedPlaceIds = placeBookmarkRepository.findBookmarkedPlaceIdsByUserIdAndPlaceIds(userId, placeIds);
+        Map<Long, Boolean> bookmarkMap = new HashMap<>();
 
-        return placeIds.stream()
-                .collect(Collectors.toMap(
-                        placeId -> placeId,
-                        bookmarkedPlaceIds::contains
-                ));
+        for (Long placeId : placeIds) {
+            String bookmarkKey = generatePlaceBookmarkKey(userId, placeId);
+
+            try {
+                // Redis에서 북마크 상태 조회
+                Boolean cachedBookmark = cacheService.get(bookmarkKey, Boolean.class);
+
+                if (cachedBookmark != null) {
+                    bookmarkMap.put(placeId, cachedBookmark);
+                } else {
+                    // Redis에 없으면 DB 조회 후 캐싱
+                    boolean isBookmarked = placeBookmarkRepository.existsByUserIdAndPlaceId(userId, placeId);
+                    bookmarkMap.put(placeId, isBookmarked);
+
+                    // Redis에 캐싱 (실패해도 무시)
+                    safeSetCache(bookmarkKey, isBookmarked);
+                }
+            } catch (Exception e) {
+                log.warn("장소 북마크 상태 조회 실패 - userId: {}, placeId: {}", userId, placeId, e);
+                // Redis 실패 시 DB에서 조회
+                boolean isBookmarked = placeBookmarkRepository.existsByUserIdAndPlaceId(userId, placeId);
+                bookmarkMap.put(placeId, isBookmarked);
+            }
+        }
+
+        return bookmarkMap;
     }
 
+    // TODO: Redis 기반 북마크 조회로 변경, 배치 조회 메서드 추가 필요
     private Map<Long, Boolean> getCourseBookmarkMap(List<Long> courseIds, Long userId) {
         if (courseIds.isEmpty()) {
             return Map.of();
         }
 
-        // TODO: Redis 기반 북마크 조회로 변경, 배치 조회 메서드 추가 필요
-        // 현재는 개별 조회
-        return courseIds.stream()
-                .collect(Collectors.toMap(
-                        courseId -> courseId,
-                        courseId -> courseBookmarkRepository.existsByCourseIdAndUserId(courseId, userId)
-                ));
+        Map<Long, Boolean> bookmarkMap = new HashMap<>();
+
+        for (Long courseId : courseIds) {
+            String bookmarkKey = generateCourseBookmarkKey(userId, courseId);
+
+            try {
+                Boolean cachedBookmark = cacheService.get(bookmarkKey, Boolean.class);
+
+                if (cachedBookmark != null) {
+                    bookmarkMap.put(courseId, cachedBookmark);
+                } else {
+                    boolean isBookmarked = courseBookmarkRepository.existsByCourseIdAndUserId(courseId, userId);
+                    bookmarkMap.put(courseId, isBookmarked);
+
+                    safeSetCache(bookmarkKey, isBookmarked);
+                }
+            } catch (Exception e) {
+                log.warn("코스 북마크 상태 조회 실패 - userId: {}, courseId: {}", userId, courseId, e);
+                boolean isBookmarked = courseBookmarkRepository.existsByCourseIdAndUserId(courseId, userId);
+                bookmarkMap.put(courseId, isBookmarked);
+            }
+        }
+
+        return bookmarkMap;
     }
+
+    private boolean isCourseBookmarked(Long userId, Long courseId) {
+        String bookmarkKey = generateCourseBookmarkKey(userId, courseId);
+
+        try {
+            Boolean cachedBookmark = cacheService.get(bookmarkKey, Boolean.class);
+
+            if (cachedBookmark != null) {
+                return cachedBookmark;
+            }
+
+            // Redis에 없으면 DB 조회 후 캐싱
+            boolean isBookmarked = courseBookmarkRepository.existsByCourseIdAndUserId(courseId, userId);
+            safeSetCache(bookmarkKey, isBookmarked);
+
+            return isBookmarked;
+        } catch (Exception e) {
+            log.warn("코스 북마크 상태 조회 실패 - userId: {}, courseId: {}", userId, courseId, e);
+            return courseBookmarkRepository.existsByCourseIdAndUserId(courseId, userId);
+        }
+    }
+
+    //===편의 메서드===//
 
     /**
      * CoursePlace를 CoursePlaceDetailsDto로 변환
@@ -164,17 +227,6 @@ public class CourseService {
     }
 
     /**
-     * 코스의 썸네일 URL 생성 (첫 번째 장소의 썸네일 사용)
-     */
-    private String getCourseThumbnailUrl(Course course) {
-        return course.getCoursePlaces().stream()
-                .findFirst()
-                .map(CoursePlace::getPlace)
-                .map(this::getThumbnailUrl)
-                .orElse(null);
-    }
-
-    /**
      * 코스에서 메인 태그들 추출 (중복 제거)
      */
     private List<TagName> extractMainTagsFromCourse(Course course) {
@@ -190,10 +242,39 @@ public class CourseService {
     }
 
     /**
+     * 코스의 썸네일 URL 생성 (첫 번째 장소의 썸네일 사용)
+     */
+    private String getCourseThumbnailUrl(Course course) {
+        return course.getCoursePlaces().stream()
+                .findFirst()
+                .map(CoursePlace::getPlace)
+                .map(this::getThumbnailUrl)
+                .orElse(null);
+    }
+
+    /**
      * 장소의 썸네일 이미지 URL 생성
      */
     private String getThumbnailUrl(Place place) {
         String fileKey = place.getThumbnailFileKey(); // Place 엔티티 메서드 활용
         return fileKey != null ? imageUrlProvider.getImageUrl(fileKey) : null;
+    }
+
+    //===Helper 메서드===//
+
+    private String generatePlaceBookmarkKey(Long userId, Long placeId) {
+        return String.format("%s:%d:%d", PLACE_BOOKMARK_KEY_PREFIX, userId, placeId);
+    }
+
+    private String generateCourseBookmarkKey(Long userId, Long courseId) {
+        return String.format("%s:%d:%d", COURSE_BOOKMARK_KEY_PREFIX, userId, courseId);
+    }
+
+    private void safeSetCache(String key, Object value) {
+        try {
+            cacheService.set(key, value, BOOKMARK_CACHE_TTL, TimeUnit.HOURS);
+        } catch (Exception e) {
+            log.warn("캐시 저장 실패 - key: {}", key, e);
+        }
     }
 }

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -11,7 +11,6 @@ import org.sopt.solply_server.domain.course.entity.CoursePlace;
 import org.sopt.solply_server.domain.course.repository.CourseBookmarkRepository;
 import org.sopt.solply_server.domain.course.repository.CourseRepository;
 import org.sopt.solply_server.domain.place.entity.Place;
-import org.sopt.solply_server.domain.place.entity.PlaceImageInfo;
 import org.sopt.solply_server.domain.place.entity.PlaceTag;
 import org.sopt.solply_server.domain.place.repository.PlaceBookmarkRepository;
 import org.sopt.solply_server.domain.tag.entity.Tag;
@@ -19,7 +18,6 @@ import org.sopt.solply_server.domain.tag.entity.TagName;
 import org.sopt.solply_server.domain.tag.entity.TagType;
 import org.sopt.solply_server.domain.town.service.TownService;
 import org.sopt.solply_server.global.cache.CacheService;
-import org.sopt.solply_server.global.exception.BusinessException;
 import org.sopt.solply_server.global.exception.EntityNotFoundException;
 import org.sopt.solply_server.global.exception.ErrorCode;
 import org.sopt.solply_server.global.util.s3.ImageUrlProvider;
@@ -28,7 +26,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -130,7 +127,7 @@ public class CourseService {
                     bookmarkMap.put(placeId, isBookmarked);
 
                     // Redis에 캐싱 (실패해도 무시)
-                    safeSetCache(bookmarkKey, isBookmarked);
+                    cacheService.set(bookmarkKey, isBookmarked, BOOKMARK_CACHE_TTL, TimeUnit.HOURS);
                 }
             } catch (Exception e) {
                 log.warn("장소 북마크 상태 조회 실패 - userId: {}, placeId: {}", userId, placeId, e);
@@ -162,7 +159,7 @@ public class CourseService {
                     boolean isBookmarked = courseBookmarkRepository.existsByCourseIdAndUserId(courseId, userId);
                     bookmarkMap.put(courseId, isBookmarked);
 
-                    safeSetCache(bookmarkKey, isBookmarked);
+                    cacheService.set(bookmarkKey, isBookmarked, BOOKMARK_CACHE_TTL, TimeUnit.HOURS);
                 }
             } catch (Exception e) {
                 log.warn("코스 북마크 상태 조회 실패 - userId: {}, courseId: {}", userId, courseId, e);
@@ -186,7 +183,7 @@ public class CourseService {
 
             // Redis에 없으면 DB 조회 후 캐싱
             boolean isBookmarked = courseBookmarkRepository.existsByCourseIdAndUserId(courseId, userId);
-            safeSetCache(bookmarkKey, isBookmarked);
+            cacheService.set(bookmarkKey, isBookmarked, BOOKMARK_CACHE_TTL, TimeUnit.HOURS);
 
             return isBookmarked;
         } catch (Exception e) {
@@ -206,7 +203,7 @@ public class CourseService {
 
         return CoursePlaceDetailsDto.of(
                 place,
-                getThumbnailUrl(place),
+                getImageUrl(place),
                 place.getPrimaryTag(), // Place 엔티티 메서드 활용
                 placeBookmarkMap.getOrDefault(place.getId(), false),
                 coursePlace.getPlaceOrder()
@@ -255,14 +252,14 @@ public class CourseService {
         return course.getCoursePlaces().stream()
                 .findFirst()
                 .map(CoursePlace::getPlace)
-                .map(this::getThumbnailUrl)
+                .map(this::getImageUrl)
                 .orElse(null);
     }
 
     /**
      * 장소의 썸네일 이미지 URL 생성
      */
-    private String getThumbnailUrl(final Place place) {
+    private String getImageUrl(final Place place) {
         String fileKey = place.getThumbnailFileKey(); // Place 엔티티 메서드 활용
         return fileKey != null ? imageUrlProvider.getImageUrl(fileKey) : null;
     }
@@ -275,13 +272,5 @@ public class CourseService {
 
     private String generateCourseBookmarkKey(final Long userId, final Long courseId) {
         return String.format("%s:%d:%d", COURSE_BOOKMARK_KEY_PREFIX, userId, courseId);
-    }
-
-    private void safeSetCache(final String key, final Object value) {
-        try {
-            cacheService.set(key, value, BOOKMARK_CACHE_TTL, TimeUnit.HOURS);
-        } catch (Exception e) {
-            log.warn("캐시 저장 실패 - key: {}", key, e);
-        }
     }
 }

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -1,8 +1,11 @@
 package org.sopt.solply_server.domain.course.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.solply_server.domain.course.dto.CoursePlaceDetailsDto;
+import org.sopt.solply_server.domain.course.dto.CourseRecommendDto;
 import org.sopt.solply_server.domain.course.dto.response.CourseDetailGetResponse;
+import org.sopt.solply_server.domain.course.dto.response.CourseRecommendGetResponse;
 import org.sopt.solply_server.domain.course.entity.Course;
 import org.sopt.solply_server.domain.course.entity.CoursePlace;
 import org.sopt.solply_server.domain.course.repository.CourseBookmarkRepository;
@@ -14,6 +17,7 @@ import org.sopt.solply_server.domain.place.repository.PlaceBookmarkRepository;
 import org.sopt.solply_server.domain.tag.entity.Tag;
 import org.sopt.solply_server.domain.tag.entity.TagName;
 import org.sopt.solply_server.domain.tag.entity.TagType;
+import org.sopt.solply_server.domain.town.service.TownService;
 import org.sopt.solply_server.global.exception.BusinessException;
 import org.sopt.solply_server.global.exception.EntityNotFoundException;
 import org.sopt.solply_server.global.exception.ErrorCode;
@@ -21,11 +25,13 @@ import org.sopt.solply_server.global.util.s3.ImageUrlProvider;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -34,6 +40,7 @@ public class CourseService {
     private final CourseRepository courseRepository;
     private final CourseBookmarkRepository courseBookmarkRepository;
     private final PlaceBookmarkRepository placeBookmarkRepository;
+    private final TownService townService;
     private final ImageUrlProvider imageUrlProvider;
 
     /**
@@ -67,6 +74,35 @@ public class CourseService {
         return CourseDetailGetResponse.of(course, isCourseBookmarked, coursePlaces);
     }
 
+    /**
+     * 추천 코스 목록 조회
+     */
+    public CourseRecommendGetResponse findRecommendCourses(final Long userId, final Long townId) {
+        townService.findTownById(townId);
+
+        List<Course> sharedCourses = courseRepository.findSharedCoursesByTownIdWithDetails(townId);
+
+        if (sharedCourses.isEmpty()) {
+            log.info("동네 ID {}에 공유된 코스가 없습니다.", townId);
+            return CourseRecommendGetResponse.from(List.of());
+        }
+
+        List<Long> courseIds = sharedCourses.stream()
+                .map(Course::getId)
+                .toList();
+
+        // 코스 북마크 상태를 한번에 조회 (TODO: Redis로 변경 필요)
+        Map<Long, Boolean> courseBookmarkMap = getCourseBookmarkMap(courseIds, userId);
+
+        List<CourseRecommendDto> courseRecommendDtos = sharedCourses.stream()
+                .map(course -> convertToCourseRecommendDto(course, courseBookmarkMap))
+                .toList();
+
+        return CourseRecommendGetResponse.from(courseRecommendDtos);
+    }
+
+    //===편의 메서드===//
+
     private Map<Long, Boolean> getPlaceBookmarkMap(List<Long> placeIds, Long userId) {
         if (placeIds.isEmpty()) {
             return Map.of();
@@ -79,6 +115,20 @@ public class CourseService {
                 .collect(Collectors.toMap(
                         placeId -> placeId,
                         bookmarkedPlaceIds::contains
+                ));
+    }
+
+    private Map<Long, Boolean> getCourseBookmarkMap(List<Long> courseIds, Long userId) {
+        if (courseIds.isEmpty()) {
+            return Map.of();
+        }
+
+        // TODO: Redis 기반 북마크 조회로 변경, 배치 조회 메서드 추가 필요
+        // 현재는 개별 조회
+        return courseIds.stream()
+                .collect(Collectors.toMap(
+                        courseId -> courseId,
+                        courseId -> courseBookmarkRepository.existsByCourseIdAndUserId(courseId, userId)
                 ));
     }
 
@@ -95,6 +145,48 @@ public class CourseService {
                 placeBookmarkMap.getOrDefault(place.getId(), false),
                 coursePlace.getPlaceOrder()
         );
+    }
+
+    /**
+     * Course를 CourseRecommendDto로 변환
+     */
+    private CourseRecommendDto convertToCourseRecommendDto(Course course, Map<Long, Boolean> courseBookmarkMap) {
+        List<TagName> mainTags = extractMainTagsFromCourse(course);
+
+        String thumbnailUrl = getCourseThumbnailUrl(course);
+
+        return CourseRecommendDto.of(
+                course,
+                thumbnailUrl,
+                mainTags,
+                courseBookmarkMap.getOrDefault(course.getId(), false)
+        );
+    }
+
+    /**
+     * 코스의 썸네일 URL 생성 (첫 번째 장소의 썸네일 사용)
+     */
+    private String getCourseThumbnailUrl(Course course) {
+        return course.getCoursePlaces().stream()
+                .findFirst()
+                .map(CoursePlace::getPlace)
+                .map(this::getThumbnailUrl)
+                .orElse(null);
+    }
+
+    /**
+     * 코스에서 메인 태그들 추출 (중복 제거)
+     */
+    private List<TagName> extractMainTagsFromCourse(Course course) {
+        return course.getCoursePlaces().stream()
+                .map(CoursePlace::getPlace)
+                .flatMap(place -> place.getPlaceTags().stream())
+                .map(PlaceTag::getTag)
+                .filter(tag -> tag.getType() == TagType.MAIN)
+                .map(Tag::getName)
+                .distinct()
+                .sorted(Comparator.comparing(TagName::name)) // 정렬로 일관성 보장
+                .toList();
     }
 
     /**

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -143,7 +143,6 @@ public class CourseService {
         return bookmarkMap;
     }
 
-    // TODO: Redis 기반 북마크 조회로 변경, 배치 조회 메서드 추가 필요
     private Map<Long, Boolean> getCourseBookmarkMap(final List<Long> courseIds, final Long userId) {
         if (courseIds.isEmpty()) {
             return Map.of();
@@ -219,7 +218,7 @@ public class CourseService {
      */
     private CourseRecommendDto convertToCourseRecommendDto(final Course course,
                                                            final Map<Long, Boolean> courseBookmarkMap) {
-        List<TagName> mainTags = extractMainTagsFromCourse(course);
+        List<TagName> mainTags = extractTopTwoPlaceMainTags(course);
 
         String thumbnailUrl = getCourseThumbnailUrl(course);
 
@@ -232,17 +231,20 @@ public class CourseService {
     }
 
     /**
-     * 코스에서 메인 태그들 추출 (중복 제거)
+     * 코스에서 상위 2개 장소의 메인 태그를 순서대로 추출 (중복 허용)
      */
-    private List<TagName> extractMainTagsFromCourse(final Course course) {
+    private List<TagName> extractTopTwoPlaceMainTags(final Course course) {
         return course.getCoursePlaces().stream()
+                .sorted(Comparator.comparing(CoursePlace::getPlaceOrder))
+                .limit(2)
                 .map(CoursePlace::getPlace)
-                .flatMap(place -> place.getPlaceTags().stream())
-                .map(PlaceTag::getTag)
-                .filter(tag -> tag.getType() == TagType.MAIN)
-                .map(Tag::getName)
-                .distinct()
-                .sorted(Comparator.comparing(TagName::name)) // 정렬로 일관성 보장
+                .map(place -> place.getPlaceTags().stream()
+                        .map(PlaceTag::getTag)
+                        .filter(tag -> tag.getType() == TagType.MAIN)
+                        .map(Tag::getName)
+                        .findFirst()
+                        .orElse(null))
+                .filter(Objects::nonNull)
                 .toList();
     }
 

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -83,7 +83,7 @@ public class CourseService {
     public CourseRecommendGetResponse findRecommendCourses(final Long userId, final Long townId) {
         townService.findTownById(townId);
 
-        List<Course> sharedCourses = courseRepository.findSharedCoursesByTownIdWithDetails(townId);
+        List<Course> sharedCourses = courseRepository.findSharedCoursesByTownIdWithPlaces(townId);
 
         if (sharedCourses.isEmpty()) {
             log.info("동네 ID {}에 공유된 코스가 없습니다.", townId);
@@ -93,6 +93,9 @@ public class CourseService {
         List<Long> courseIds = sharedCourses.stream()
                 .map(Course::getId)
                 .toList();
+
+        // 장소 태그 정보를 미리 로드 (영속성 컨텍스트에 적재)
+        courseRepository.findPlacesWithTagsByCourseIds(courseIds);
 
         Map<Long, Boolean> courseBookmarkMap = getCourseBookmarkMap(courseIds, userId);
 


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #68 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- 필터링 성격의 파라미터이므로 Query Parameter가 더 적절
- townName 대신 townId로 정확한 식별자 사용하도록 수정 반영
- 마찬가지로 MultipleBagFetchException 해결
  - 단계별 조회 방식: 여러 OneToMany 컬렉션을 동시에 FETCH JOIN하지 않음
  - 1단계: findSharedCoursesByTownIdWithPlaces() - 코스와 장소 정보 조회
  - 2단계: findPlacesWithTagsByCourseIds() - 장소 태그 정보 배치 조회
  - N+1 문제 해결: 총 2개의 쿼리로 모든 데이터 조회 완료
- Redis 캐시 기반 북마크 조회
  - 기존 장소 북마크 패턴 활용: PlaceBookmarkService의 Redis 패턴 적용
  - 코스 북마크 캐시 구현: course_bookmark:{userId}:{courseId} 키 패턴 사용
  - Fallback 전략: Redis 실패 시 DB 조회로 안정성 보장
- 비즈니스 로직 (태그)
  - 상위 2개 장소 메인 태그: placeOrder 순서대로 중복 허용하여 반환
  - 공유 코스 필터링: isShared = true 조건으로 공개된 코스만 조회
  - 최신순 정렬: createdAt DESC 기준으로 정렬
- final 파라미터 적용: 메서드 파라미터에 final 키워드로 불변성 보장
- Place 엔티티 편의 메서드 활용



<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 쿼리 및 로직이 올바르게 구현되었는지 확인 부탁드립니당
- 수정사항 있으면 말씀해주세요!!!

<br/>

## 🚀 알게된 점 (선택)

---

- final 파라미터의 중요성
  - 불변성 보장: 메서드 내에서 파라미터 값 실수 변경 방지
  - 가독성 향상: 해당 파라미터가 변경되지 않는다는 의도 명확히 표현
  - 코드 안정성: 의도치 않은 재할당 방지
- Redis 캐시 패턴
  - 기존 PlaceBookmarkService 패턴을 코스 도메인에 확장 적용

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 