### PR TITLE
[FEAT] 코스 수정 API 구현

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/course/controller/CourseController.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/controller/CourseController.java
@@ -7,11 +7,9 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.sopt.solply_server.domain.course.dto.request.CourseCreateRequest;
-import org.sopt.solply_server.domain.course.dto.response.CourseCreateResponse;
-import org.sopt.solply_server.domain.course.dto.response.CourseDetailGetResponse;
-import org.sopt.solply_server.domain.course.dto.response.CourseFolderPreviewListGetResponse;
+import org.sopt.solply_server.domain.course.dto.request.CourseUpdateRequest;
+import org.sopt.solply_server.domain.course.dto.response.*;
 import org.sopt.solply_server.domain.course.service.CourseBookmarkService;
-import org.sopt.solply_server.domain.course.dto.response.CourseRecommendGetResponse;
 import org.sopt.solply_server.domain.course.service.CourseService;
 import org.sopt.solply_server.global.annotation.CurrentUserId;
 import org.sopt.solply_server.global.dto.CustomApiResponse;
@@ -39,6 +37,18 @@ public class CourseController {
         return CustomApiResponse.success(
                 "코스 생성을 완료했습니다.",
                 courseService.createCourse(userId, request)
+        );
+    }
+
+    @Operation(summary = "코스 수정", description = "기존 코스를 수정합니다.")
+    @PutMapping("/{courseId}")
+    public ResponseEntity<CustomApiResponse<CourseUpdateResponse>> updateCourse(
+            @CurrentUserId Long userId,
+            @PathVariable Long courseId,
+            @Valid @RequestBody CourseUpdateRequest request) {
+        return CustomApiResponse.success(
+                "코스 정보가 성공적으로 수정되었습니다.",
+                courseService.updateCourse(userId, courseId, request)
         );
     }
 

--- a/src/main/java/org/sopt/solply_server/domain/course/dto/request/CourseCreateRequest.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/dto/request/CourseCreateRequest.java
@@ -11,8 +11,8 @@ public record CourseCreateRequest(
         @NotNull(message = "원본 코스 ID는 필수입니다.")
         Long originalCourseId,
 
-        @NotBlank(message = "코스 이름은 필수입니다.")  // 추가
-        @Size(max = 50, message = "코스 이름은 50자 이하로 입력해주세요.")  // 추가
+        @NotBlank(message = "코스 이름은 필수입니다.")
+        @Size(max = 50, message = "코스 이름은 50자 이하로 입력해주세요.")
         String courseName,
 
         @NotEmpty(message = "코스에는 2개 이상의 장소가 포함되어야 합니다.")

--- a/src/main/java/org/sopt/solply_server/domain/course/dto/request/CourseUpdateRequest.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/dto/request/CourseUpdateRequest.java
@@ -1,0 +1,47 @@
+package org.sopt.solply_server.domain.course.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record CourseUpdateRequest(
+        @NotNull(message = "원본 코스 ID는 필수입니다.")
+        Long originalCourseId,
+
+        @NotBlank(message = "코스 이름은 필수입니다.")  // 추가
+        @Size(max = 50, message = "코스 이름은 50자 이하로 입력해주세요.")  // 추가
+        String courseName,
+
+        @NotEmpty(message = "코스에는 2개 이상의 장소가 포함되어야 합니다.")
+        @Size(min = 2, max = 6, message = "코스에는 2개 이상 6개 이하의 장소가 포함되어야 합니다.")
+        @Valid
+        List<CoursePlaceUpdateRequest> places
+) {
+
+    public record CoursePlaceUpdateRequest(
+            @NotNull(message = "장소 ID는 필수입니다.")
+            Long placeId,
+
+            @NotNull(message = "순서는 필수입니다.")
+            Integer placeOrder
+    ) {
+    }
+
+    public CourseCreateRequest toCreateRequest() {
+        List<CourseCreateRequest.CoursePlaceRequest> createPlaces = this.places.stream()
+                .map(place -> new CourseCreateRequest.CoursePlaceRequest(
+                        place.placeId(),
+                        place.placeOrder()
+                ))
+                .toList();
+
+        return new CourseCreateRequest(
+                this.originalCourseId,
+                this.courseName,
+                createPlaces
+        );
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/course/dto/request/CourseUpdateRequest.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/dto/request/CourseUpdateRequest.java
@@ -8,11 +8,8 @@ import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public record CourseUpdateRequest(
-        @NotNull(message = "원본 코스 ID는 필수입니다.")
-        Long originalCourseId,
-
-        @NotBlank(message = "코스 이름은 필수입니다.")  // 추가
-        @Size(max = 50, message = "코스 이름은 50자 이하로 입력해주세요.")  // 추가
+        @NotBlank(message = "코스 이름은 필수입니다.")
+        @Size(max = 50, message = "코스 이름은 50자 이하로 입력해주세요.")
         String courseName,
 
         @NotEmpty(message = "코스에는 2개 이상의 장소가 포함되어야 합니다.")
@@ -28,20 +25,5 @@ public record CourseUpdateRequest(
             @NotNull(message = "순서는 필수입니다.")
             Integer placeOrder
     ) {
-    }
-
-    public CourseCreateRequest toCreateRequest() {
-        List<CourseCreateRequest.CoursePlaceRequest> createPlaces = this.places.stream()
-                .map(place -> new CourseCreateRequest.CoursePlaceRequest(
-                        place.placeId(),
-                        place.placeOrder()
-                ))
-                .toList();
-
-        return new CourseCreateRequest(
-                this.originalCourseId,
-                this.courseName,
-                createPlaces
-        );
     }
 }

--- a/src/main/java/org/sopt/solply_server/domain/course/dto/response/CourseUpdateResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/dto/response/CourseUpdateResponse.java
@@ -1,9 +1,10 @@
 package org.sopt.solply_server.domain.course.dto.response;
 
 public record CourseUpdateResponse(
-        Long courseId
+        Long courseId,
+        boolean isNewCourse
 ) {
-    public static CourseUpdateResponse from(Long courseId) {
-        return new CourseUpdateResponse(courseId);
+    public static CourseUpdateResponse of(Long courseId, boolean isNewCourse) {
+        return new CourseUpdateResponse(courseId, isNewCourse);
     }
 }

--- a/src/main/java/org/sopt/solply_server/domain/course/dto/response/CourseUpdateResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/dto/response/CourseUpdateResponse.java
@@ -1,0 +1,9 @@
+package org.sopt.solply_server.domain.course.dto.response;
+
+public record CourseUpdateResponse(
+        Long courseId
+) {
+    public static CourseUpdateResponse from(Long courseId) {
+        return new CourseUpdateResponse(courseId);
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/course/entity/Course.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/entity/Course.java
@@ -65,6 +65,16 @@ public class Course extends BaseTimeEntity {
     }
 
     public boolean isCreatedBy(Long userId) {
+        if (this.createdBy == null || userId == null) {
+            return false;
+        }
         return this.createdBy.getId().equals(userId);
+    }
+
+    public void updateCourse(String newName, List<CoursePlace> newCoursePlaces) {
+        this.name = newName;
+        this.coursePlaces.clear();
+        this.coursePlaces.addAll(newCoursePlaces);
+        newCoursePlaces.forEach(cp -> cp.setCourse(this));
     }
 }

--- a/src/main/java/org/sopt/solply_server/domain/course/entity/Course.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/entity/Course.java
@@ -62,6 +62,7 @@ public class Course extends BaseTimeEntity {
 
     public void addCoursePlace(CoursePlace coursePlace) {
         this.coursePlaces.add(coursePlace);
+        coursePlace.setCourse(this);
     }
 
     public boolean isCreatedBy(Long userId) {
@@ -71,10 +72,7 @@ public class Course extends BaseTimeEntity {
         return this.createdBy.getId().equals(userId);
     }
 
-    public void updateCourse(String newName, List<CoursePlace> newCoursePlaces) {
+    public void updateName(String newName) {
         this.name = newName;
-        this.coursePlaces.clear();
-        this.coursePlaces.addAll(newCoursePlaces);
-        newCoursePlaces.forEach(cp -> cp.setCourse(this));
     }
 }

--- a/src/main/java/org/sopt/solply_server/domain/course/entity/CoursePlace.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/entity/CoursePlace.java
@@ -49,4 +49,8 @@ public class CoursePlace extends BaseTimeEntity {
                 .build();
     }
 
+    public void setCourse(Course course) {
+        this.course = course;
+    }
+
 }

--- a/src/main/java/org/sopt/solply_server/domain/course/repository/CourseRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/repository/CourseRepository.java
@@ -3,6 +3,7 @@ package org.sopt.solply_server.domain.course.repository;
 import org.sopt.solply_server.domain.course.entity.Course;
 import org.sopt.solply_server.domain.place.entity.Place;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -71,5 +72,9 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
             "ORDER BY c.name")
     List<String> findCourseNamesByTownAndNamePattern(@Param("townId") Long townId,
                                                      @Param("namePattern") String namePattern);
+
+    @Modifying
+    @Query("DELETE FROM CoursePlace cp WHERE cp.course.id = :courseId")
+    void deleteCoursePlacesByCourseId(@Param("courseId") Long courseId);
 
 }

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -7,10 +7,8 @@ import org.sopt.solply_server.domain.course.dto.CourseFolderDto;
 import org.sopt.solply_server.domain.course.dto.CoursePlaceDetailsDto;
 import org.sopt.solply_server.domain.course.dto.CoursePreviewDto;
 import org.sopt.solply_server.domain.course.dto.request.CourseCreateRequest;
-import org.sopt.solply_server.domain.course.dto.response.CourseCreateResponse;
-import org.sopt.solply_server.domain.course.dto.response.CourseDetailGetResponse;
-import org.sopt.solply_server.domain.course.dto.response.CourseFolderPreviewListGetResponse;
-import org.sopt.solply_server.domain.course.dto.response.CourseRecommendGetResponse;
+import org.sopt.solply_server.domain.course.dto.request.CourseUpdateRequest;
+import org.sopt.solply_server.domain.course.dto.response.*;
 import org.sopt.solply_server.domain.course.entity.Course;
 import org.sopt.solply_server.domain.course.entity.CoursePlace;
 import org.sopt.solply_server.domain.course.mapper.CourseMapper;
@@ -86,6 +84,68 @@ public class CourseService {
         }
 
         return CourseCreateResponse.from(savedCourse.getId());
+    }
+
+    /**
+     * 코스 수정
+     * - 사용자의 코스로 등록되어있는 경우: 기존 코스 수정
+     * - 그렇지 않은 경우: 새 코스 생성 후 북마크 등록
+     */
+    @Transactional
+    public CourseUpdateResponse updateCourse(Long userId, Long courseId, CourseUpdateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_USER));
+
+        Course courseToUpdate = courseRepository.findByIdWithPlaces(courseId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_COURSE));
+
+        List<Place> places = getAndValidatePlacesFromRequest(request.places());
+
+        if (courseToUpdate.isCreatedBy(userId)) {
+            updateCourseInPlace(courseToUpdate, request, places);
+            log.info("기존 코스 수정 완료 - userId: {}, courseId: {}", userId, courseId);
+            return CourseUpdateResponse.of(courseId, false);
+        }
+        else {
+            Course newCourse = createNewCourseFromShared(user, courseToUpdate, request, places);
+            courseRepository.save(newCourse);
+            courseBookmarkService.createCourseBookmark(userId, newCourse.getId());
+            log.info("공유 코스 기반 새 코스 생성 및 북마크 완료 - userId: {}, newCourseId: {}", userId, newCourse.getId());
+            return CourseUpdateResponse.of(newCourse.getId(), true);
+        }
+
+    }
+
+    /**
+     * 기존 코스 업데이트
+     */
+    private void updateCourseInPlace(Course course, CourseUpdateRequest request, List<Place> places) {
+        List<CoursePlace> newCoursePlaces = createCoursePlaces(course, request.places(), places);
+        course.updateCourse(request.courseName(), newCoursePlaces);
+    }
+
+    /**
+     * 공유 코스를 기반으로 사용자 소유의 새로운 코스 생성
+     */
+    private Course createNewCourseFromShared(User user, Course originalCourse, CourseUpdateRequest request, List<Place> places) {
+        String introduction = originalCourse.getIntroduction();
+        Town town = places.get(0).getTown();
+
+        Course newCourse = Course.createUserCourse(request.courseName(), introduction, town, user);
+
+        List<CoursePlace> coursePlaces = createCoursePlaces(newCourse, request.places(), places);
+        coursePlaces.forEach(newCourse::addCoursePlace);
+
+        return newCourse;
+    }
+
+    private List<CoursePlace> createCoursePlaces(Course course, List<CourseUpdateRequest.CoursePlaceUpdateRequest> placeRequests, List<Place> places) {
+        Map<Long, Place> placeMap = places.stream()
+                .collect(Collectors.toMap(Place::getId, Function.identity()));
+
+        return placeRequests.stream()
+                .map(req -> CoursePlace.create(course, placeMap.get(req.placeId()), req.placeOrder()))
+                .collect(Collectors.toList());
     }
 
     /**
@@ -243,12 +303,45 @@ public class CourseService {
         List<Long> placeIds = request.places().stream()
                 .map(CourseCreateRequest.CoursePlaceRequest::placeId)
                 .toList();
-
         if (placeIds.isEmpty()) {
             throw new BusinessException(ErrorCode.INVALID_REQUEST_BODY, "장소 목록이 비어있습니다.");
         }
 
         return placeService.getPlacesWithTownByPlaceIds(placeIds);
+    }
+
+    private List<Place> getAndValidatePlacesFromRequest(List<CourseUpdateRequest.CoursePlaceUpdateRequest> placeRequests) {
+        validateCoursePlaceRequests(placeRequests);
+
+        List<Long> placeIds = placeRequests.stream().map(CourseUpdateRequest.CoursePlaceUpdateRequest::placeId).toList();
+        List<Place> places = placeService.getPlacesWithTownByPlaceIds(placeIds);
+
+        if (places.stream().map(place -> place.getTown().getId()).distinct().count() > 1) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST_BODY, "모든 장소는 같은 동네에 속해야 합니다.");
+        }
+        return places;
+    }
+
+    private void validateCoursePlaceRequests(List<CourseUpdateRequest.CoursePlaceUpdateRequest> places) {
+        if (places.size() < 2 || places.size() > 6) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST_BODY, "코스에는 2개 이상 6개 이하의 장소가 포함되어야 합니다.");
+        }
+
+        List<Integer> orders = places.stream()
+                .map(CourseUpdateRequest.CoursePlaceUpdateRequest::placeOrder)
+                .sorted()
+                .toList();
+
+        for (int i = 0; i < orders.size(); i++) {
+            if (orders.get(i) != i + 1) {
+                throw new BusinessException(ErrorCode.INVALID_REQUEST_BODY, "장소 순서는 1부터 순차적이어야 합니다.");
+            }
+        }
+
+        Set<Long> uniquePlaceIds = new HashSet<>();
+        if (places.stream().anyMatch(p -> !uniquePlaceIds.add(p.placeId()))) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST_BODY, "중복된 장소가 포함되어 있습니다.");
+        }
     }
 
     private void validateSameTown(List<Place> places, Town referenceTown) {
@@ -300,12 +393,10 @@ public class CourseService {
     }
 
     private String getOriginalCourseIntroduction(Long originalCourseId) {
-        Course originalCourse = courseRepository.findById(originalCourseId)
+        return courseRepository.findById(originalCourseId)
+                .map(Course::getIntroduction)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_COURSE));
-
-        return originalCourse.getIntroduction();
     }
-
 
     /**
      * 코스에서 상위 2개 장소의 메인 태그를 순서대로 추출 (중복 허용)

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -120,8 +120,10 @@ public class CourseService {
      * 기존 코스 업데이트
      */
     private void updateCourseInPlace(Course course, CourseUpdateRequest request, List<Place> places) {
+        course.updateName(request.courseName());
+        courseRepository.deleteCoursePlacesByCourseId(course.getId());
         List<CoursePlace> newCoursePlaces = createCoursePlaces(course, request.places(), places);
-        course.updateCourse(request.courseName(), newCoursePlaces);
+        newCoursePlaces.forEach(course::addCoursePlace);
     }
 
     /**
@@ -316,7 +318,7 @@ public class CourseService {
         List<Long> placeIds = placeRequests.stream().map(CourseUpdateRequest.CoursePlaceUpdateRequest::placeId).toList();
         List<Place> places = placeService.getPlacesWithTownByPlaceIds(placeIds);
 
-        if (places.stream().map(place -> place.getTown().getId()).distinct().count() > 1) {
+        if (places.stream().map(Place::getTown).map(Town::getId).distinct().count() > 1) {
             throw new BusinessException(ErrorCode.INVALID_REQUEST_BODY, "모든 장소는 같은 동네에 속해야 합니다.");
         }
         return places;


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #91 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- 요청한 유저가 직접 생성한 코스를 수정할 경우, 기존 코스의 정보를 덮어쓰기 방식으로 처리합니다.
- 공유된 코스(어드민)를 수정할 경우, 원본의 이름과 소개글을 유지한 채 유저 소유의 새로운 코스를 생성하고 자동으로 북마크에 추가하도록 구현했습니다.


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 뭔가 코스 생성이랑 겹치는 로직이 많은데 CRUD는 그대로 따로 만드려고하다보니 옳은 방향으로 잘 구현한건지 모르겠네요,, 리팩토링이 필요할 것 같은 구현인 것 같습니다ㅠ
- 컬렉션의 상태 변경 책임을 서비스가 아닌 엔티티 스스로가 갖게 하려고 했는데 중복 키 문제나 데이터 삭제 관련해서 문제들이 발생해서 어렵네요,, 우선은 지금처럼 구현을 완성했습니다.
```
2025-07-15T15:48:35.962+09:00 ERROR 40317 --- [nio-8080-exec-2] o.h.engine.jdbc.spi.SqlExceptionHelper   : ERROR: duplicate key value violates unique constraint "idx_course_place_course_id_place_id"
  Detail: Key (course_id, place_id)=(5, 3) already exists.
2025-07-15T15:48:35.966+09:00 ERROR 40317 --- [nio-8080-exec-2] o.s.s.g.handler.GlobalExceptionHandler   : Unhandled Exception: could not execute statement [ERROR: duplicate key value violates unique constraint "idx_course_place_course_id_place_id"
  Detail: Key (course_id, place_id)=(5, 3) already exists.] [insert into course_place (course_id,created_at,place_id,place_order,updated_at) values (?,?,?,?,?) returning id]; SQL [insert into course_place (course_id,created_at,place_id,place_order,updated_at) values (?,?,?,?,?) returning id]; constraint [idx_course_place_course_id_place_id]

```

<br/>

## 🚀 알게된 점 (선택)

---

-

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 