### PR TITLE
[FEAT] 코스 북마크 필터링 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/course/controller/CourseController.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/controller/CourseController.java
@@ -10,7 +10,6 @@ import org.sopt.solply_server.domain.course.dto.request.CourseCreateRequest;
 import org.sopt.solply_server.domain.course.dto.response.CourseCreateResponse;
 import org.sopt.solply_server.domain.course.dto.response.CourseDetailGetResponse;
 import org.sopt.solply_server.domain.course.dto.response.CourseFolderPreviewListGetResponse;
-import org.sopt.solply_server.domain.course.dto.request.PlaceAddToCourseRequest;
 import org.sopt.solply_server.domain.course.dto.response.*;
 import org.sopt.solply_server.domain.course.service.CourseBookmarkService;
 import org.sopt.solply_server.domain.course.service.CourseService;
@@ -41,17 +40,6 @@ public class CourseController {
                 "코스 생성을 완료했습니다.",
                 courseService.createCourse(userId, request)
         );
-    }
-
-    @Operation(summary = "코스에 장소 추가", description = "기존 코스에 새로운 장소를 마지막 순서로 추가합니다.")
-    @PostMapping("/{courseId}/places")
-    public ResponseEntity<CustomApiResponse<Void>> addPlaceToCourse(
-            @CurrentUserId Long userId,
-            @Parameter(description = "코스 ID", required = true)
-            @PathVariable("courseId") Long courseId,
-            @Valid @RequestBody PlaceAddToCourseRequest request) {
-        courseService.addPlaceToCourse(userId, courseId, request);
-        return CustomApiResponse.success("해당 코스에 장소가 성공적으로 추가되었습니다.");
     }
 
     @Operation(summary = "코스 상세 조회", description = "코스 ID를 통해 코스의 상세 정보를 조회합니다.")

--- a/src/main/java/org/sopt/solply_server/domain/course/controller/CourseController.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/controller/CourseController.java
@@ -10,8 +10,9 @@ import org.sopt.solply_server.domain.course.dto.request.CourseCreateRequest;
 import org.sopt.solply_server.domain.course.dto.response.CourseCreateResponse;
 import org.sopt.solply_server.domain.course.dto.response.CourseDetailGetResponse;
 import org.sopt.solply_server.domain.course.dto.response.CourseFolderPreviewListGetResponse;
+import org.sopt.solply_server.domain.course.dto.request.PlaceAddToCourseRequest;
+import org.sopt.solply_server.domain.course.dto.response.*;
 import org.sopt.solply_server.domain.course.service.CourseBookmarkService;
-import org.sopt.solply_server.domain.course.dto.response.CourseRecommendGetResponse;
 import org.sopt.solply_server.domain.course.service.CourseService;
 import org.sopt.solply_server.global.annotation.CurrentUserId;
 import org.sopt.solply_server.global.dto.CustomApiResponse;
@@ -42,6 +43,17 @@ public class CourseController {
         );
     }
 
+    @Operation(summary = "코스에 장소 추가", description = "기존 코스에 새로운 장소를 마지막 순서로 추가합니다.")
+    @PostMapping("/{courseId}/places")
+    public ResponseEntity<CustomApiResponse<Void>> addPlaceToCourse(
+            @CurrentUserId Long userId,
+            @Parameter(description = "코스 ID", required = true)
+            @PathVariable("courseId") Long courseId,
+            @Valid @RequestBody PlaceAddToCourseRequest request) {
+        courseService.addPlaceToCourse(userId, courseId, request);
+        return CustomApiResponse.success("해당 코스에 장소가 성공적으로 추가되었습니다.");
+    }
+
     @Operation(summary = "코스 상세 조회", description = "코스 ID를 통해 코스의 상세 정보를 조회합니다.")
     @GetMapping("/{courseId}")
     public ResponseEntity<CustomApiResponse<CourseDetailGetResponse>> findCourseDetailsById(
@@ -50,6 +62,24 @@ public class CourseController {
         return CustomApiResponse.success(
                 "코스 상세 조회에 성공했습니다.",
                 courseService.findCourseDetailsById(userId, courseId)
+        );
+    }
+
+    @Operation(summary = "사용자 북마크 코스 목록 조회",
+            description = "사용자가 추가 또는 조회할 수 있는 북마크한 코스 목록을 조회합니다.")
+    @GetMapping("/bookmarks")
+    public ResponseEntity<CustomApiResponse<CourseBookmarkListGetResponse>> getBookmarkedCourses(
+            @CurrentUserId Long userId,
+            @Parameter(description = "동네 ID", required = true)
+            @RequestParam("townId")
+            @NotNull(message = "동네 ID는 필수입니다")
+            Long townId,
+            @Parameter(description = "장소 ID (선택사항, 해당 장소를 추가할 수 있는 코스만 필터링)")
+            @RequestParam(value = "placeId", required = false)
+            Long placeId) {
+        return CustomApiResponse.success(
+                "사용자 코스 목록 조회에 성공했습니다.",
+                courseService.getBookmarkedCourses(userId, townId, placeId)
         );
     }
 

--- a/src/main/java/org/sopt/solply_server/domain/course/dto/CourseBookmarkDto.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/dto/CourseBookmarkDto.java
@@ -1,0 +1,31 @@
+package org.sopt.solply_server.domain.course.dto;
+
+import lombok.Builder;
+import org.sopt.solply_server.domain.course.entity.Course;
+import org.sopt.solply_server.domain.tag.entity.TagName;
+
+import java.util.List;
+
+@Builder
+public record CourseBookmarkDto(
+        Long courseId,
+        String title,
+        int placeCount,
+        String thumbnailImage,
+        List<TagName> mainTags,
+        boolean isBookmarked,
+        boolean isActive
+) {
+    public static CourseBookmarkDto of(Course course, String thumbnailImage,
+                                       List<TagName> mainTags, boolean isActive) {
+        return CourseBookmarkDto.builder()
+                .courseId(course.getId())
+                .title(course.getName())
+                .placeCount(course.getCoursePlaces().size())
+                .thumbnailImage(thumbnailImage)
+                .mainTags(mainTags)
+                .isBookmarked(true)
+                .isActive(isActive)
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/course/dto/response/CourseBookmarkListGetResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/dto/response/CourseBookmarkListGetResponse.java
@@ -1,0 +1,17 @@
+package org.sopt.solply_server.domain.course.dto.response;
+
+import lombok.Builder;
+import org.sopt.solply_server.domain.course.dto.CourseBookmarkDto;
+
+import java.util.List;
+
+@Builder
+public record CourseBookmarkListGetResponse(
+        List<CourseBookmarkDto> courses
+) {
+    public static CourseBookmarkListGetResponse from(List<CourseBookmarkDto> courses) {
+        return CourseBookmarkListGetResponse.builder()
+                .courses(courses)
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/course/mapper/CourseMapper.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/mapper/CourseMapper.java
@@ -3,6 +3,7 @@ package org.sopt.solply_server.domain.course.mapper;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.sopt.solply_server.domain.course.dto.CourseBookmarkDto;
 import org.sopt.solply_server.domain.course.dto.CourseFolderDto;
 import org.sopt.solply_server.domain.course.dto.CoursePlaceDetailsDto;
 import org.sopt.solply_server.domain.course.dto.CoursePreviewDto;
@@ -49,5 +50,10 @@ public class CourseMapper {
                 placeBookmarkMap.getOrDefault(place.getId(), false),
                 coursePlace.getPlaceOrder()
         );
+    }
+
+    public CourseBookmarkDto toCourseBookmarkDto(Course course, String thumbnailUrl,
+                                                 List<TagName> mainTags, boolean isActive) {
+        return CourseBookmarkDto.of(course, thumbnailUrl, mainTags, isActive);
     }
 }

--- a/src/main/java/org/sopt/solply_server/domain/course/repository/CourseRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/repository/CourseRepository.java
@@ -72,4 +72,20 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
     List<String> findCourseNamesByTownAndNamePattern(@Param("townId") Long townId,
                                                      @Param("namePattern") String namePattern);
 
+    /**
+     * 특정 동네의 북마크된 코스 목록 조회
+     * 코스와 코스 내 장소들을 함께 조회
+     */
+    @Query("""
+    SELECT DISTINCT c FROM Course c
+    JOIN FETCH c.town t
+    JOIN FETCH c.coursePlaces cp
+    JOIN FETCH cp.place p
+    WHERE c.id IN :courseIds 
+    AND c.town.id = :townId
+    ORDER BY c.createdAt DESC
+    """)
+    List<Course> findBookmarkedCoursesByTownId(@Param("courseIds") List<Long> courseIds,
+                                               @Param("townId") Long townId);
+
 }

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -2,11 +2,10 @@ package org.sopt.solply_server.domain.course.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.sopt.solply_server.domain.course.dto.CourseBookmarkRedisDto;
-import org.sopt.solply_server.domain.course.dto.CourseFolderDto;
-import org.sopt.solply_server.domain.course.dto.CoursePlaceDetailsDto;
-import org.sopt.solply_server.domain.course.dto.CoursePreviewDto;
+import org.sopt.solply_server.domain.course.dto.*;
 import org.sopt.solply_server.domain.course.dto.request.CourseCreateRequest;
+import org.sopt.solply_server.domain.course.dto.request.PlaceAddToCourseRequest;
+import org.sopt.solply_server.domain.course.dto.response.*;
 import org.sopt.solply_server.domain.course.dto.response.CourseCreateResponse;
 import org.sopt.solply_server.domain.course.dto.response.CourseDetailGetResponse;
 import org.sopt.solply_server.domain.course.dto.response.CourseFolderPreviewListGetResponse;
@@ -56,6 +55,8 @@ public class CourseService {
     private final CourseBookmarkRedisDataManager courseBookmarkRedisDataManager;
     private final CourseNameGenerator courseNameGenerator;
 
+    private static final int MAX_COURSE_PLACES = 6;
+
     /**
      * 새로운 코스 생성
      */
@@ -89,6 +90,28 @@ public class CourseService {
     }
 
     /**
+     * 코스에 장소 추가
+     */
+    @Transactional
+    public void addPlaceToCourse(Long userId, Long courseId, PlaceAddToCourseRequest request) {
+        Course course = courseRepository.findByIdWithPlaces(courseId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_COURSE));
+        validateCourseOwner(course, userId);
+        Place place = placeService.getPlaceById(request.placeId());
+        validateAddPlace(course, place);
+
+        int nextOrder = calculateNextPlaceOrder(course);
+
+        CoursePlace newCoursePlace = CoursePlace.create(course, place, nextOrder);
+        course.addCoursePlace(newCoursePlace);
+
+        courseRepository.save(course);
+
+        log.info("코스에 장소 추가 완료 - userId: {}, courseId: {}, placeId: {}, order: {}",
+                userId, courseId, request.placeId(), nextOrder);
+    }
+
+    /**
      * 코스 상세 정보 조회
      */
     public CourseDetailGetResponse findCourseDetailsById(final Long userId, final Long courseId) {
@@ -119,6 +142,54 @@ public class CourseService {
                 .toList();
 
         return CourseDetailGetResponse.of(course, isCourseBookmarked, coursePlaces);
+    }
+
+    /**
+     * 사용자가 북마크한 코스 목록 조회 (동네 기준 필터링 + 장소 추가 가능 여부)
+     */
+    public CourseBookmarkListGetResponse getBookmarkedCourses(final Long userId, final Long townId, final Long placeId) {
+        townService.existsById(townId);
+
+        if (placeId != null) {
+            placeService.validatePlaceExists(placeId);
+        }
+
+        // Redis에서 활성화된 코스 북마크 데이터 조회
+        List<CourseBookmarkRedisDto> activeBookmarks = courseBookmarkRedisDataManager.getActiveCourseBookmarks(userId);
+
+        if (activeBookmarks.isEmpty()) {
+            log.info("사용자 {}의 북마크된 코스가 없습니다.", userId);
+            return CourseBookmarkListGetResponse.from(List.of());
+        }
+
+        List<Long> courseIds = activeBookmarks.stream()
+                .map(CourseBookmarkRedisDto::courseId)
+                .toList();
+
+        List<Course> filteredCourses = courseRepository.findBookmarkedCoursesByTownId(courseIds, townId);
+
+        if (filteredCourses.isEmpty()) {
+            log.info("동네 {}에 북마크된 코스가 없습니다.", townId);
+            return CourseBookmarkListGetResponse.from(List.of());
+        }
+
+        // 코스 태그 정보 배치 로딩
+        List<Long> filteredCourseIds = filteredCourses.stream()
+                .map(Course::getId)
+                .toList();
+        courseRepository.findPlacesWithTagsByCourseIds(filteredCourseIds);
+
+        List<CourseBookmarkDto> courseBookmarkDtos = filteredCourses.stream()
+                .map(course -> {
+                    List<TagName> mainTags = extractTopTwoPlaceMainTags(course);
+                    String thumbnailUrl = getCourseThumbnailUrl(course);
+                    boolean isActive = calculateCourseActiveStatus(course, placeId);
+
+                    return courseMapper.toCourseBookmarkDto(course, thumbnailUrl, mainTags, isActive);
+                })
+                .toList();
+
+        return CourseBookmarkListGetResponse.from(courseBookmarkDtos);
     }
 
     /**
@@ -237,6 +308,56 @@ public class CourseService {
                         "중복된 장소가 포함되어 있습니다.");
             }
         }
+    }
+
+    private void validateCourseOwner(Course course, Long userId) {
+        if (!course.isCreatedBy(userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_RESOURCE);
+        }
+    }
+
+    private void validateAddPlace(Course course, Place place) {
+        if (course.getCoursePlaces().size() >= MAX_COURSE_PLACES) {
+            throw new BusinessException(ErrorCode.COURSE_MAX_PLACES_EXCEEDED);
+        }
+
+        boolean isDuplicate = course.getCoursePlaces().stream()
+                .anyMatch(cp -> cp.getPlace().getId().equals(place.getId()));
+
+        if (isDuplicate) {
+            throw new BusinessException(ErrorCode.DUPLICATE_PLACE_IN_COURSE);
+        }
+
+        if (!course.getTown().getId().equals(place.getTown().getId())) {
+            throw new BusinessException(ErrorCode.DIFFERENT_TOWN_PLACE);
+        }
+    }
+
+    private int calculateNextPlaceOrder(Course course) {
+        return course.getCoursePlaces().stream()
+                .mapToInt(CoursePlace::getPlaceOrder)
+                .max()
+                .orElse(0) + 1;
+    }
+
+    /**
+     * 코스의 활성화 상태 계산
+     * - placeId가 null이면 항상 활성화
+     * - placeId가 있으면 해당 장소를 추가할 수 있는지 확인
+     */
+    private boolean calculateCourseActiveStatus(Course course, Long placeId) {
+        if (placeId == null) {
+            return true; // 장소 필터링이 없으면 모든 코스 활성화
+        }
+
+        if (course.getCoursePlaces().size() >= 6) {
+            return false;
+        }
+
+        boolean containsPlace = course.getCoursePlaces().stream()
+                .anyMatch(cp -> cp.getPlace().getId().equals(placeId));
+
+        return !containsPlace;
     }
 
     private List<Place> getPlacesByPlaceIds(CourseCreateRequest request) {

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.solply_server.domain.course.dto.*;
 import org.sopt.solply_server.domain.course.dto.request.CourseCreateRequest;
-import org.sopt.solply_server.domain.course.dto.request.PlaceAddToCourseRequest;
 import org.sopt.solply_server.domain.course.dto.response.*;
 import org.sopt.solply_server.domain.course.dto.response.CourseCreateResponse;
 import org.sopt.solply_server.domain.course.dto.response.CourseDetailGetResponse;
@@ -55,8 +54,6 @@ public class CourseService {
     private final CourseBookmarkRedisDataManager courseBookmarkRedisDataManager;
     private final CourseNameGenerator courseNameGenerator;
 
-    private static final int MAX_COURSE_PLACES = 6;
-
     /**
      * 새로운 코스 생성
      */
@@ -87,28 +84,6 @@ public class CourseService {
         }
 
         return CourseCreateResponse.from(savedCourse.getId());
-    }
-
-    /**
-     * 코스에 장소 추가
-     */
-    @Transactional
-    public void addPlaceToCourse(Long userId, Long courseId, PlaceAddToCourseRequest request) {
-        Course course = courseRepository.findByIdWithPlaces(courseId)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_COURSE));
-        validateCourseOwner(course, userId);
-        Place place = placeService.getPlaceById(request.placeId());
-        validateAddPlace(course, place);
-
-        int nextOrder = calculateNextPlaceOrder(course);
-
-        CoursePlace newCoursePlace = CoursePlace.create(course, place, nextOrder);
-        course.addCoursePlace(newCoursePlace);
-
-        courseRepository.save(course);
-
-        log.info("코스에 장소 추가 완료 - userId: {}, courseId: {}, placeId: {}, order: {}",
-                userId, courseId, request.placeId(), nextOrder);
     }
 
     /**
@@ -308,36 +283,6 @@ public class CourseService {
                         "중복된 장소가 포함되어 있습니다.");
             }
         }
-    }
-
-    private void validateCourseOwner(Course course, Long userId) {
-        if (!course.isCreatedBy(userId)) {
-            throw new BusinessException(ErrorCode.FORBIDDEN_RESOURCE);
-        }
-    }
-
-    private void validateAddPlace(Course course, Place place) {
-        if (course.getCoursePlaces().size() >= MAX_COURSE_PLACES) {
-            throw new BusinessException(ErrorCode.COURSE_MAX_PLACES_EXCEEDED);
-        }
-
-        boolean isDuplicate = course.getCoursePlaces().stream()
-                .anyMatch(cp -> cp.getPlace().getId().equals(place.getId()));
-
-        if (isDuplicate) {
-            throw new BusinessException(ErrorCode.DUPLICATE_PLACE_IN_COURSE);
-        }
-
-        if (!course.getTown().getId().equals(place.getTown().getId())) {
-            throw new BusinessException(ErrorCode.DIFFERENT_TOWN_PLACE);
-        }
-    }
-
-    private int calculateNextPlaceOrder(Course course) {
-        return course.getCoursePlaces().stream()
-                .mapToInt(CoursePlace::getPlaceOrder)
-                .max()
-                .orElse(0) + 1;
     }
 
     /**

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
@@ -137,6 +137,12 @@ public class PlaceService {
     }
 
 
+    public void validatePlaceExists(Long placeId) {
+        if (!placeRepository.existsById(placeId)) {
+            throw new EntityNotFoundException(ErrorCode.NOT_FOUND_PLACE);
+        }
+    }
+
     //=== Private Methods ===//
 
     /**


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #102 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- 사용자 북마크 코스 목록 조회 API 구현
- `townId` 필수 파라미터로 해당 동네의 북마크된 코스만 조회
- `placeId` 선택적 파라미터로 각 코스의 장소 추가 가능 상태를 `isActive`로 반환
  - 코스에 이미 6개 장소가 있으면 `isActive: false`
  - 해당 장소가 이미 코스에 포함되어 있으면 `isActive: false`


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
-

<br/>

## 🚀 알게된 점 (선택)

---

-

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 