### PR TITLE
[FIX] 유저 닉네임 중복 체크 과정에서 본인 닉네임은 중복 체크 패싱하도록 수정

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/user/controller/UserController.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/controller/UserController.java
@@ -31,13 +31,14 @@ public class UserController {
     @Operation(summary = "닉네임 중복 검사", description = "닉네임 사용 가능 여부를 확인합니다.")
     @GetMapping("/check-nickname")
     public ResponseEntity<CustomApiResponse<NicknameCheckResponse>> checkNickname(
+            @CurrentUserId Long currentUserId,
             @Parameter(description = "확인할 닉네임", required = true)
             @RequestParam("nickname")
             @NotBlank(message = "닉네임은 필수입니다")
             @Size(min = 2, max = 8, message = "닉네임은 2자 이상 8자 이하여야 합니다")
             String nickname
     ) {
-        NicknameCheckResponse response = userService.checkNickname(nickname);
+        NicknameCheckResponse response = userService.checkNickname(currentUserId, nickname);
         return CustomApiResponse.success("닉네임 중복검사에 성공했습니다", response);
     }
 

--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserOnboardingService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserOnboardingService.java
@@ -45,7 +45,7 @@ public class UserOnboardingService {
     @Transactional
     public UserOnboardingUpdateResponse updateUserFromOnboarding(Long userId, UserOnboardingUpdateRequest request) {
         User user = entityLoader.getUser(userId);
-        userValidator.validateNicknameNotDuplicated(request.nickname());
+        userValidator.validateNickname(user.getNickname(), request.nickname());
 
         return updateUserWithRetry(user, request);
     }

--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
@@ -14,6 +14,7 @@ import org.sopt.solply_server.domain.user.dto.response.UserTownGetResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserTownsUpdateResponse;
 import org.sopt.solply_server.domain.user.entity.User;
 import org.sopt.solply_server.domain.user.entity.UserInterestTown;
+import org.sopt.solply_server.global.exception.BusinessException;
 import org.sopt.solply_server.global.util.EntityLoader;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,10 +30,16 @@ public class UserService {
     private final EntityLoader entityLoader;
     private final TownValidator townValidator;
 
-    public NicknameCheckResponse checkNickname(String nickname) {
-        boolean isDuplicated = userValidator.isNicknameDuplicated(nickname);
+    public NicknameCheckResponse checkNickname(Long userId, String nickname) {
+        User user = entityLoader.getUser(userId);
+        boolean isDuplicated;
+        try {
+            userValidator.validateNickname(user.getNickname(), nickname);
+        } catch (BusinessException e) {
+            isDuplicated = true;
+        }
 
-        return NicknameCheckResponse.of(isDuplicated);
+        return NicknameCheckResponse.of(false);
     }
 
     public UserProfileGetResponse getUserProfile(Long userId) {

--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserValidator.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserValidator.java
@@ -18,13 +18,11 @@ public class UserValidator {
 
     private final UserRepository userRepository;
 
-    public boolean isNicknameDuplicated(String nickname) {
-        return userRepository.existsByNickname(nickname);
-    }
-
-    public void validateNicknameNotDuplicated(String nickname) {
-        if (isNicknameDuplicated(nickname)) {
-            log.debug("중복된 닉네임 사용 시도: nickname={}", nickname);
+    public void validateNickname(String currentNickname, String nicknameToUpdate) {
+        if (currentNickname.equals(nicknameToUpdate)) { // 현재 닉네임과 변경하려는 닉네임이 동일한 경우
+            return;
+        }
+        if (userRepository.existsByNickname(nicknameToUpdate)) {
             throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
         }
     }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #108 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- 닉네임 중복 체크는 본인 닉네임을 패싱하도록 수정했습니다.


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
-

<br/>

## 🚀 알게된 점 (선택)

---

-

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 