### PR TITLE
[FIX] 유저 정보 조회 버그 및 닉네임 중복 검사 버그 수정

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/auth/service/AuthService.java
+++ b/src/main/java/org/sopt/solply_server/domain/auth/service/AuthService.java
@@ -1,17 +1,23 @@
 package org.sopt.solply_server.domain.auth.service;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.solply_server.domain.auth.entity.SocialPlatform;
 import org.sopt.solply_server.domain.auth.dto.request.SocialLoginRequest;
 import org.sopt.solply_server.domain.auth.dto.response.SocialLoginResponse;
 import org.sopt.solply_server.domain.auth.dto.response.RefreshResponse;
 import org.sopt.solply_server.domain.auth.repository.RefreshTokenRepository;
+import org.sopt.solply_server.domain.town.entity.Town;
+import org.sopt.solply_server.domain.town.repository.TownRepository;
 import org.sopt.solply_server.domain.user.entity.User;
+import org.sopt.solply_server.domain.user.service.UserInterestTownService;
 import org.sopt.solply_server.global.exception.ErrorCode;
 import org.sopt.solply_server.global.exception.JwtTokenException;
 import org.sopt.solply_server.global.jwt.JwtTokenProvider;
 import org.sopt.solply_server.global.jwt.JwtTokenResolver;
 import org.sopt.solply_server.global.jwt.dto.TokenCollectionDto;
+import org.sopt.solply_server.global.util.EntityLoader;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,12 +30,24 @@ public class AuthService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final OAuthServiceProvider oAuthServiceProvider;
 
+    // 관심 지역 임시 처리
+    private final UserInterestTownService userInterestTownService;
+
 
     private final JwtTokenResolver jwtTokenResolver;
+    private final EntityLoader entityLoader;
 
     public SocialLoginResponse socialLogin(SocialPlatform socialPlatform, SocialLoginRequest request) {
         OAuthService oAuthService = oAuthServiceProvider.getService(socialPlatform);
         User user = oAuthService.socialLogin(request.oauthAccessToken());
+
+        Town town1 = entityLoader.getTown(Long.parseLong("2")); // 연희동
+        Town town2 = entityLoader.getTown(Long.parseLong("3")); // 망원동
+        List<Town> initialTowns = new ArrayList<>();
+        initialTowns.add(town1);
+        initialTowns.add(town2);
+
+        userInterestTownService.updateUserInterestTowns(user, initialTowns);
 
         return SocialLoginResponse.of(
                 saveTokenCollection(user.getId()),

--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
@@ -32,6 +32,9 @@ public class UserService {
         User user = entityLoader.getUser(userId);
         boolean isDuplicated = false;
         try {
+            if (user.getNickname() == null) {
+                return NicknameCheckResponse.of(isDuplicated);
+            }
             userValidator.validateNickname(user.getNickname(), nickname);
         } catch (BusinessException e) {
             isDuplicated = true;

--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
@@ -4,17 +4,16 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import lombok.RequiredArgsConstructor;
 import org.sopt.solply_server.domain.town.entity.Town;
-import org.sopt.solply_server.domain.town.util.TownValidator;
 import org.sopt.solply_server.domain.user.dto.UserTownInfoDto;
 import org.sopt.solply_server.domain.user.dto.request.UserTownsUpdateRequest;
 import org.sopt.solply_server.domain.user.dto.response.NicknameCheckResponse;
-import org.sopt.solply_server.domain.user.dto.response.UserOnboardingUpdateResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserProfileGetResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserTownGetResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserTownsUpdateResponse;
 import org.sopt.solply_server.domain.user.entity.User;
 import org.sopt.solply_server.domain.user.entity.UserInterestTown;
 import org.sopt.solply_server.global.exception.BusinessException;
+import org.sopt.solply_server.global.exception.ErrorCode;
 import org.sopt.solply_server.global.util.EntityLoader;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,7 +27,6 @@ public class UserService {
     private final UserValidator userValidator;
     private final UserInterestTownService userInterestTownService;
     private final EntityLoader entityLoader;
-    private final TownValidator townValidator;
 
     public NicknameCheckResponse checkNickname(Long userId, String nickname) {
         User user = entityLoader.getUser(userId);
@@ -44,6 +42,9 @@ public class UserService {
 
     public UserProfileGetResponse getUserProfile(Long userId) {
         User user = entityLoader.getUser(userId);
+        if (user.getSelectedTownId() == null) {
+            throw new BusinessException(ErrorCode.NOT_FOUND_USER_SELECTED_TOWN);
+        }
         Town selectedTown = entityLoader.getTown(user.getSelectedTownId());
         return UserProfileGetResponse.of(user, UserTownInfoDto.of(selectedTown.getId(), selectedTown.getName()));
     }

--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package org.sopt.solply_server.domain.user.service;
 
 import java.util.List;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import lombok.RequiredArgsConstructor;
 import org.sopt.solply_server.domain.town.entity.Town;
@@ -11,7 +12,6 @@ import org.sopt.solply_server.domain.user.dto.response.UserProfileGetResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserTownGetResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserTownsUpdateResponse;
 import org.sopt.solply_server.domain.user.entity.User;
-import org.sopt.solply_server.domain.user.entity.UserInterestTown;
 import org.sopt.solply_server.global.exception.BusinessException;
 import org.sopt.solply_server.global.exception.ErrorCode;
 import org.sopt.solply_server.global.util.EntityLoader;
@@ -70,15 +70,21 @@ public class UserService {
 
     public UserTownGetResponse getTownsRelatedUser(Long userId) {
         User user = entityLoader.getUser(userId);
-        Town selectedTown = entityLoader.getTown(user.getSelectedTownId());
-        List<UserInterestTown> interestTowns = entityLoader.getInterestTownsWithTownsByIds(userId);
 
-        return UserTownGetResponse.of(
-                UserTownInfoDto.of(selectedTown.getId(), selectedTown.getName()),
-                interestTowns.stream()
-                        .map(interestTown
-                                -> UserTownInfoDto.of(interestTown.getTown().getId(), interestTown.getTown().getName()))
-                        .toList()
-        );
+        // 선택한 동네가 없는 경우 null 처리
+        UserTownInfoDto selectedTown = Optional.ofNullable(user.getSelectedTownId())
+                .map(entityLoader::getTown)
+                .map(town -> UserTownInfoDto.of(town.getId(), town.getName()))
+                .orElse(null);
+
+        // 관심 동네들
+        List<UserTownInfoDto> interestTowns = entityLoader.getInterestTownsWithTownsByIds(userId)
+                .stream()
+                .map(interestTown -> UserTownInfoDto.of(
+                        interestTown.getTown().getId(),
+                        interestTown.getTown().getName()))
+                .toList();
+
+        return UserTownGetResponse.of(selectedTown, interestTowns);
     }
 }

--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
@@ -32,14 +32,14 @@ public class UserService {
 
     public NicknameCheckResponse checkNickname(Long userId, String nickname) {
         User user = entityLoader.getUser(userId);
-        boolean isDuplicated;
+        boolean isDuplicated = false;
         try {
             userValidator.validateNickname(user.getNickname(), nickname);
         } catch (BusinessException e) {
             isDuplicated = true;
         }
 
-        return NicknameCheckResponse.of(false);
+        return NicknameCheckResponse.of(isDuplicated);
     }
 
     public UserProfileGetResponse getUserProfile(Long userId) {

--- a/src/main/java/org/sopt/solply_server/global/exception/ErrorCode.java
+++ b/src/main/java/org/sopt/solply_server/global/exception/ErrorCode.java
@@ -71,7 +71,8 @@ public enum ErrorCode {
     NOT_FOUND_TAG(HttpStatus.NOT_FOUND, "TAG-001", "존재하지 않는 태그입니다."),
     INVALID_TAG_TYPE(HttpStatus.BAD_REQUEST, "TAG-002", "잘못된 타입의 태그입니다."),
     INVALID_TAG_RELATIONSHIP(HttpStatus.BAD_REQUEST, "TAG-004", "메인 태그와 서브 태그의 관계가 올바르지 않습니다."),
-    NOT_EMPTY_SUB_TAG(HttpStatus.BAD_REQUEST, "TAG-005", "서브 태그 값은 null 혹은 id 값으로 전송해야 합니다.");
+    NOT_EMPTY_SUB_TAG(HttpStatus.BAD_REQUEST, "TAG-005", "서브 태그 값은 null 혹은 id 값으로 전송해야 합니다."),
+    NOT_FOUND_USER_SELECTED_TOWN(HttpStatus.NOT_FOUND, "USER-006" , "유저가 선택한 동네가 없어서 온보딩을 진행해야 합니다.");
 
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #113 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- 닉네임 중복 검사가 제대로 되지 않는 부분을 수정했습니다.
- 유저 정보 조회 시 selectedTownId가 null인 경우 500에러가 발생하는 문제를 해결했습니다.


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 유저 생성시 "연희동", "망원동"을 관심지역으로 설정하도록 임시로 구현해놨습니다.

<br/>

## 🚀 알게된 점 (선택)

---

-

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 