### PR TITLE
[FIX] 온보딩 사용자 정보 업데이트 경우에 발생하는 닉네임 중복 검사 버그

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
@@ -32,9 +32,6 @@ public class UserService {
         User user = entityLoader.getUser(userId);
         boolean isDuplicated = false;
         try {
-            if (user.getNickname() == null) {
-                return NicknameCheckResponse.of(isDuplicated);
-            }
             userValidator.validateNickname(user.getNickname(), nickname);
         } catch (BusinessException e) {
             isDuplicated = true;

--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserValidator.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserValidator.java
@@ -19,7 +19,7 @@ public class UserValidator {
     private final UserRepository userRepository;
 
     public void validateNickname(String currentNickname, String nicknameToUpdate) {
-        if (currentNickname.equals(nicknameToUpdate)) { // 현재 닉네임과 변경하려는 닉네임이 동일한 경우
+        if (currentNickname.isBlank() && currentNickname.equals(nicknameToUpdate)) { // 현재 닉네임과 변경하려는 닉네임이 동일한 경우
             return;
         }
         if (userRepository.existsByNickname(nicknameToUpdate)) {


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- 닉네임이 null로 들어온 경우를 공통 메서드에서 처리하도록 수정했습니다.


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
-

<br/>

## 🚀 알게된 점 (선택)

---

-

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 