### PR TITLE
[FIX] 장소 필터링 API에서 리스트 형태의 쿼리파라미터를 받을 때 파싱이 안되는 문제 해결

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/place/controller/PlaceController.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/controller/PlaceController.java
@@ -1,6 +1,8 @@
 package org.sopt.solply_server.domain.place.controller;
 
+import com.drew.lang.annotations.NotNull;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
@@ -48,11 +50,21 @@ public class PlaceController {
         );
     }
 
-    @Operation(summary = "장소 리스트 조회", description = "동네, 장소 태그, 북마크 여부를 기반으로 장소를 필터링합니다.")
+    @Operation(
+            summary = "장소 리스트 조회",
+            description = "동네, 장소 태그, 북마크 여부를 기반으로 장소를 필터링합니다.",
+            parameters = {
+                    @Parameter(name = "townId", description = "동네 ID", required = true, example = "1"),
+                    @Parameter(name = "isBookmarkSearch", description = "북마크 검색 여부", required = true, example = "true"),
+                    @Parameter(name = "mainTagId", description = "메인 태그 ID", example = "5"),
+                    @Parameter(name = "subTagAIdList", description = "서브 태그(옵션1) ID 목록 (쉼표 구분)", example = "8,9,10"),
+                    @Parameter(name = "subTagBIdList", description = "서브 태그(옵션2) ID 목록 (쉼표 구분)", example = "11,12")
+            }
+    )
     @GetMapping
     public ResponseEntity<CustomApiResponse<PlaceFilterGetResponse>> getPlacesByTag(
             @CurrentUserId Long userId,
-            @Validated @ModelAttribute PlaceFilterGetRequest placeFilterGetRequest) {
+            @Parameter(hidden = true) @ModelAttribute @Validated PlaceFilterGetRequest placeFilterGetRequest) {
         return CustomApiResponse.success(
                 "장소 리스트 조회 성공",
                 placeService.getPlacesByTownAndTag(

--- a/src/main/java/org/sopt/solply_server/global/config/WebConfig.java
+++ b/src/main/java/org/sopt/solply_server/global/config/WebConfig.java
@@ -1,6 +1,8 @@
 package org.sopt.solply_server.global.config;
 
 import org.sopt.solply_server.global.http.SocialPlatformRequestConverter;
+import org.sopt.solply_server.global.util.StringToLongListConverter;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -10,6 +12,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new StringToLongListConverter());
         registry.addConverter(new SocialPlatformRequestConverter());
     }
 }

--- a/src/main/java/org/sopt/solply_server/global/util/StringToLongListConverter.java
+++ b/src/main/java/org/sopt/solply_server/global/util/StringToLongListConverter.java
@@ -1,4 +1,27 @@
 package org.sopt.solply_server.global.util;
 
-public class StringToLongListConverter {
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StringToLongListConverter implements Converter<String, List<Long>> {
+
+    @Override
+    public List<Long> convert(String source) {
+        if (source == null || source.trim().isEmpty()) {
+            return List.of();
+        }
+
+        try {
+            return Arrays.stream(source.split(","))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .map(Long::parseLong)
+                    .toList();
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid number format in list: " + source, e);
+        }
+    }
 }

--- a/src/main/java/org/sopt/solply_server/global/util/StringToLongListConverter.java
+++ b/src/main/java/org/sopt/solply_server/global/util/StringToLongListConverter.java
@@ -1,0 +1,4 @@
+package org.sopt.solply_server.global.util;
+
+public class StringToLongListConverter {
+}


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #124 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- Converter를 구현해서 자동 파싱되도록 수정했습니다.


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
-

<br/>

## 🚀 알게된 점 (선택)

---

-

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 