### PR TITLE
[FIX] 코스 이름 생성 시 사용자가 북마크한 코스들에 한정해서 중복 검사 수행

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/course/repository/CourseRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/repository/CourseRepository.java
@@ -111,4 +111,12 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
     @Query("DELETE FROM CoursePlace cp WHERE cp.course.id = :courseId")
     void deleteCoursePlacesByCourseId(@Param("courseId") Long courseId);
 
+    /**
+     * 특정 사용자가 북마크한 코스명들 조회 (패턴 매칭)
+     */
+    @Query("SELECT c.name FROM Course c " +
+            "WHERE c.id in :courseIds " +
+            "AND c.name LIKE :namePattern")
+    List<String> findCourseNamesByBookmarkedCourses(
+            @Param("courseIds") List<Long> courseIds, @Param("namePattern") String namePattern);
 }

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CoursePlaceService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CoursePlaceService.java
@@ -10,6 +10,7 @@ import org.sopt.solply_server.domain.course.dto.PlaceInCourseInfo;
 import org.sopt.solply_server.domain.course.entity.Course;
 import org.sopt.solply_server.domain.course.entity.CoursePlace;
 import org.sopt.solply_server.domain.course.repository.CoursePlaceRepository;
+import org.sopt.solply_server.domain.course.util.CoursePlaceValidator;
 import org.sopt.solply_server.domain.place.entity.Place;
 import org.sopt.solply_server.global.exception.BusinessException;
 import org.sopt.solply_server.global.exception.ErrorCode;
@@ -49,7 +50,6 @@ public class CoursePlaceService {
             coursePlaceRepository.save(coursePlace);
         }
     }
-
 
 
     /**

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.solply_server.domain.course.dto.*;
 import org.sopt.solply_server.domain.course.dto.request.CourseCreateRequest;
+import org.sopt.solply_server.domain.course.dto.request.CoursePlaceRequest;
 import org.sopt.solply_server.domain.course.dto.response.*;
 import org.sopt.solply_server.domain.course.dto.response.CourseCreateResponse;
 import org.sopt.solply_server.domain.course.dto.response.CourseDetailGetResponse;
@@ -69,12 +70,13 @@ public class CourseService {
         List<PlaceInCourseInfo> placeInfos = PlaceInCourseInfo.from(request.places());
 
         // 코스에 등록할 장소들
-        List<Place> places = getPlacesInOrderWithTowns(placeInfos);
+        List<Place> placesToAdd = getPlacesInOrderWithTowns(placeInfos);
 
-        coursePlaceValidator.validatePlacesForCourse(placeInfos, places);
+        // 장소를 코스에 추가할 수 있는지 검증
+        coursePlaceValidator.validatePlacesForCourse(placeInfos, placesToAdd);
 
-        String courseName = generateUniqueCourseName(request.courseName(), places.getFirst().getTown());
-        Course savedCourse = createCopiedCourse(user, courseName, request.courseDescription(), placeInfos, places);
+        String uniqueCourseName = courseNameGenerator.generateUniqueNameForUser(request.courseName(), user.getId());
+        Course savedCourse = createCopiedCourse(user, uniqueCourseName, request.courseDescription(), placeInfos, placesToAdd);
 
         return CourseCreateResponse.from(savedCourse.getId());
     }
@@ -87,23 +89,28 @@ public class CourseService {
     @Transactional
     public CourseUpdateResponse updateCourse(Long userId, Long courseId, CourseUpdateRequest request) {
         User user = entityLoader.getUser(userId);
-        Course courseToUpdate = entityLoader.getCourseWithPlaces(courseId);
+        Course originCourse = entityLoader.getCourseWithPlaces(courseId);
 
         // 코스 북마크 검증
         courseBookmarkService.checkCourseIsBookmarked(userId, courseId);
 
         List<PlaceInCourseInfo> placeInfosInCourse = PlaceInCourseInfo.from(request.places());
-        // 코스에 등록할 장소들
-        List<Place> places = getPlacesInOrderWithTowns(placeInfosInCourse);
 
-        if (courseToUpdate.isCreatedBy(userId)) { // 사용자가 소유한 코스인 경우
-            updateCourseInPlace(courseToUpdate, request, places);
+        List<Place> placesToAdd = getPlacesInOrderWithTowns(placeInfosInCourse); // 코스에 등록할 장소들
+
+        // 장소를 코스에 추가할 수 있는지 검증
+        coursePlaceValidator.validatePlacesForCourse(placeInfosInCourse, placesToAdd);
+
+        if (originCourse.isCreatedBy(userId)) { // 사용자가 소유한 코스인 경우
+            updateCourseInPlace(originCourse, request, placesToAdd);
             log.info("기존 코스 수정 완료 - userId: {}, courseId: {}", userId, courseId);
             return CourseUpdateResponse.of(courseId, request.courseName(), false);
         }
         else { // 남의 공유된 코스인 경우
+            // 기존 기본 코스 북마크 삭제
+            courseBookmarkService.deleteCourseBookmark(userId, originCourse.getId());
             Course newCourse = createCopiedCourse(
-                    user, request.courseName(), request.courseDescription(), placeInfosInCourse, places);
+                    user, request.courseName(), request.courseDescription(), placeInfosInCourse, placesToAdd);
             log.info("공유 코스 기반 새 코스 생성 및 북마크 완료 - userId: {}, newCourseId: {}", userId, newCourse.getId());
             return CourseUpdateResponse.of(newCourse.getId(), newCourse.getName(), true);
         }
@@ -116,26 +123,27 @@ public class CourseService {
     public CourseAddPlaceResponse addPlaceToCourse(final Long userId, final Long placeId, final Long courseId) {
         User user = entityLoader.getUser(userId);
         Place place = entityLoader.getPlace(placeId);
-        Course originalCourse = entityLoader.getCourseWithPlaces(courseId);
+        Course originCourse = entityLoader.getCourseWithPlaces(courseId);
 
         // 코스 북마크 검증
         courseBookmarkService.checkCourseIsBookmarked(userId, courseId);
 
-        coursePlaceValidator.validateCanAddPlace(originalCourse, place);
+        // 장소를 코스에 추가할 수 있는지 검증
+        coursePlaceValidator.validateCanAddPlace(originCourse, place);
 
         log.info("장소 코스 추가 시작 - userId: {}, placeId: {}, courseId: {}", userId, placeId, courseId);
 
         // 코스 소유권 확인
-        if (originalCourse.isCreatedBy(userId)) {
+        if (originCourse.isCreatedBy(userId)) {
             // 본인 코스에 장소 추가
-            coursePlaceService.addPlaceToMyCourse(originalCourse, place);
+            coursePlaceService.addPlaceToMyCourse(originCourse, place);
         } else {
             // 코스 복제 후 장소 추가
-            List<PlaceInCourseInfo> placesInCourse = originalCourse.getPlacesInCourseInfo();
-            List<Place> places = originalCourse.getPlaces();
+            List<PlaceInCourseInfo> placesInCourse = originCourse.getPlacesInCourseInfo();
+            List<Place> places = originCourse.getPlaces();
 
             Course copiedCourse = createCopiedCourse(
-                    user, originalCourse.getName(), originalCourse.getIntroduction(), placesInCourse, places);
+                    user, originCourse.getName(), originCourse.getIntroduction(), placesInCourse, places);
             coursePlaceService.createAndSaveCoursePlace(copiedCourse, place);
 
             courseBookmarkService.deleteCourseBookmark(userId, copiedCourse.getId());
@@ -149,9 +157,9 @@ public class CourseService {
         }
 
         return CourseAddPlaceResponse.of(
-                originalCourse,
+                originCourse,
                 place,
-                originalCourse.getPlaceCount() + 1,
+                originCourse.getPlaceCount() + 1,
                 false
         );
     }
@@ -324,8 +332,9 @@ public class CourseService {
         }
 
         // 코스 생성
+        String uniqueCourseName = courseNameGenerator.generateUniqueNameForUser(courseName, user.getId());
         Town town = placesToAdd.getFirst().getTown();
-        Course newCourse = Course.create(courseName, intro, town, user);
+        Course newCourse = Course.create(uniqueCourseName, intro, town, user);
         courseRepository.save(newCourse);
 
         // 장소들 추가
@@ -345,18 +354,6 @@ public class CourseService {
         coursePlaceValidator.validatePlacesForCourse(placeInfos, places);
 
         return places;
-    }
-
-
-    /**
-     * 중복되지 않는 코스명 생성
-     */
-    private String generateUniqueCourseName(String originalName, Town town) {
-        String namePattern = originalName + "%";
-        List<String> existingNames = courseRepository
-                .findCourseNamesByTownAndNamePattern(town.getId(), namePattern);
-
-        return courseNameGenerator.generateUniqueName(originalName, existingNames);
     }
 
     /**

--- a/src/main/java/org/sopt/solply_server/domain/course/util/CourseNameGenerator.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/util/CourseNameGenerator.java
@@ -1,76 +1,103 @@
 package org.sopt.solply_server.domain.course.util;
 
+import java.util.HashSet;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.sopt.solply_server.domain.course.dto.CourseBookmarkRedisDto;
+import org.sopt.solply_server.domain.course.dto.response.CourseBookmarkListGetResponse;
+import org.sopt.solply_server.domain.course.repository.CourseRepository;
+import org.sopt.solply_server.domain.course.service.cache.CourseBookmarkRedisDataManager;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class CourseNameGenerator {
 
+    private final CourseRepository courseRepository;
+    private final CourseBookmarkRedisDataManager courseBookmarkRedisDataManager;
+
     /**
-     * 중복되지 않는 고유한 코스명 생성
+     * 사용자별 고유한 코스명 생성
      */
-    public String generateUniqueName(String baseName, List<String> existingNames) {
-        log.debug("코스명 생성 시작 - baseName: '{}', 기존 코스명 개수: {}", baseName, existingNames.size());
+    public String generateUniqueNameForUser(String baseName, Long userId) {
+        log.debug("사용자별 코스명 생성 시작 - baseName: '{}', userId: {}", baseName, userId);
+
+        // 해당 사용자가 북마크한 것들의 코스명 리스트 조회
+        List<CourseBookmarkRedisDto> activeBookmarks = courseBookmarkRedisDataManager.getActiveCourseBookmarks(userId);
+        List<Long> courseIds = activeBookmarks.stream()
+                .map(CourseBookmarkRedisDto::courseId)
+                .toList();
+
+        List<String> existingNames =
+                courseRepository.findCourseNamesByBookmarkedCourses(courseIds, baseName + "%");
 
         if (existingNames.isEmpty()) {
             log.debug("기존 코스명이 없어 원본 이름 사용: '{}'", baseName);
             return baseName;
         }
 
-        // 중복 번호 찾기, 다음 번호 생성
-        int nextSequence = findNextSequenceNumber(baseName, existingNames);
-        String uniqueName = generateNameWithSequence(baseName, nextSequence);
+        // 중복되지 않는 이름 생성
+        String uniqueName = generateUniqueSequenceName(baseName, existingNames);
 
         log.debug("고유 코스명 생성 완료: '{}' -> '{}'", baseName, uniqueName);
         return uniqueName;
     }
 
     /**
-     * 기본 이름과 순서 번호로 코스명 생성
+     * 순번을 붙여서 고유한 이름 생성
      */
-    public String generateNameWithSequence(String baseName, int sequence) {
-        if (sequence == 0) {
+    private String generateUniqueSequenceName(String baseName, List<String> existingNames) {
+        // 기본 이름이 중복되지 않으면 그대로 반환
+        if (!existingNames.contains(baseName)) {
             return baseName;
         }
-        return String.format("%s (%d)", baseName, sequence);
+
+        // 다음 시퀀스 번호 찾기
+        int nextSequence = findNextSequenceNumber(baseName, existingNames);
+        return formatNameWithSequence(baseName, nextSequence);
     }
 
     /**
-     * 다음 사용 가능한 순서 번호 찾기
+     * 다음 시퀀스 번호 찾기
      */
     private int findNextSequenceNumber(String baseName, List<String> existingNames) {
-        // 정규식: "기본이름 (숫자)" 패턴
-        // Pattern.quote()로 특수문자 이스케이프 처리
-        Pattern pattern = Pattern.compile(Pattern.quote(baseName) + "\\s*\\((\\d+)\\)");
-        int maxNumber = -1;
+        Set<Integer> usedNumbers = new HashSet<>();
+        String basePattern = baseName + " (";
 
-        boolean baseNameExists = existingNames.contains(baseName);
-        if (baseNameExists) {
-            maxNumber = 0;
-        }
+        for (String existingName : existingNames) {
+            if (existingName.startsWith(basePattern) && existingName.endsWith(")")) {
+                // "홍대 맛집 투어 (2)" -> "2" 추출
+                String numberPart = existingName.substring(
+                        basePattern.length(),
+                        existingName.length() - 1
+                );
 
-        for (String name : existingNames) {
-            Matcher matcher = pattern.matcher(name);
-            if (matcher.matches()) {
                 try {
-                    int number = Integer.parseInt(matcher.group(1));
-                    maxNumber = Math.max(maxNumber, number);
+                    int number = Integer.parseInt(numberPart);
+                    usedNumbers.add(number);
                 } catch (NumberFormatException e) {
-                    log.warn("코스명에서 숫자 파싱 실패: '{}'", name);
+                    log.debug("숫자가 아닌 패턴 무시: '{}'", existingName);
                 }
             }
         }
 
-        int nextSequence = maxNumber + 1;
+        // 다음 사용 가능한 번호 찾기
+        int nextNumber = 2; // (1)은 사용하지 않고 (2)부터 시작
+        while (usedNumbers.contains(nextNumber)) {
+            nextNumber++;
+        }
 
-        log.debug("코스명 생성 분석 - baseName: '{}', 최대 번호: {}, 다음 번호: {}",
-                baseName, maxNumber, nextSequence);
+        return nextNumber;
+    }
 
-        return nextSequence;
+    /**
+     * 시퀀스 번호를 붙인 이름 포맷
+     */
+    private String formatNameWithSequence(String baseName, int sequence) {
+        return String.format("%s (%d)", baseName, sequence);
     }
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #130 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- 코스 이름 생성시 모든 코스들을 기반으로 중복 검사가 진행되고 있었고, 사용자가 북마크한 코스들에 한정해서 중복 검사를 수행하도록 변경했습니다.


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->

- 추가로, 코스 수정 이전엔 무조건 해당 장소들을 추가할 수 있는지 검증하도록 보완했습니다.

<br/>

## 🚀 알게된 점 (선택)

---

-

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 