### PR TITLE
[FIX] Redis-DB 동기화 및 북마크 상태 확인 버그 수정

### DIFF
--- a/src/main/java/org/sopt/solply_server/SolplyServerApplication.java
+++ b/src/main/java/org/sopt/solply_server/SolplyServerApplication.java
@@ -4,7 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 @EnableJpaAuditing
 public class SolplyServerApplication {

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseBookmarkService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseBookmarkService.java
@@ -88,10 +88,11 @@ public class CourseBookmarkService {
     public boolean isBookmarked(final Long userId, final Long courseId) {
         CourseBookmarkRedisDto bookmarkData = courseBookmarkRedisDataManager.getCourseBookmarkDto(userId, courseId);
 
-        if (bookmarkData != null && bookmarkData.isActive()) {
-            return true;
+        if (bookmarkData != null) {
+            return bookmarkData.isActive();
         }
 
+        // Redis에 데이터가 없을 때만 DB 조회
         return courseBookmarkRepository.existsByCourseIdAndUserId(courseId, userId);
     }
 

--- a/src/main/java/org/sopt/solply_server/domain/course/service/cache/CourseBookmarkFlushScheduler.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/cache/CourseBookmarkFlushScheduler.java
@@ -3,7 +3,9 @@ package org.sopt.solply_server.domain.course.service.cache;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.solply_server.global.cache.RedisFlushScheduler;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Component
@@ -17,6 +19,8 @@ public class CourseBookmarkFlushScheduler implements RedisFlushScheduler {
         return "COURSE_BOOKMARK";
     }
 
+    @Scheduled(fixedRate = 900000) // 15분 주기로 설정
+    @Transactional
     @Override
     public void executeFlush() {
         log.info("=== {} 전체 코스 북마크 플러시 시작 ===", getDomainName());

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceBookmarkService.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceBookmarkService.java
@@ -96,10 +96,11 @@ public class PlaceBookmarkService {
         String bookmarkKey = generatePlaceBookmarkKey(userId, placeId);
         BookmarkRedisDto bookmarkData = placeBookmarkRedisDataManager.getBookmarkDto(bookmarkKey);
 
-        if (bookmarkData != null && bookmarkData.isActive()) {
-            return true;
+        if (bookmarkData != null) {
+            return bookmarkData.isActive();
         }
 
+        // Redis에 데이터가 없을 때만 DB 조회
         return placeBookmarkRepository.existsByPlaceIdAndUserId(placeId, userId);
     }
 

--- a/src/main/java/org/sopt/solply_server/domain/place/service/cache/PlaceBookmarkFlushScheduler.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/cache/PlaceBookmarkFlushScheduler.java
@@ -19,7 +19,7 @@ public class PlaceBookmarkFlushScheduler implements RedisFlushScheduler {
         return "BOOKMARK";
     }
 
-    @Scheduled(fixedRate = 3600000) // 1시간마다
+    @Scheduled(fixedRate = 900000) // 15분마다
     @Transactional
     @Override
     public void executeFlush() {


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #132 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- @EnableScheduling 어노테이션이 누락되어, Redis의 북마크 변경사항을 DB로 주기적으로 flush하는 스케줄러가 동작하지 않고 있던 문제를 해결했습니다.
- Redis에서 'DELETE' 상태를 확인하더라도 DB에 아직 남아있는 데이터를 재조회하여 최종적으로 '북마크됨'으로 잘못 판단할 수 있는 구조적 문제를 해결했습니다.


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 추가적으로 수정해야할 부분이 있다면 말씀해주세요!

<br/>

## 🚀 알게된 점 (선택)

---

-

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 