### PR TITLE
[FIX] 최신 북마크 순으로 폴더썸네일/북마크된 장소/코스들을 조회해오도록 수정

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/course/controller/CourseController.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/controller/CourseController.java
@@ -96,7 +96,7 @@ public class CourseController {
             Long candidatePlaceId) {
         return CustomApiResponse.success(
                 "사용자 코스 목록 조회에 성공했습니다.",
-                courseService.getBookmarkedCourses(userId, townId, candidatePlaceId)
+                courseService.getBookmarkedCoursesByTownByLatest(userId, townId, candidatePlaceId)
         );
     }
 

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -1,6 +1,7 @@
 package org.sopt.solply_server.domain.course.service;
 
 import java.time.LocalDateTime;
+import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.solply_server.domain.course.dto.*;
@@ -298,21 +299,33 @@ public class CourseService {
         // 동네별 최신 북마크 코스 필터링
         Map<Long, CourseBookmarkRedisDto> latestBookmarkByTown = getLatestBookmarkByTown(activeBookmarks);
 
-        // 코스 정보와 장소 정보 배치 조회
-        List<Long> courseIds = latestBookmarkByTown.values().stream()
+        // 북마크 시간 기준으로 정렬된 코스 ID 리스트 생성
+        List<Long> sortedCourseIds = latestBookmarkByTown.values().stream()
+                .sorted((dto1, dto2)
+                        -> dto2.createdAt().compareTo(dto1.createdAt()))
                 .map(CourseBookmarkRedisDto::courseId)
                 .toList();
 
-        List<Course> courses = courseRepository.findBookmarkedCoursesWithPlacesByIds(courseIds);
+        // 코스 정보와 장소 정보 배치 조회
+        List<Course> notSortedCourseList = courseRepository.findBookmarkedCoursesWithPlacesByIds(sortedCourseIds);
 
-        if (courses.isEmpty()) {
+        if (notSortedCourseList.isEmpty()) {
             return CourseFolderPreviewListGetResponse.from(List.of());
         }
 
-        courseRepository.findPlacesWithTagsByCourseIds(courseIds);
+        courseRepository.findPlacesWithTagsByCourseIds(sortedCourseIds);
 
-        // DTO 변환
-        List<CourseFolderDto> folderDtos = courses.stream()
+        // 코스들을 정렬된 순서대로 재배열
+        Map<Long, Course> courseMap = notSortedCourseList.stream()
+                .collect(Collectors.toMap(Course::getId, Function.identity()));
+
+        List<Course> sortedCourses = sortedCourseIds.stream()
+                .map(courseMap::get)
+                .filter(Objects::nonNull)
+                .toList();
+
+        // DTO 변환 (이미 정렬된 순서)
+        List<CourseFolderDto> folderDtos = sortedCourses.stream()
                 .map(course -> {
                     List<TagName> primaryTags = courseUtils.extractTopTwoPlaceMainTags(course);
                     String thumbnailUrl = courseUtils.getCourseThumbnailUrl(course);
@@ -322,7 +335,6 @@ public class CourseService {
 
         return CourseFolderPreviewListGetResponse.from(folderDtos);
     }
-
 
 
     //=== private method ===//

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -1,5 +1,6 @@
 package org.sopt.solply_server.domain.course.service;
 
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.solply_server.domain.course.dto.*;
@@ -233,6 +234,12 @@ public class CourseService {
             return CourseBookmarkListGetResponse.from(List.of());
         }
 
+        Map<Long, LocalDateTime> courseIdCreatedAtMap = activeBookmarks.stream()
+                .collect(Collectors.toMap(
+                        CourseBookmarkRedisDto::courseId,
+                        CourseBookmarkRedisDto::createdAt
+                ));
+
         List<Long> courseIds = activeBookmarks.stream()
                 .map(CourseBookmarkRedisDto::courseId)
                 .toList();
@@ -259,6 +266,13 @@ public class CourseService {
         // DTO 변환
         List<CourseInfoDto> courseInfoDtos = filteredCourses.stream()
                 .map(course -> createCourseInfoDto(course, validationResults, checkCanAddPlaceToCourse))
+                .sorted( // 최신 순으로 정렬
+                        (dto1, dto2) -> {
+                            LocalDateTime createdAt1 = courseIdCreatedAtMap.get(dto1.courseId());
+                            LocalDateTime createdAt2 = courseIdCreatedAtMap.get(dto2.courseId());
+                            return createdAt2.compareTo(createdAt1);
+                        }
+                )
                 .toList();
 
         log.info("북마크 코스 {}개 조회 완료", courseInfoDtos.size());

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.solply_server.domain.course.dto.*;
 import org.sopt.solply_server.domain.course.dto.request.CourseCreateRequest;
-import org.sopt.solply_server.domain.course.dto.request.CoursePlaceRequest;
 import org.sopt.solply_server.domain.course.dto.response.*;
 import org.sopt.solply_server.domain.course.dto.response.CourseCreateResponse;
 import org.sopt.solply_server.domain.course.dto.response.CourseDetailGetResponse;
@@ -147,7 +146,9 @@ public class CourseService {
                     user, originCourse.getName(), originCourse.getIntroduction(), placesInCourse, places);
             coursePlaceService.createAndSaveCoursePlace(copiedCourse, place);
 
+            // 기존 코스 북마크 삭제 후 새 코스 북마크 등록
             courseBookmarkService.deleteCourseBookmark(userId, copiedCourse.getId());
+            courseBookmarkService.createCourseBookmark(userId, copiedCourse.getId());
 
             return CourseAddPlaceResponse.of(
                     copiedCourse,
@@ -215,7 +216,7 @@ public class CourseService {
     /**
      * 사용자가 북마크한 코스 목록 조회 (동네 기준 필터링 + 장소 추가 가능 여부)
      */
-    public CourseBookmarkListGetResponse getBookmarkedCourses(final Long userId, final Long townId, final Long placeId) {
+    public CourseBookmarkListGetResponse getBookmarkedCoursesByTownByLatest(final Long userId, final Long townId, final Long placeId) {
         townValidator.validateTownId(townId);
 
         // placeId가 있는 경우에만 장소 조회 및 검증
@@ -234,6 +235,7 @@ public class CourseService {
             return CourseBookmarkListGetResponse.from(List.of());
         }
 
+        // 코스 ID와 북마크 저장 시간을 매핑하여 저장
         Map<Long, LocalDateTime> courseIdCreatedAtMap = activeBookmarks.stream()
                 .collect(Collectors.toMap(
                         CourseBookmarkRedisDto::courseId,

--- a/src/main/java/org/sopt/solply_server/domain/course/util/CoursePlaceValidator.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/util/CoursePlaceValidator.java
@@ -32,7 +32,7 @@ public class CoursePlaceValidator {
             return CourseValidationResult.placeCountLimited();
         }
 
-        log.info("Place {} can be added to Course {}", place.getId(), course.getId());
+        log.info("장소(id:{})는 코스(id:{})에 추가될 수 있습니다.", place.getId(), course.getId());
 
         return CourseValidationResult.success();
     }

--- a/src/main/java/org/sopt/solply_server/domain/place/dto/PlaceBookmarkRedisDto.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/dto/PlaceBookmarkRedisDto.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
         include = JsonTypeInfo.As.PROPERTY,
         property = "@class"
 )
-public record BookmarkRedisDto(
+public record PlaceBookmarkRedisDto(
         Long userId,
         Long placeId,
         LocalDateTime createdAt,
@@ -34,18 +34,18 @@ public record BookmarkRedisDto(
     /**
      * 활성 북마크 생성
      */
-    public static BookmarkRedisDto createActive(Long userId, Long placeId) {
-        return new BookmarkRedisDto(userId, placeId, LocalDateTime.now(), BookmarkStatus.ACTIVE);
+    public static PlaceBookmarkRedisDto createActive(Long userId, Long placeId) {
+        return new PlaceBookmarkRedisDto(userId, placeId, LocalDateTime.now(), BookmarkStatus.ACTIVE);
     }
 
     /**
      * 삭제 마커 생성
      */
-    public static BookmarkRedisDto createDeleted(Long userId, Long placeId) {
-        return new BookmarkRedisDto(userId, placeId, LocalDateTime.now(), BookmarkStatus.DELETED);
+    public static PlaceBookmarkRedisDto createDeleted(Long userId, Long placeId) {
+        return new PlaceBookmarkRedisDto(userId, placeId, LocalDateTime.now(), BookmarkStatus.DELETED);
     }
 
-    public static BookmarkRedisDto of(Long userId, Long placeId) {
+    public static PlaceBookmarkRedisDto of(Long userId, Long placeId) {
         return createActive(userId, placeId);
     }
 }

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceBookmarkService.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceBookmarkService.java
@@ -4,7 +4,7 @@ import static org.sopt.solply_server.global.cache.RedisKeyGenerator.generatePlac
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.sopt.solply_server.domain.place.dto.BookmarkRedisDto;
+import org.sopt.solply_server.domain.place.dto.PlaceBookmarkRedisDto;
 import org.sopt.solply_server.domain.place.entity.Place;
 import org.sopt.solply_server.domain.place.entity.PlaceBookmark;
 import org.sopt.solply_server.domain.place.repository.PlaceBookmarkRepository;
@@ -14,8 +14,6 @@ import org.sopt.solply_server.domain.user.entity.User;
 import org.sopt.solply_server.domain.user.repository.UserRepository;
 import org.sopt.solply_server.global.cache.CacheService;
 import org.sopt.solply_server.global.cache.RedisKeyGenerator;
-import org.sopt.solply_server.global.exception.EntityNotFoundException;
-import org.sopt.solply_server.global.exception.ErrorCode;
 import org.sopt.solply_server.global.util.EntityLoader;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -49,7 +47,7 @@ public class PlaceBookmarkService {
 
         try {
             // 북마크 DTO 생성 (Record의 정적 팩토리 메서드 사용)
-            BookmarkRedisDto bookmarkData = BookmarkRedisDto.createActive(userId, placeId);
+            PlaceBookmarkRedisDto bookmarkData = PlaceBookmarkRedisDto.createActive(userId, placeId);
 
             // 개별 북마크 정보 저장 (TTL 1시간)
             cacheService.set(bookmarkKey, bookmarkData);
@@ -71,7 +69,7 @@ public class PlaceBookmarkService {
     public void deletePlaceBookmark(final Long userId, final Long placeId) {
         String bookmarkKey = RedisKeyGenerator.generatePlaceBookmarkKey(userId, placeId);
 
-        BookmarkRedisDto deleteMarker = BookmarkRedisDto.createDeleted(userId, placeId);
+        PlaceBookmarkRedisDto deleteMarker = PlaceBookmarkRedisDto.createDeleted(userId, placeId);
         cacheService.set(bookmarkKey, deleteMarker);
 
         log.info("장소 북마크 삭제 마커 설정 완료 - userId: {}, placeId: {}", userId, placeId);
@@ -94,7 +92,7 @@ public class PlaceBookmarkService {
      */
     public boolean isBookmarked(final Long userId, final Long placeId) {
         String bookmarkKey = generatePlaceBookmarkKey(userId, placeId);
-        BookmarkRedisDto bookmarkData = placeBookmarkRedisDataManager.getBookmarkDto(bookmarkKey);
+        PlaceBookmarkRedisDto bookmarkData = placeBookmarkRedisDataManager.getBookmarkDto(bookmarkKey);
 
         if (bookmarkData != null) {
             return bookmarkData.isActive();

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
@@ -157,24 +157,15 @@ public class PlaceService {
             validateTagConditions(mainTagId, subTagAIdList, subTagBIdList);
         }
 
-        List<Long> bookmarkedPlaceIds = null;
         if (isOnlyBookmarkSearch) {
-            bookmarkedPlaceIds = placeBookmarkRedisDataManager.getActivePlaceBookmarkDtos(userId).stream()
-                    .map(PlaceBookmarkRedisDto::placeId)
-                    .collect(Collectors.toList());
-            log.info("북마크된 장소 ID 목록 조회 완료: {} 개", bookmarkedPlaceIds.size());
+            return getBookmarkedPlacesByLatest(userId, selectedTownId, mainTagId, subTagAIdList, subTagBIdList);
         }
 
         // 통합 조회
         List<Place> places = placeRepository.findPlacesByConditions(
-                PlaceSearchConditionDto.of(
-                    selectedTownId,
-                    isOnlyBookmarkSearch,
-                    bookmarkedPlaceIds,
-                    mainTagId,
-                    subTagAIdList,
-                    subTagBIdList)
+                PlaceSearchConditionDto.of(selectedTownId, false, null, mainTagId, subTagAIdList, subTagBIdList)
         );
+
 
         log.info("장소 조회 완료 - townId: {}, isOnlyBookmarkSearch: {}, mainTagId: {}, 결과: {} 개",
                 selectedTownId, isOnlyBookmarkSearch, mainTagId, places.size());
@@ -211,14 +202,7 @@ public class PlaceService {
         }
 
         // Place 정보 조회 및 매핑
-        List<Long> placeIds = activePlaceBookmarkRedisDtos.stream()
-                .map(PlaceBookmarkRedisDto::placeId)
-                .distinct() // 중복 제거 추가
-                .collect(Collectors.toList());
-
-        Map<Long, Place> placeMap = placeRepository.findAllByIdsWithTown(placeIds)
-                .stream()
-                .collect(Collectors.toMap(Place::getId, Function.identity()));
+        Map<Long, Place> placeMap = getPlaceMapFromBookmarks(activePlaceBookmarkRedisDtos);
 
         // 동네별 최신 북마크한 장소 추출 (createdAt 기준)
         // key: townId, value: PlaceBookmarkRedisDto
@@ -235,6 +219,52 @@ public class PlaceService {
         return latestBookmarkedPlaceByTown.values().stream()
                 .map(dto -> placeMap.get(dto.placeId()))
                 .collect(Collectors.toList());
+    }
+
+    private List<Place> getBookmarkedPlacesByLatest(final Long userId, final Long selectedTownId,
+            final Long mainTagId, final List<Long> subTagAIdList, final List<Long> subTagBIdList) {
+
+        List<PlaceBookmarkRedisDto> bookmarkDtos = placeBookmarkRedisDataManager.getActivePlaceBookmarkDtos(userId);
+
+        if (bookmarkDtos.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> bookmarkedPlaceIds = bookmarkDtos.stream()
+                .map(PlaceBookmarkRedisDto::placeId)
+                .collect(Collectors.toList());
+
+        Map<Long, LocalDateTime> placeIdToCreatedAtMap = bookmarkDtos.stream()
+                .collect(Collectors.toMap(
+                        PlaceBookmarkRedisDto::placeId,
+                        PlaceBookmarkRedisDto::createdAt,
+                        (existing, replacement) -> existing.isAfter(replacement) ? existing : replacement
+                ));
+
+        // 태그 조건 포함하여 조회
+        List<Place> places = placeRepository.findPlacesByConditions(
+                PlaceSearchConditionDto.of(selectedTownId, true, bookmarkedPlaceIds, mainTagId, subTagAIdList, subTagBIdList)
+        );
+
+        // 북마크 시간 기준 최신순 정렬
+        return places.stream()
+                .sorted((place1, place2) -> {
+                    LocalDateTime createdAt1 = placeIdToCreatedAtMap.get(place1.getId());
+                    LocalDateTime createdAt2 = placeIdToCreatedAtMap.get(place2.getId());
+                    return createdAt2.compareTo(createdAt1);
+                })
+                .collect(Collectors.toList());
+    }
+
+    private Map<Long, Place> getPlaceMapFromBookmarks(List<PlaceBookmarkRedisDto> bookmarkDtos) {
+        List<Long> placeIds = bookmarkDtos.stream()
+                .map(PlaceBookmarkRedisDto::placeId)
+                .distinct()
+                .collect(Collectors.toList());
+
+        return placeRepository.findAllByIdsWithTown(placeIds)
+                .stream()
+                .collect(Collectors.toMap(Place::getId, Function.identity()));
     }
 
 }

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
@@ -102,7 +102,7 @@ public class PlaceService {
         List<PlaceBookmarkRedisDto> placeBookmarkList = placeBookmarkRedisDataManager.getActivePlaceBookmarkDtos(userId);
 
         // 동네별로 가장 최근에 북마크 한 장소 가져오기
-        List<Place> recentPlacesByTown = getBookmarkedPlaceListByTownByLatest(placeBookmarkList);
+        List<Place> recentPlacesByTown = getBookmarkedPlacePreviewListByTownByLatest(placeBookmarkList);
 
         return PlaceFolderPreviewListGetResponse.from(
                 recentPlacesByTown.stream()
@@ -196,7 +196,8 @@ public class PlaceService {
     /**
      * Redis 북마크 데이터를 기반으로 동네별 최신 북마크 장소를 필터링
      */
-    private List<Place> getBookmarkedPlaceListByTownByLatest(final List<PlaceBookmarkRedisDto> activePlaceBookmarkRedisDtos) {
+    private List<Place> getBookmarkedPlacePreviewListByTownByLatest(
+            final List<PlaceBookmarkRedisDto> activePlaceBookmarkRedisDtos) {
         if (activePlaceBookmarkRedisDtos.isEmpty()) {
             return List.of();
         }

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
@@ -215,6 +215,8 @@ public class PlaceService {
                 .map(BookmarkRedisDto::placeId)
                 .collect(Collectors.toList());
 
+        //
+
         Map<Long, Place> placeMap = placeRepository.findAllByIdsWithTown(placeIds)
                 .stream()
                 .collect(Collectors.toMap(Place::getId, place -> place));

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
@@ -1,5 +1,6 @@
 package org.sopt.solply_server.domain.place.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -7,8 +8,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.sopt.solply_server.domain.course.dto.PlaceInCourseInfo;
-import org.sopt.solply_server.domain.place.dto.BookmarkRedisDto;
+import org.sopt.solply_server.domain.place.dto.PlaceBookmarkRedisDto;
 import org.sopt.solply_server.domain.place.dto.PlaceFolderPreviewDto;
 import org.sopt.solply_server.domain.place.dto.PlaceImageInfoDto;
 import org.sopt.solply_server.domain.place.dto.PlaceSearchConditionDto;
@@ -99,10 +99,10 @@ public class PlaceService {
      */
     public PlaceFolderPreviewListGetResponse getBookmarkedPlaceFolderPreviewList(Long userId) {
         // Redis에서 활성화된 북마크 장소(가장 최근에 북마크한 장소들) ID 목록 가져오기
-        List<BookmarkRedisDto> placeBookmarkList = placeBookmarkRedisDataManager.getActivePlaceBookmarkDtos(userId);
+        List<PlaceBookmarkRedisDto> placeBookmarkList = placeBookmarkRedisDataManager.getActivePlaceBookmarkDtos(userId);
 
         // 동네별로 가장 최근에 북마크 한 장소 가져오기
-        List<Place> recentPlacesByTown = getLatestPlaceListByTown(placeBookmarkList);
+        List<Place> recentPlacesByTown = getBookmarkedPlaceListByTownByLatest(placeBookmarkList);
 
         return PlaceFolderPreviewListGetResponse.from(
                 recentPlacesByTown.stream()
@@ -151,16 +151,16 @@ public class PlaceService {
     /**
      * 장소 조회 조건에 따라 장소를 조회하는 메서드
      */
-    private List<Place> getPlacesByCondition(final Long userId, final Long selectedTownId, final boolean isBookmarkSearch,
+    private List<Place> getPlacesByCondition(final Long userId, final Long selectedTownId, final boolean isOnlyBookmarkSearch,
             final Long mainTagId, final List<Long> subTagAIdList, final List<Long> subTagBIdList) {
         if (mainTagId != null) {
             validateTagConditions(mainTagId, subTagAIdList, subTagBIdList);
         }
 
         List<Long> bookmarkedPlaceIds = null;
-        if (isBookmarkSearch) {
+        if (isOnlyBookmarkSearch) {
             bookmarkedPlaceIds = placeBookmarkRedisDataManager.getActivePlaceBookmarkDtos(userId).stream()
-                    .map(BookmarkRedisDto::placeId)
+                    .map(PlaceBookmarkRedisDto::placeId)
                     .collect(Collectors.toList());
             log.info("북마크된 장소 ID 목록 조회 완료: {} 개", bookmarkedPlaceIds.size());
         }
@@ -169,15 +169,15 @@ public class PlaceService {
         List<Place> places = placeRepository.findPlacesByConditions(
                 PlaceSearchConditionDto.of(
                     selectedTownId,
-                    isBookmarkSearch,
+                    isOnlyBookmarkSearch,
                     bookmarkedPlaceIds,
                     mainTagId,
                     subTagAIdList,
                     subTagBIdList)
         );
 
-        log.info("장소 조회 완료 - townId: {}, isBookmarkSearch: {}, mainTagId: {}, 결과: {} 개",
-                selectedTownId, isBookmarkSearch, mainTagId, places.size());
+        log.info("장소 조회 완료 - townId: {}, isOnlyBookmarkSearch: {}, mainTagId: {}, 결과: {} 개",
+                selectedTownId, isOnlyBookmarkSearch, mainTagId, places.size());
 
         return places;
     }
@@ -205,31 +205,33 @@ public class PlaceService {
     /**
      * Redis 북마크 데이터를 기반으로 동네별 최신 북마크 장소를 필터링
      */
-    private List<Place> getLatestPlaceListByTown(final List<BookmarkRedisDto> bookmarkRedisDtos) {
-        if (bookmarkRedisDtos.isEmpty()) {
+    private List<Place> getBookmarkedPlaceListByTownByLatest(final List<PlaceBookmarkRedisDto> activePlaceBookmarkRedisDtos) {
+        if (activePlaceBookmarkRedisDtos.isEmpty()) {
             return List.of();
         }
 
         // Place 정보 조회 및 매핑
-        List<Long> placeIds = bookmarkRedisDtos.stream()
-                .map(BookmarkRedisDto::placeId)
+        List<Long> placeIds = activePlaceBookmarkRedisDtos.stream()
+                .map(PlaceBookmarkRedisDto::placeId)
+                .distinct() // 중복 제거 추가
                 .collect(Collectors.toList());
-
-        //
 
         Map<Long, Place> placeMap = placeRepository.findAllByIdsWithTown(placeIds)
                 .stream()
-                .collect(Collectors.toMap(Place::getId, place -> place));
+                .collect(Collectors.toMap(Place::getId, Function.identity()));
 
-        Map<Long, BookmarkRedisDto> latestBookmarkedPlaceByTown = bookmarkRedisDtos.stream()
+        // 동네별 최신 북마크한 장소 추출 (createdAt 기준)
+        // key: townId, value: PlaceBookmarkRedisDto
+        Map<Long, PlaceBookmarkRedisDto> latestBookmarkedPlaceByTown = activePlaceBookmarkRedisDtos.stream()
                 .filter(dto -> placeMap.containsKey(dto.placeId()))
                 .collect(Collectors.toMap(
-                        dto -> placeMap.get(dto.placeId()).getTown().getId(), // townId
-                        dto -> dto,
+                        dto -> placeMap.get(dto.placeId()).getTown().getId(), // townId를 key로
+                        dto -> dto, // PlaceBookmarkRedisDto를 value로
                         (existing, replacement) ->
                                 replacement.createdAt().isAfter(existing.createdAt()) ? replacement : existing
                 ));
 
+        // Place 객체로 변환하여 반환
         return latestBookmarkedPlaceByTown.values().stream()
                 .map(dto -> placeMap.get(dto.placeId()))
                 .collect(Collectors.toList());

--- a/src/main/java/org/sopt/solply_server/domain/place/service/cache/PlaceBookmarkRedisDataManager.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/cache/PlaceBookmarkRedisDataManager.java
@@ -71,16 +71,16 @@ public class PlaceBookmarkRedisDataManager implements RedisDataManager {
         Set<String> keys = cacheService.findKeys(getKeyPattern());
 
         if (keys.isEmpty()) {
-            log.debug("플러시할 북마크 데이터 없음");
+            log.debug("플러시할 장소 북마크 데이터 없음");
         }
 
-        log.info("북마크 플러시 대상: {}개", keys.size());
+        log.info("장소 북마크 플러시 대상: {}개", keys.size());
 
         for (String key : keys) {
             try {
                 flushToDatabase(key);
             } catch (Exception e) {
-                log.error("북마크 개별 키 처리 실패 - key: {}", key, e);
+                log.error("장소 북마크 개별 키 처리 실패 - key: {}", key, e);
             }
         }
     }
@@ -92,7 +92,7 @@ public class PlaceBookmarkRedisDataManager implements RedisDataManager {
         try {
             return cacheService.get(bookmarkKey, PlaceBookmarkRedisDto.class);
         } catch (Exception e) {
-            log.warn("북마크 DTO 조회 실패 - key: {}", bookmarkKey, e);
+            log.warn("장소 북마크 DTO 조회 실패 - key: {}", bookmarkKey, e);
             return null;
         }
     }
@@ -116,12 +116,12 @@ public class PlaceBookmarkRedisDataManager implements RedisDataManager {
                 }
             }
 
-            log.info("패턴 스캔으로 활성 북마크 조회 - userId: {}, 활성 북마크 {}개",
+            log.info("패턴 스캔으로 활성 장소 북마크 조회 - userId: {}, 활성 북마크 {}개",
                     userId, activeBookmarkDtos.size());
 
             return activeBookmarkDtos;
         } catch (Exception e) {
-            log.error("Redis에서 북마크 조회 실패 - userId: {}", userId, e);
+            log.error("Redis에서 장소 북마크 조회 실패 - userId: {}", userId, e);
             return new ArrayList<>();
         }
     }
@@ -140,7 +140,7 @@ public class PlaceBookmarkRedisDataManager implements RedisDataManager {
             PlaceBookmark bookmark = PlaceBookmark.create(place, user);
             placeBookmarkRepository.save(bookmark);
 
-            log.debug("활성 북마크 DB 저장 완료 - userId: {}, placeId: {}",
+            log.debug("활성 장소 북마크 DB 저장 완료 - userId: {}, placeId: {}",
                     bookmarkData.userId(), bookmarkData.placeId());
 
         } catch (DataIntegrityViolationException e) {

--- a/src/main/java/org/sopt/solply_server/domain/place/service/cache/PlaceBookmarkRedisDataManager.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/cache/PlaceBookmarkRedisDataManager.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.sopt.solply_server.domain.place.dto.BookmarkRedisDto;
+import org.sopt.solply_server.domain.place.dto.PlaceBookmarkRedisDto;
 import org.sopt.solply_server.domain.place.entity.Place;
 import org.sopt.solply_server.domain.place.entity.PlaceBookmark;
 import org.sopt.solply_server.domain.place.repository.PlaceBookmarkRepository;
@@ -51,7 +51,7 @@ public class PlaceBookmarkRedisDataManager implements RedisDataManager {
         }
 
         // Redis에서 북마크 데이터 조회
-        BookmarkRedisDto bookmarkData = cacheService.get(bookmarkKey, BookmarkRedisDto.class);
+        PlaceBookmarkRedisDto bookmarkData = cacheService.get(bookmarkKey, PlaceBookmarkRedisDto.class);
 
         if (bookmarkData == null) {
             log.warn("북마크 데이터가 Redis에 없음 - key: {}", bookmarkKey);
@@ -88,9 +88,9 @@ public class PlaceBookmarkRedisDataManager implements RedisDataManager {
     /**
      * 북마크 키로부터 BookmarkRedisDto를 조회하는 메서드
      */
-    public BookmarkRedisDto getBookmarkDto(String bookmarkKey) {
+    public PlaceBookmarkRedisDto getBookmarkDto(String bookmarkKey) {
         try {
-            return cacheService.get(bookmarkKey, BookmarkRedisDto.class);
+            return cacheService.get(bookmarkKey, PlaceBookmarkRedisDto.class);
         } catch (Exception e) {
             log.warn("북마크 DTO 조회 실패 - key: {}", bookmarkKey, e);
             return null;
@@ -101,16 +101,16 @@ public class PlaceBookmarkRedisDataManager implements RedisDataManager {
     /**
      * 활성 북마크의 전체 정보(DTO)를 반환하는 메서드
      */
-    public List<BookmarkRedisDto> getActivePlaceBookmarkDtos(Long userId) {
+    public List<PlaceBookmarkRedisDto> getActivePlaceBookmarkDtos(Long userId) {
         try {
             // 사용자의 모든 북마크 키 스캔
             String userBookmarkPattern = String.format("%s:%d:*",
                     CachePrefix.PLACE_BOOKMARK.getPrefix(), userId);
             Set<String> userBookmarkKeys = cacheService.findKeys(userBookmarkPattern);
 
-            List<BookmarkRedisDto> activeBookmarkDtos = new ArrayList<>();
+            List<PlaceBookmarkRedisDto> activeBookmarkDtos = new ArrayList<>();
             for (String bookmarkKey : userBookmarkKeys) {
-                BookmarkRedisDto bookmarkDto = cacheService.get(bookmarkKey, BookmarkRedisDto.class);
+                PlaceBookmarkRedisDto bookmarkDto = cacheService.get(bookmarkKey, PlaceBookmarkRedisDto.class);
                 if (bookmarkDto != null && bookmarkDto.isActive()) {
                     activeBookmarkDtos.add(bookmarkDto);
                 }
@@ -130,7 +130,7 @@ public class PlaceBookmarkRedisDataManager implements RedisDataManager {
     /**
      * 활성 북마크 처리
      */
-    private void saveActiveBookmark(BookmarkRedisDto bookmarkData) {
+    private void saveActiveBookmark(PlaceBookmarkRedisDto bookmarkData) {
         try {
             User user = userRepository.findById(bookmarkData.userId())
                     .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_USER));
@@ -152,7 +152,7 @@ public class PlaceBookmarkRedisDataManager implements RedisDataManager {
     /**
      * 삭제 마커 처리
      */
-    private void deleteBookmark(String bookmarkKey, BookmarkRedisDto bookmarkData) {
+    private void deleteBookmark(String bookmarkKey, PlaceBookmarkRedisDto bookmarkData) {
         // DB에서 삭제 (존재하지 않아도 에러 발생하지 않음)
         placeBookmarkRepository.deleteByUserIdAndPlaceId(bookmarkData.userId(), bookmarkData.placeId());
 


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #135 
close #136 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->


- 최신 순으로 폴더썸네일/북마크된 장소들을 조회해오도록 수정
- 코스 폴더 프리뷰 조회 시 가장 최신에 북마크 한 코스를 프리뷰로 띄우도록 수정

<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->

- 장소 추가한 새로운 코스를 북마크로 등록하는 로직도 빠져있어서 추가했습니다.

- "코스 북마크 폴더 프리뷰 조회"하는 경우 영경이가 말한 방식(redis에서 들고온 id를 정렬하고, 정렬한 순서에 따라 추후에 재정렬하는 방식)으로만 가능해보이더라구요!

<br/>

## 🚀 알게된 점 (선택)

---

-

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 