### PR TITLE
#139 fix: 기존 코스 삭제 시 코스 이름을 그대로 사용하도록 수정

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -78,7 +78,7 @@ public class CourseService {
 
         String uniqueCourseName = courseNameGenerator.generateUniqueNameForUser(request.courseName(), user.getId());
         Course savedCourse = createCopiedCourse(
-                user, uniqueCourseName, request.courseDescription(), placeInfos, placesToAdd);
+                user, uniqueCourseName, request.courseDescription(), placeInfos, placesToAdd, false);
 
         return CourseCreateResponse.from(savedCourse.getId());
     }
@@ -109,9 +109,9 @@ public class CourseService {
             return CourseUpdateResponse.of(courseId, request.courseName(), false);
         }
         else { // 남의 공유된 코스인 경우
-            // 복제 + 수정 후 기존 기본 코스 북마크 삭제
+            // 기존 코스 북마크 삭제 후 새 코스 북마크 등록
             Course copiedCourses = createCopiedCourse(
-                    user, request.courseName(), request.courseDescription(), placeInfosInCourse, placesToAdd);
+                    user, request.courseName(), request.courseDescription(), placeInfosInCourse, placesToAdd, true);
             courseBookmarkService.deleteCourseBookmark(userId, originCourse.getId());
             log.info("공유 코스 기반 새 코스 생성 및 북마크 완료 - userId: {}, newCourseId: {}", userId, copiedCourses.getId());
             return CourseUpdateResponse.of(copiedCourses.getId(), copiedCourses.getName(), true);
@@ -146,7 +146,7 @@ public class CourseService {
 
             // 기존 코스 북마크 삭제 후 새 코스 북마크 등록
             Course copiedCourse = createCopiedCourse(
-                    user, originCourse.getName(), originCourse.getIntroduction(), placesInCourse, places);
+                    user, originCourse.getName(), originCourse.getIntroduction(), placesInCourse, places, true);
             courseBookmarkService.deleteCourseBookmark(userId, originCourse.getId());
 
             coursePlaceService.createAndSaveCoursePlace(copiedCourse, place);
@@ -354,13 +354,16 @@ public class CourseService {
      * 사용자 소유의 새로운 코스 생성
      */
     private Course createCopiedCourse(User user, String courseName, String intro,
-            List<PlaceInCourseInfo> placeInfos, List<Place> placesToAdd) {
+            List<PlaceInCourseInfo> placeInfos, List<Place> placesToAdd, Boolean isReplaced) {
         if (placesToAdd.isEmpty()) {
             throw new BusinessException(ErrorCode.NOT_SUFFICIENT_PLACE_COUNT);
         }
 
         // 코스 생성
-        String uniqueCourseName = courseNameGenerator.generateUniqueNameForUser(courseName, user.getId());
+        String uniqueCourseName = courseName;
+        if (!isReplaced) {
+           uniqueCourseName = courseNameGenerator.generateUniqueNameForUser(courseName, user.getId());
+        }
         Town town = placesToAdd.getFirst().getTown();
         Course newCourse = Course.create(uniqueCourseName, intro, town, user);
         courseRepository.save(newCourse);

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -76,9 +76,8 @@ public class CourseService {
         // 장소를 코스에 추가할 수 있는지 검증
         coursePlaceValidator.validatePlacesForCourse(placeInfos, placesToAdd);
 
-        String uniqueCourseName = courseNameGenerator.generateUniqueNameForUser(request.courseName(), user.getId());
-        Course savedCourse = createCopiedCourse(
-                user, uniqueCourseName, request.courseDescription(), placeInfos, placesToAdd, false);
+        Course savedCourse = createNewCourse(
+                user, request.courseName(), request.courseDescription(), placeInfos, placesToAdd);
 
         return CourseCreateResponse.from(savedCourse.getId());
     }
@@ -110,9 +109,9 @@ public class CourseService {
         }
         else { // 남의 공유된 코스인 경우
             // 기존 코스 북마크 삭제 후 새 코스 북마크 등록
-            Course copiedCourses = createCopiedCourse(
-                    user, request.courseName(), request.courseDescription(), placeInfosInCourse, placesToAdd, true);
             courseBookmarkService.deleteCourseBookmark(userId, originCourse.getId());
+            Course copiedCourses = createNewCourse(
+                    user, request.courseName(), request.courseDescription(), placeInfosInCourse, placesToAdd);
             log.info("공유 코스 기반 새 코스 생성 및 북마크 완료 - userId: {}, newCourseId: {}", userId, copiedCourses.getId());
             return CourseUpdateResponse.of(copiedCourses.getId(), copiedCourses.getName(), true);
         }
@@ -145,10 +144,9 @@ public class CourseService {
             List<Place> places = originCourse.getPlaces();
 
             // 기존 코스 북마크 삭제 후 새 코스 북마크 등록
-            Course copiedCourse = createCopiedCourse(
-                    user, originCourse.getName(), originCourse.getIntroduction(), placesInCourse, places, true);
             courseBookmarkService.deleteCourseBookmark(userId, originCourse.getId());
-
+            Course copiedCourse = createNewCourse(
+                    user, originCourse.getName(), originCourse.getIntroduction(), placesInCourse, places);
             coursePlaceService.createAndSaveCoursePlace(copiedCourse, place);
 
             return CourseAddPlaceResponse.of(
@@ -353,17 +351,14 @@ public class CourseService {
     /**
      * 사용자 소유의 새로운 코스 생성
      */
-    private Course createCopiedCourse(User user, String courseName, String intro,
-            List<PlaceInCourseInfo> placeInfos, List<Place> placesToAdd, Boolean isReplaced) {
+    private Course createNewCourse(User user, String courseName, String intro,
+            List<PlaceInCourseInfo> placeInfos, List<Place> placesToAdd) {
         if (placesToAdd.isEmpty()) {
             throw new BusinessException(ErrorCode.NOT_SUFFICIENT_PLACE_COUNT);
         }
 
         // 코스 생성
-        String uniqueCourseName = courseName;
-        if (!isReplaced) {
-           uniqueCourseName = courseNameGenerator.generateUniqueNameForUser(courseName, user.getId());
-        }
+        String uniqueCourseName = courseNameGenerator.generateUniqueNameForUser(courseName, user.getId());
         Town town = placesToAdd.getFirst().getTown();
         Course newCourse = Course.create(uniqueCourseName, intro, town, user);
         courseRepository.save(newCourse);

--- a/src/main/java/org/sopt/solply_server/domain/course/util/CourseNameGenerator.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/util/CourseNameGenerator.java
@@ -42,7 +42,6 @@ public class CourseNameGenerator {
 
         // 중복되지 않는 이름 생성
         String uniqueName = generateUniqueSequenceName(baseName, existingNames);
-
         log.debug("고유 코스명 생성 완료: '{}' -> '{}'", baseName, uniqueName);
         return uniqueName;
     }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- 기존 코스가 북마크가 해제되기 전에 unique한 이름 생성을 먼저 시도하는 버그를 수정했습니다.


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
-

<br/>

## 🚀 알게된 점 (선택)

---

-

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 