### PR TITLE
[FEAT] pg_trgm 도입, 검색어 기반 장소 조회(3개까지) 기능 구현

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/place/controller/PlaceController.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/controller/PlaceController.java
@@ -10,6 +10,7 @@ import org.sopt.solply_server.domain.place.dto.request.PlaceFilterGetRequest;
 import org.sopt.solply_server.domain.place.dto.response.PlaceAllGetResponse;
 import org.sopt.solply_server.domain.place.dto.response.PlaceFilterGetResponse;
 import org.sopt.solply_server.domain.place.dto.response.PlaceFolderPreviewListGetResponse;
+import org.sopt.solply_server.domain.place.dto.response.PlaceSearchResponse;
 import org.sopt.solply_server.domain.place.service.PlaceBookmarkService;
 import org.sopt.solply_server.domain.place.service.PlaceService;
 import org.sopt.solply_server.global.annotation.CurrentUserId;
@@ -71,6 +72,17 @@ public class PlaceController {
                         placeFilterGetRequest.subTagAIdList(),
                         placeFilterGetRequest.subTagBIdList()
                 )
+        );
+    }
+
+
+    @Operation(summary = "장소 검색", description = "검색 키워드를 기반으로 장소를 조회합니다.")
+    @GetMapping("/search")
+    public ResponseEntity<CustomApiResponse<PlaceSearchResponse>> searchPlaces(
+            @RequestParam("keyword") String keyword) {
+        return CustomApiResponse.success(
+                "장소 검색 성공",
+                placeService.searchPlaces(keyword)
         );
     }
 

--- a/src/main/java/org/sopt/solply_server/domain/place/dto/PlacePreviewDto.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/dto/PlacePreviewDto.java
@@ -9,6 +9,7 @@ public record PlacePreviewDto(
         String placeName,
         String thumbnailImageUrl,
         TagName primaryTag,
+        String address,
         boolean isBookmarked
 ) {
     public static PlacePreviewDto of(
@@ -16,6 +17,7 @@ public record PlacePreviewDto(
             String placeName,
             String thumbnailImageUrl,
             TagName primaryTag,
+            String address,
             boolean isBookmarked
     ) {
         return PlacePreviewDto.builder()
@@ -23,6 +25,7 @@ public record PlacePreviewDto(
                 .placeName(placeName)
                 .thumbnailImageUrl(thumbnailImageUrl)
                 .primaryTag(primaryTag)
+                .address(address)
                 .isBookmarked(isBookmarked)
                 .build();
     }

--- a/src/main/java/org/sopt/solply_server/domain/place/dto/response/PlaceFilterGetResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/dto/response/PlaceFilterGetResponse.java
@@ -4,7 +4,7 @@ import java.util.List;
 import org.sopt.solply_server.domain.place.dto.PlacePreviewDto;
 
 public record PlaceFilterGetResponse(
-        List<PlacePreviewDto> places
+        List<   PlacePreviewDto> places
 ) {
 
     public static PlaceFilterGetResponse from(List<PlacePreviewDto> places) {

--- a/src/main/java/org/sopt/solply_server/domain/place/dto/response/PlaceSearchResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/dto/response/PlaceSearchResponse.java
@@ -1,0 +1,9 @@
+package org.sopt.solply_server.domain.place.dto.response;
+
+import java.util.List;
+import org.sopt.solply_server.domain.place.dto.PlacePreviewDto;
+
+public record PlaceSearchResponse(
+        List<PlacePreviewDto> places
+) {
+}

--- a/src/main/java/org/sopt/solply_server/domain/place/repository/querydsl/PlaceRepositoryCustom.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/repository/querydsl/PlaceRepositoryCustom.java
@@ -6,4 +6,5 @@ import org.sopt.solply_server.domain.place.entity.Place;
 
 public interface PlaceRepositoryCustom {
     List<Place> findPlacesByConditions(PlaceSearchConditionDto placeSearchConditionDto);
+    List<Place> findPlacesByKeyword(String keyword);
 }

--- a/src/main/java/org/sopt/solply_server/domain/place/repository/querydsl/PlaceRepositoryImpl.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/repository/querydsl/PlaceRepositoryImpl.java
@@ -2,6 +2,7 @@ package org.sopt.solply_server.domain.place.repository.querydsl;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -36,6 +37,40 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
         }
 
         return findPlacesWithTags(place, whereCondition, condition);
+    }
+
+    public List<Place> findPlacesByKeyword(String keyword) {
+        QPlace p = QPlace.place;
+        String kw = keyword.trim();
+        int length = kw.codePointCount(0, kw.length());
+
+        if (length >= 3) {
+            // 3글자 이상: pg_trgm 유사도 검색
+            var sim   = Expressions.numberTemplate(Double.class, "similarity({0}, {1})", p.name, kw);
+            var match = Expressions.booleanTemplate("{0} % {1}", p.name, kw);
+
+            return queryFactory.selectFrom(p)
+                    .where(match)
+                    .orderBy(sim.desc(), p.name.asc(), p.id.asc())
+                    .limit(3)
+                    .fetch();
+        } else {
+            // 2글자: ILIKE + strpos
+            String pattern = "%" + kw + "%";
+            var pos = Expressions.numberTemplate(Integer.class, "strpos(lower({0}), lower({1}))", p.name, kw);
+            var sim = Expressions.numberTemplate(Double.class, "similarity({0}, {1})", p.name, kw);
+
+            return queryFactory.selectFrom(p)
+                    .where(p.name.likeIgnoreCase(pattern))
+                    .orderBy(
+                            pos.asc().nullsLast(),
+                            sim.desc(),
+                            p.name.asc(),
+                            p.id.asc()
+                    )
+                    .limit(3)
+                    .fetch();
+        }
     }
 
     // 전체 조회

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
@@ -16,6 +16,7 @@ import org.sopt.solply_server.domain.place.dto.PlacePreviewDto;
 import org.sopt.solply_server.domain.place.dto.response.PlaceAllGetResponse;
 import org.sopt.solply_server.domain.place.dto.response.PlaceFilterGetResponse;
 import org.sopt.solply_server.domain.place.dto.response.PlaceFolderPreviewListGetResponse;
+import org.sopt.solply_server.domain.place.dto.response.PlaceSearchResponse;
 import org.sopt.solply_server.domain.place.entity.Place;
 import org.sopt.solply_server.domain.place.repository.PlaceRepository;
 import org.sopt.solply_server.domain.place.service.cache.PlaceBookmarkRedisDataManager;
@@ -23,9 +24,11 @@ import org.sopt.solply_server.domain.tag.entity.TagType;
 import org.sopt.solply_server.domain.tag.util.TagValidator;
 import org.sopt.solply_server.domain.town.entity.Town;
 import org.sopt.solply_server.domain.town.util.TownValidator;
+import org.sopt.solply_server.global.exception.BusinessException;
 import org.sopt.solply_server.global.exception.EntityNotFoundException;
 import org.sopt.solply_server.global.exception.ErrorCode;
 import org.sopt.solply_server.global.util.EntityLoader;
+import org.sopt.solply_server.global.util.InputValidator;
 import org.sopt.solply_server.global.util.s3.ImageUrlProvider;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -86,6 +89,7 @@ public class PlaceService {
                         place.getName(),
                         imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
                         place.getPrimaryTag(),
+                        place.getAddress(),
                         placeBookmarkService.isBookmarked(userId, place.getId())
                 ))
                 .toList();
@@ -117,6 +121,25 @@ public class PlaceService {
                     })
                     .toList()
         );
+    }
+
+    public PlaceSearchResponse searchPlaces(String keyword) {
+        if (InputValidator.isBlank(keyword) || keyword.length() < 2) {
+            throw new BusinessException(ErrorCode.INVALID_KEYWORD);
+        }
+        var places = placeRepository.findPlacesByKeyword(keyword);
+        List<PlacePreviewDto> placePreviews = places.stream()
+                .map(place -> PlacePreviewDto.of(
+                        place.getId(),
+                        place.getName(),
+                        imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
+                        place.getPrimaryTag(),
+                        place.getAddress(),
+                        false // 검색 결과에서는 북마크 여부를 제공 X
+                ))
+                .toList();
+
+        return new PlaceSearchResponse(placePreviews);
     }
 
 

--- a/src/main/java/org/sopt/solply_server/global/exception/ErrorCode.java
+++ b/src/main/java/org/sopt/solply_server/global/exception/ErrorCode.java
@@ -56,6 +56,7 @@ public enum ErrorCode {
     PLACE_TAG_REQUIRED(HttpStatus.UNPROCESSABLE_ENTITY, "PLACE-002", "장소에 MAIN 태그가 최소 1개 이상 존재해야 합니다."),
     ALREADY_BOOKMARKED(HttpStatus.CONFLICT, "PlACE-010", "이미 북마크된 장소입니다."),
 
+
     // 코스 관련 (COURSE-xxx)
     NOT_FOUND_COURSE(HttpStatus.NOT_FOUND, "COURSE-001", "존재하지 않는 코스입니다."),
     ALREADY_BOOKMARKED_COURSE(HttpStatus.CONFLICT, "COURSE-002", "이미 북마크된 코스입니다."),
@@ -77,7 +78,10 @@ public enum ErrorCode {
     NOT_FOUND_USER_SELECTED_TOWN(HttpStatus.NOT_FOUND, "USER-006" , "유저가 선택한 동네가 없어서 온보딩을 진행해야 합니다."),
 
     // 북마크 관련 (BOOKMARK-xxx)
-    NOT_BOOKMARKED_COURSE(HttpStatus.FORBIDDEN, "BOOKMARK-001", "북마크된 코스가 아닙니다.");
+    NOT_BOOKMARKED_COURSE(HttpStatus.FORBIDDEN, "BOOKMARK-001", "북마크된 코스가 아닙니다."),
+
+    // 검색 관련 (SEARCH-xxx)
+    INVALID_KEYWORD(HttpStatus.BAD_REQUEST, "SEARCH-001", "검색어는 최소 2자 이상이어야 합니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/resources/db/migration/V4__enable_pg_trgm.sql
+++ b/src/main/resources/db/migration/V4__enable_pg_trgm.sql
@@ -1,0 +1,5 @@
+-- pg_trgm 확장 설치
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS idx_places_name_trgm
+    ON places USING gin (name gin_trgm_ops);


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #150 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- 3글자 이상의 장소명을 가진 장소들이 많으므로, `pg_bigm`이 아닌 `pg_trgm`를 채택했고, 자연어 검색이 아니라 간단한 장소명 검색이기 때문에 elastic search 같은 무거운 엔진이 아니라 `pg_trgm`이 더 적합할 것 같다는 생각을 했습니다.


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->

2글자 이하에서는 매치/유사도 점수가 지나치게 낮아서 분기해서 처리하도록 했습니다.

- 3글자 이상 검색 시
`%` 조건으로 GIN 인덱스 타서 "키워드" 관련 행만 가져오고, 그 후보군에 대해서만 `similarity()`를 계산해서 상위 3개만 추출하는 방식으로 구현했습니다.

`similarity()`는 3글자 단위(trigram)로 쪼개서 비교해서 컬럼 값과 검색어가 얼마나 비슷한지를 점수(0.0 ~ 1.0)로 계산하는 함수입니다.
자바 변수 sim 안에 숫자(Double)가 직접 저장되는 게 아니라, “쿼리 실행 시 similarity(name, '강남')를 계산해라”라는 SQL이 저장되어 있는 것이라고 보면 됩니다!

`%`는 다음처럼 boolean 값을 반환해줍니다.
```
SELECT '강남카페' % '강남역카페'; -- true (비슷하다 판정)
SELECT '강남' % '강남역';        -- false (비슷하지 않다 판정)
```

<br>

- 2글자 검색 시
1. `ILIKE`로 후보군 확보
ex) ILIKE '%강남%'로 "강남역카페", "카페강남", "역 강남 고기집" 전부 가져옴.
2. 정렬 1순위: `strpos()`
- "강남카페" (앞에서 시작) → 우선
- "카페강남" (뒤에서 시작) → 후순위
3. 정렬 2순위: `similarity()`
- 같은 위치라면, 유사도 점수가 높은 쪽(더 비슷한 문자열)을 위에.
4. 정렬 3순위: `name ASC`, `id ASC`
- 안정적인 tie-breaker → 페이징이나 결과 재현성 보장.

<br/>

## 🚀 알게된 점 (선택)

---

-

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 장소 키워드 검색 API 추가(GET /api/places/search). 최소 2자 키워드로 장소를 검색하고 결과를 반환합니다.
  - 검색·목록 결과 미리보기에 ‘주소’ 정보가 표시됩니다.
- 오류 처리
  - 유효하지 않은 검색어(2자 미만) 요청 시 400 오류를 반환합니다.
- 문서
  - 검색 API에 대한 OpenAPI 설명을 추가했습니다.
- 작업
  - 검색 성능 향상을 위해 데이터베이스에 pg_trgm 확장과 이름 컬럼 트라이그램 인덱스를 적용했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->