### PR TITLE
[FEAT] 관심 동네 제거, 몇몇 API 요청/응답 바디 수정

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/auth/service/AuthService.java
+++ b/src/main/java/org/sopt/solply_server/domain/auth/service/AuthService.java
@@ -47,7 +47,7 @@ public class AuthService {
         initialTowns.add(town1);
         initialTowns.add(town2);
 
-        userInterestTownService.updateUserInterestTowns(user, initialTowns);
+//        userInterestTownService.updateUserInterestTowns(user, initialTowns);
 
         return SocialLoginResponse.of(
                 saveTokenCollection(user.getId()),

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -201,7 +201,7 @@ public class CourseService {
                     return CoursePlaceDetailsDto.of(
                             place,
                             thumbnailUrl,
-                            place.getPrimaryTag(),
+                            place.getMainTag(),
                             placeBookmarkMap.getOrDefault(place.getId(), false),
                             coursePlace.getPlaceOrder()
                     );

--- a/src/main/java/org/sopt/solply_server/domain/place/controller/PlaceController.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/controller/PlaceController.java
@@ -10,6 +10,7 @@ import org.sopt.solply_server.domain.place.dto.request.PlaceFilterGetRequest;
 import org.sopt.solply_server.domain.place.dto.response.PlaceAllGetResponse;
 import org.sopt.solply_server.domain.place.dto.response.PlaceFilterGetResponse;
 import org.sopt.solply_server.domain.place.dto.response.PlaceFolderPreviewListGetResponse;
+import org.sopt.solply_server.domain.place.dto.response.PlaceSearchResponse;
 import org.sopt.solply_server.domain.place.service.PlaceBookmarkService;
 import org.sopt.solply_server.domain.place.service.PlaceService;
 import org.sopt.solply_server.global.annotation.CurrentUserId;
@@ -71,6 +72,17 @@ public class PlaceController {
                         placeFilterGetRequest.subTagAIdList(),
                         placeFilterGetRequest.subTagBIdList()
                 )
+        );
+    }
+
+
+    @Operation(summary = "장소 검색", description = "검색 키워드를 기반으로 장소를 조회합니다.")
+    @GetMapping("/search")
+    public ResponseEntity<CustomApiResponse<PlaceSearchResponse>> searchPlaces(
+            @RequestParam("keyword") String keyword) {
+        return CustomApiResponse.success(
+                "장소 검색 성공",
+                placeService.searchPlaces(keyword)
         );
     }
 

--- a/src/main/java/org/sopt/solply_server/domain/place/dto/PlacePreviewDto.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/dto/PlacePreviewDto.java
@@ -9,6 +9,7 @@ public record PlacePreviewDto(
         String placeName,
         String thumbnailImageUrl,
         TagName primaryTag,
+        String address,
         boolean isBookmarked
 ) {
     public static PlacePreviewDto of(
@@ -16,6 +17,7 @@ public record PlacePreviewDto(
             String placeName,
             String thumbnailImageUrl,
             TagName primaryTag,
+            String address,
             boolean isBookmarked
     ) {
         return PlacePreviewDto.builder()
@@ -23,6 +25,7 @@ public record PlacePreviewDto(
                 .placeName(placeName)
                 .thumbnailImageUrl(thumbnailImageUrl)
                 .primaryTag(primaryTag)
+                .address(address)
                 .isBookmarked(isBookmarked)
                 .build();
     }

--- a/src/main/java/org/sopt/solply_server/domain/place/dto/response/PlaceAllGetResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/dto/response/PlaceAllGetResponse.java
@@ -11,7 +11,7 @@ import org.sopt.solply_server.domain.tag.entity.TagName;
 public record PlaceAllGetResponse(
         long placeId,
         String placeName,
-        TagName primaryTag,
+        TagName mainTag,
         String introduction,
         List<PlaceImageInfoDto> imageInfos,
         String address,
@@ -25,11 +25,11 @@ public record PlaceAllGetResponse(
         long placeDefaultId
 ) {
 
-    public static PlaceAllGetResponse of(Place place, TagName primaryTag, List<PlaceImageInfoDto> placeImageInfos, boolean isBookmarked) {
+    public static PlaceAllGetResponse of(Place place, TagName mainTag, List<PlaceImageInfoDto> placeImageInfos, boolean isBookmarked) {
         return PlaceAllGetResponse.builder()
                 .placeId(place.getId())
                 .placeName(place.getName())
-                .primaryTag(primaryTag)
+                .mainTag(mainTag)
                 .introduction(place.getIntroduction())
                 .imageInfos(placeImageInfos)
                 .address(place.getAddress())

--- a/src/main/java/org/sopt/solply_server/domain/place/dto/response/PlaceFilterGetResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/dto/response/PlaceFilterGetResponse.java
@@ -4,7 +4,7 @@ import java.util.List;
 import org.sopt.solply_server.domain.place.dto.PlacePreviewDto;
 
 public record PlaceFilterGetResponse(
-        List<PlacePreviewDto> places
+        List<   PlacePreviewDto> places
 ) {
 
     public static PlaceFilterGetResponse from(List<PlacePreviewDto> places) {

--- a/src/main/java/org/sopt/solply_server/domain/place/dto/response/PlaceSearchResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/dto/response/PlaceSearchResponse.java
@@ -1,0 +1,9 @@
+package org.sopt.solply_server.domain.place.dto.response;
+
+import java.util.List;
+import org.sopt.solply_server.domain.place.dto.PlacePreviewDto;
+
+public record PlaceSearchResponse(
+        List<PlacePreviewDto> places
+) {
+}

--- a/src/main/java/org/sopt/solply_server/domain/place/entity/Place.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/entity/Place.java
@@ -18,7 +18,6 @@ import jakarta.persistence.MapKeyEnumerated;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
-import java.awt.Point;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -104,7 +103,7 @@ public class Place extends BaseTimeEntity {
     /**
      * 장소의 1차 태그(MAIN) 추출
      */
-    public TagName getPrimaryTag() {
+    public TagName getMainTag() {
         return this.placeTags.stream()
                 .map(PlaceTag::getTag)
                 .filter(tag -> tag.getType() == TagType.MAIN)

--- a/src/main/java/org/sopt/solply_server/domain/place/repository/querydsl/PlaceRepositoryCustom.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/repository/querydsl/PlaceRepositoryCustom.java
@@ -6,4 +6,5 @@ import org.sopt.solply_server.domain.place.entity.Place;
 
 public interface PlaceRepositoryCustom {
     List<Place> findPlacesByConditions(PlaceSearchConditionDto placeSearchConditionDto);
+    List<Place> findPlacesByKeyword(String keyword);
 }

--- a/src/main/java/org/sopt/solply_server/domain/place/repository/querydsl/PlaceRepositoryImpl.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/repository/querydsl/PlaceRepositoryImpl.java
@@ -51,7 +51,11 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
 
             return queryFactory.selectFrom(p)
                     .where(match)
-                    .orderBy(sim.desc(), p.name.asc(), p.id.asc())
+                    .orderBy(
+                            sim.desc(),
+                            p.name.asc(),
+                            p.id.asc()
+                    )
                     .limit(3)
                     .fetch();
         } else {

--- a/src/main/java/org/sopt/solply_server/domain/place/repository/querydsl/PlaceRepositoryImpl.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/repository/querydsl/PlaceRepositoryImpl.java
@@ -2,6 +2,7 @@ package org.sopt.solply_server.domain.place.repository.querydsl;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -36,6 +37,40 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
         }
 
         return findPlacesWithTags(place, whereCondition, condition);
+    }
+
+    public List<Place> findPlacesByKeyword(String keyword) {
+        QPlace p = QPlace.place;
+        String kw = keyword.trim();
+        int length = kw.codePointCount(0, kw.length());
+
+        if (length >= 3) {
+            // 3글자 이상: pg_trgm 유사도 검색
+            var sim   = Expressions.numberTemplate(Double.class, "similarity({0}, {1})", p.name, kw);
+            var match = Expressions.booleanTemplate("{0} % {1}", p.name, kw);
+
+            return queryFactory.selectFrom(p)
+                    .where(match)
+                    .orderBy(sim.desc(), p.name.asc(), p.id.asc())
+                    .limit(3)
+                    .fetch();
+        } else {
+            // 2글자: ILIKE + strpos
+            String pattern = "%" + kw + "%";
+            var pos = Expressions.numberTemplate(Integer.class, "strpos(lower({0}), lower({1}))", p.name, kw);
+            var sim = Expressions.numberTemplate(Double.class, "similarity({0}, {1})", p.name, kw);
+
+            return queryFactory.selectFrom(p)
+                    .where(p.name.likeIgnoreCase(pattern))
+                    .orderBy(
+                            pos.asc().nullsLast(),
+                            sim.desc(),
+                            p.name.asc(),
+                            p.id.asc()
+                    )
+                    .limit(3)
+                    .fetch();
+        }
     }
 
     // 전체 조회

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
@@ -16,6 +16,7 @@ import org.sopt.solply_server.domain.place.dto.PlacePreviewDto;
 import org.sopt.solply_server.domain.place.dto.response.PlaceAllGetResponse;
 import org.sopt.solply_server.domain.place.dto.response.PlaceFilterGetResponse;
 import org.sopt.solply_server.domain.place.dto.response.PlaceFolderPreviewListGetResponse;
+import org.sopt.solply_server.domain.place.dto.response.PlaceSearchResponse;
 import org.sopt.solply_server.domain.place.entity.Place;
 import org.sopt.solply_server.domain.place.repository.PlaceRepository;
 import org.sopt.solply_server.domain.place.service.cache.PlaceBookmarkRedisDataManager;
@@ -23,9 +24,11 @@ import org.sopt.solply_server.domain.tag.entity.TagType;
 import org.sopt.solply_server.domain.tag.util.TagValidator;
 import org.sopt.solply_server.domain.town.entity.Town;
 import org.sopt.solply_server.domain.town.util.TownValidator;
+import org.sopt.solply_server.global.exception.BusinessException;
 import org.sopt.solply_server.global.exception.EntityNotFoundException;
 import org.sopt.solply_server.global.exception.ErrorCode;
 import org.sopt.solply_server.global.util.EntityLoader;
+import org.sopt.solply_server.global.util.InputValidator;
 import org.sopt.solply_server.global.util.s3.ImageUrlProvider;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -86,6 +89,7 @@ public class PlaceService {
                         place.getName(),
                         imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
                         place.getPrimaryTag(),
+                        place.getAddress(),
                         placeBookmarkService.isBookmarked(userId, place.getId())
                 ))
                 .toList();
@@ -117,6 +121,25 @@ public class PlaceService {
                     })
                     .toList()
         );
+    }
+
+    public PlaceSearchResponse searchPlaces(String keyword) {
+        if (InputValidator.isBlank(keyword) || keyword.length() < 2) {
+            throw new BusinessException(ErrorCode.INVALID_KEYWORD);
+        }
+        var places = placeRepository.findPlacesByKeyword(keyword);
+        List<PlacePreviewDto> placePreviews = places.stream()
+                .map(place -> PlacePreviewDto.of(
+                        place.getId(),
+                        place.getName(),
+                        imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
+                        place.getPrimaryTag(),
+                        place.getAddress(),
+                        false // 검색 결과에서는 북마크 여부를 제공 X
+                ))
+                .toList();
+
+        return new PlaceSearchResponse(placePreviews);
     }
 
 

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
@@ -64,7 +64,7 @@ public class PlaceService {
 
         return PlaceAllGetResponse.of(
                 place,
-                place.getPrimaryTag(),
+                place.getMainTag(),
                 imageInfos,
                 isBookmarked
         );
@@ -88,7 +88,7 @@ public class PlaceService {
                         place.getId(),
                         place.getName(),
                         imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
-                        place.getPrimaryTag(),
+                        place.getMainTag(),
                         place.getAddress(),
                         placeBookmarkService.isBookmarked(userId, place.getId())
                 ))
@@ -133,7 +133,7 @@ public class PlaceService {
                         place.getId(),
                         place.getName(),
                         imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
-                        place.getPrimaryTag(),
+                        place.getMainTag(),
                         place.getAddress(),
                         false // 검색 결과에서는 북마크 여부를 제공 X
                 ))

--- a/src/main/java/org/sopt/solply_server/domain/recommend/dto/PlaceInfoDto.java
+++ b/src/main/java/org/sopt/solply_server/domain/recommend/dto/PlaceInfoDto.java
@@ -6,17 +6,17 @@ public record PlaceInfoDto(
         long placeId,
         String placeName,
         String thumbnailImageUrl,
-        TagName primaryTag,
+        TagName mainTag,
         String introduction
 ) {
     public static PlaceInfoDto from(
             long placeId,
             String placeName,
             String thumbnailImageUrl,
-            TagName primaryTag,
+            TagName mainTag,
             String introduction
     ) {
-        return new PlaceInfoDto(placeId, placeName, thumbnailImageUrl, primaryTag, introduction);
+        return new PlaceInfoDto(placeId, placeName, thumbnailImageUrl, mainTag, introduction);
     }
 
 }

--- a/src/main/java/org/sopt/solply_server/domain/recommend/service/RecommendService.java
+++ b/src/main/java/org/sopt/solply_server/domain/recommend/service/RecommendService.java
@@ -77,7 +77,7 @@ public class RecommendService {
                         place.getId(),
                         place.getName(),
                         imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
-                        place.getPrimaryTag(),
+                        place.getMainTag(),
                         place.getIntroduction()
                 ))
                 .collect(Collectors.toList());

--- a/src/main/java/org/sopt/solply_server/domain/test/service/TestService.java
+++ b/src/main/java/org/sopt/solply_server/domain/test/service/TestService.java
@@ -38,13 +38,13 @@ public class TestService {
 //        String nickname = "user_" + UUID.randomUUID().toString().substring(0, 5);
 
         User user = userRepository.save(User.create(email));
-        Town town1 = entityLoader.getTown(Long.parseLong("2")); // 연희동
-        Town town2 = entityLoader.getTown(Long.parseLong("3")); // 망원동
-        List<Town> initialTowns = new ArrayList<>();
-        initialTowns.add(town1);
-        initialTowns.add(town2);
-
-        userInterestTownService.updateUserInterestTowns(user, initialTowns);
+//        Town town1 = entityLoader.getTown(Long.parseLong("2")); // 연희동
+//        Town town2 = entityLoader.getTown(Long.parseLong("3")); // 망원동
+//        List<Town> initialTowns = new ArrayList<>();
+//        initialTowns.add(town1);
+//        initialTowns.add(town2);
+//
+//        userInterestTownService.updateUserInterestTowns(user, initialTowns);
 
         return TestLoginResponse.of(
                 saveTokenCollection(user.getId()),

--- a/src/main/java/org/sopt/solply_server/domain/user/controller/UserController.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/controller/UserController.java
@@ -61,7 +61,7 @@ public class UserController {
         return CustomApiResponse.success("유저 정보 조회에 성공하였습니다.", response);
     }
 
-    @Operation(summary = "유저의 동네 정보 조회", description = "유저의 관심 동네 및 선택 동네를 조회합니다.")
+    @Operation(summary = "동네 관련 정보 조회", description = "유저가 선택한 동네를 조회합니다.")
     @GetMapping("/towns")
     public ResponseEntity<CustomApiResponse<UserTownGetResponse>> getUserTowns(
             @CurrentUserId Long userId

--- a/src/main/java/org/sopt/solply_server/domain/user/dto/request/UserOnboardingUpdateRequest.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/dto/request/UserOnboardingUpdateRequest.java
@@ -10,9 +10,6 @@ public record UserOnboardingUpdateRequest(
         @NotNull(message = "동네 선택은 필수입니다")
         Long selectedTownId,
 
-        @NotNull(message = "관심 동네는 필수입니다")
-        List<Long> favoriteTownIdList,
-
         @NotNull(message = "유저 성향은 필수입니다")
         UserPersona persona,
 

--- a/src/main/java/org/sopt/solply_server/domain/user/dto/request/UserTownsUpdateRequest.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/dto/request/UserTownsUpdateRequest.java
@@ -6,10 +6,10 @@ import java.util.List;
 
 public record UserTownsUpdateRequest(
         @NotNull(message = "동네 선택은 필수입니다")
-        Long selectedTownId,
+        Long selectedTownId
 
-        @NotEmpty(message = "관심 동네는 필수입니다")
-        List<Long> favoriteTownIdList
+//        @NotEmpty(message = "관심 동네는 필수입니다")
+//        List<Long> favoriteTownIdList
 ) {
 
 }

--- a/src/main/java/org/sopt/solply_server/domain/user/dto/response/UserTownGetResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/dto/response/UserTownGetResponse.java
@@ -4,11 +4,10 @@ import java.util.List;
 import org.sopt.solply_server.domain.user.dto.UserTownInfoDto;
 
 public record UserTownGetResponse(
-        UserTownInfoDto selectedTown,
-        List<UserTownInfoDto> favoriteTownList
+        UserTownInfoDto selectedTown
 ) {
-    public static UserTownGetResponse of(UserTownInfoDto selectedTown, List<UserTownInfoDto> userInterestTown) {
-        return new UserTownGetResponse(selectedTown, userInterestTown);
+    public static UserTownGetResponse of(UserTownInfoDto selectedTown) {
+        return new UserTownGetResponse(selectedTown);
     }
 
 }

--- a/src/main/java/org/sopt/solply_server/domain/user/dto/response/UserTownsUpdateResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/dto/response/UserTownsUpdateResponse.java
@@ -4,11 +4,10 @@ import java.util.List;
 import org.sopt.solply_server.domain.user.dto.UserTownInfoDto;
 
 public record UserTownsUpdateResponse(
-        UserTownInfoDto selectedTown,
-        List<UserTownInfoDto> favoriteTownList
+        UserTownInfoDto selectedTown
 ) {
-    public static UserTownsUpdateResponse of(UserTownInfoDto selectedTown, List<UserTownInfoDto> favoriteTownList) {
-        return new UserTownsUpdateResponse(selectedTown, favoriteTownList);
+    public static UserTownsUpdateResponse of(UserTownInfoDto selectedTown) {
+        return new UserTownsUpdateResponse(selectedTown);
     }
 
 }

--- a/src/main/java/org/sopt/solply_server/domain/user/repository/UserInterestTownRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/repository/UserInterestTownRepository.java
@@ -15,8 +15,8 @@ public interface UserInterestTownRepository extends JpaRepository<UserInterestTo
 
     void deleteByUserId(Long id);
 
-    @Query("SELECT uit FROM UserInterestTown uit " +
-            "LEFT JOIN FETCH uit.town " +
-            "WHERE uit.user.id = :userId")
-    List<UserInterestTown> findAllByUserWithTown(Long userId);
+//    @Query("SELECT uit FROM UserInterestTown uit " +
+//            "LEFT JOIN FETCH uit.town " +
+//            "WHERE uit.user.id = :userId")
+//    List<UserInterestTown> findAllByUserWithTown(Long userId);
 }

--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserOnboardingService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserOnboardingService.java
@@ -67,10 +67,10 @@ public class UserOnboardingService {
         try {
             // 온보딩 정보 업데이트(페르소나, 닉네임, 선택 동네)
             user.updateOnboardingInfo(request.persona(), request.nickname(), request.selectedTownId());
-            List<Town> towns = request.favoriteTownIdList().stream()
-                    .map(entityLoader::getTown)
-                    .toList();
-            userInterestTownService.updateUserInterestTowns(user, towns);
+//            List<Town> towns = request.favoriteTownIdList().stream()
+//                    .map(entityLoader::getTown)
+//                    .toList();
+//            userInterestTownService.updateUserInterestTowns(user, towns);
             return UserOnboardingUpdateResponse.of(user, entityLoader.getTown(request.selectedTownId()));
         } catch (DataIntegrityViolationException e) {
             log.warn("DB 제약조건 위반으로 인한 온보딩 실패: userId={}, nickname={}",

--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
@@ -53,18 +53,15 @@ public class UserService {
     @Transactional
     public UserTownsUpdateResponse updateUserTowns(final Long userId, UserTownsUpdateRequest request) {
         User user = entityLoader.getUser(userId);
-        List<Town> towns = request.favoriteTownIdList().stream()
-                .map(entityLoader::getTown)
-                .toList();
-        userInterestTownService.updateUserInterestTowns(user, towns);
+//        List<Town> towns = request.favoriteTownIdList().stream()
+//                .map(entityLoader::getTown)
+//                .toList();
+//        userInterestTownService.updateUserInterestTowns(user, towns);
         Town selectedTown = entityLoader.getTown(request.selectedTownId());
         user.updateSelectedTown(request.selectedTownId());
 
         return UserTownsUpdateResponse.of(
-                UserTownInfoDto.of(request.selectedTownId(), selectedTown.getName()),
-                towns.stream()
-                        .map(town -> UserTownInfoDto.of(town.getId(), town.getName()))
-                        .toList()
+                UserTownInfoDto.of(request.selectedTownId(), selectedTown.getName())
         );
     }
 

--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
@@ -78,13 +78,13 @@ public class UserService {
                 .orElse(null);
 
         // 관심 동네들
-        List<UserTownInfoDto> interestTowns = entityLoader.getInterestTownsWithTownsByIds(userId)
-                .stream()
-                .map(interestTown -> UserTownInfoDto.of(
-                        interestTown.getTown().getId(),
-                        interestTown.getTown().getName()))
-                .toList();
+//        List<UserTownInfoDto> interestTowns = entityLoader.getInterestTownsWithTownsByIds(userId)
+//                .stream()
+//                .map(interestTown -> UserTownInfoDto.of(
+//                        interestTown.getTown().getId(),
+//                        interestTown.getTown().getName()))
+//                .toList();
 
-        return UserTownGetResponse.of(selectedTown, interestTowns);
+        return UserTownGetResponse.of(selectedTown);
     }
 }

--- a/src/main/java/org/sopt/solply_server/global/exception/ErrorCode.java
+++ b/src/main/java/org/sopt/solply_server/global/exception/ErrorCode.java
@@ -56,6 +56,7 @@ public enum ErrorCode {
     PLACE_TAG_REQUIRED(HttpStatus.UNPROCESSABLE_ENTITY, "PLACE-002", "장소에 MAIN 태그가 최소 1개 이상 존재해야 합니다."),
     ALREADY_BOOKMARKED(HttpStatus.CONFLICT, "PlACE-010", "이미 북마크된 장소입니다."),
 
+
     // 코스 관련 (COURSE-xxx)
     NOT_FOUND_COURSE(HttpStatus.NOT_FOUND, "COURSE-001", "존재하지 않는 코스입니다."),
     ALREADY_BOOKMARKED_COURSE(HttpStatus.CONFLICT, "COURSE-002", "이미 북마크된 코스입니다."),
@@ -77,7 +78,10 @@ public enum ErrorCode {
     NOT_FOUND_USER_SELECTED_TOWN(HttpStatus.NOT_FOUND, "USER-006" , "유저가 선택한 동네가 없어서 온보딩을 진행해야 합니다."),
 
     // 북마크 관련 (BOOKMARK-xxx)
-    NOT_BOOKMARKED_COURSE(HttpStatus.FORBIDDEN, "BOOKMARK-001", "북마크된 코스가 아닙니다.");
+    NOT_BOOKMARKED_COURSE(HttpStatus.FORBIDDEN, "BOOKMARK-001", "북마크된 코스가 아닙니다."),
+
+    // 검색 관련 (SEARCH-xxx)
+    INVALID_KEYWORD(HttpStatus.BAD_REQUEST, "SEARCH-001", "검색어는 최소 2자 이상이어야 합니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/sopt/solply_server/global/util/EntityLoader.java
+++ b/src/main/java/org/sopt/solply_server/global/util/EntityLoader.java
@@ -51,7 +51,7 @@ public class EntityLoader {
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_TOWN));
     }
 
-    public List<UserInterestTown> getInterestTownsWithTownsByIds(Long userId) {
-        return userInterestTownRepository.findAllByUserWithTown(userId);
-    }
+//    public List<UserInterestTown> getInterestTownsWithTownsByIds(Long userId) {
+//        return userInterestTownRepository.findAllByUserWithTown(userId);
+//    }
 }

--- a/src/main/resources/db/migration/V4__enable_pg_trgm.sql
+++ b/src/main/resources/db/migration/V4__enable_pg_trgm.sql
@@ -1,0 +1,5 @@
+-- pg_trgm 확장 설치
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS idx_places_name_trgm
+    ON places USING gin (name gin_trgm_ops);


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #154


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- 이슈 내용과 같습니다.


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 관심 동네는 나중에 즐겨찾기처럼 추가 될 가능성을 고려해서 기존 구조는 냅두고 주석 처리만 했습니다.
- 이전에 pr 올렸던 브랜치에서 곧바로 체크아웃해서 이전 pr 커밋도 같이 딸려왔네요.. 다음엔 이런 일 없도록 하겠슴다..

<br/>

## 🚀 알게된 점 (선택)

---

-

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 장소 키워드 검색 API 추가(최소 2자 키워드 필요)
  - 장소 미리보기/검색 결과에 주소 정보 포함
  - 코스/추천에서 대표 태그 표기 일관화

- 변경사항
  - 유저 동네 응답에서 관심 동네 목록 제거(선택 동네만 제공)
  - 온보딩/동네 수정 시 관심 동네 입력 불필요
  - 2자 미만 키워드 검색 시 오류 응답 반환

- 성능
  - 검색 성능 향상을 위한 데이터베이스 확장 및 인덱스 추가

- 문서
  - 동네 조회 엔드포인트 설명 문구 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->