### PR TITLE
[FEAT] PresignedURL 도메인 별 발급 처리, S3 파일 위치 변경 및 DB 반영 비동기 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.3.5'
 	id 'io.spring.dependency-management' version '1.1.7'
-	id 'org.flywaydb.flyway' version '10.19.0'
+	id 'org.flywaydb.flyway' version '10.14.0'
 }
 
 group = 'org.sopt'

--- a/src/main/java/org/sopt/solply_server/SolplyServerApplication.java
+++ b/src/main/java/org/sopt/solply_server/SolplyServerApplication.java
@@ -4,8 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableAsync
 @EnableScheduling
 @SpringBootApplication
 @EnableJpaAuditing

--- a/src/main/java/org/sopt/solply_server/domain/file/controller/FileController.java
+++ b/src/main/java/org/sopt/solply_server/domain/file/controller/FileController.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.sopt.solply_server.domain.file.dto.request.FilesUploadRequest;
 import org.sopt.solply_server.domain.file.dto.response.FilesUploadResponse;
 import org.sopt.solply_server.domain.file.service.FileService;
+import org.sopt.solply_server.global.annotation.CurrentUserId;
 import org.sopt.solply_server.global.dto.CustomApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,11 +26,12 @@ public class FileController {
 
     @PostMapping(value = "/presigned-urls")
     public ResponseEntity<CustomApiResponse<FilesUploadResponse>> createPresignedUrlToUpload(
+            @CurrentUserId Long userId,
             @Valid @RequestBody FilesUploadRequest request
     ) {
         return CustomApiResponse.success(
                 "업로드용 presigned url 생성에 성공했습니다.",
-                fileService.createPresignedUrlToUpload(request)
+                fileService.createPresignedUrlToUpload(userId, request)
         );
     }
 

--- a/src/main/java/org/sopt/solply_server/domain/file/service/FileService.java
+++ b/src/main/java/org/sopt/solply_server/domain/file/service/FileService.java
@@ -1,8 +1,11 @@
 package org.sopt.solply_server.domain.file.service;
 
+import static java.util.stream.Collectors.toList;
+
 import jakarta.validation.Valid;
 import java.time.Duration;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.sopt.solply_server.domain.file.dto.PresignedUrlInfo;
 import org.sopt.solply_server.domain.file.dto.request.FilesUploadRequest;
@@ -16,12 +19,12 @@ public class FileService {
     private final PresignedUrlProvider presignedUrlProvider;
     private static final Duration PRESIGN_TTL = java.time.Duration.ofMinutes(10);
 
-    public FilesUploadResponse createPresignedUrlToUpload(@Valid FilesUploadRequest request) {
+    public FilesUploadResponse createPresignedUrlToUpload(Long userId, @Valid FilesUploadRequest request) {
 
         List<PresignedUrlInfo> presignedUrlInfos = request.files().stream()
                         .map(file ->
-                            presignedUrlProvider.createPresignedUrlInfo(
-                                    file.fileName(), PRESIGN_TTL
+                            presignedUrlProvider.createStagingUploadUrl(
+                                    userId, UUID.randomUUID().toString(), file.fileName(), PRESIGN_TTL
                             )
                         ).toList();
         return new FilesUploadResponse(

--- a/src/main/java/org/sopt/solply_server/domain/place/dto/ImageFileKeyUpdateEvent.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/dto/ImageFileKeyUpdateEvent.java
@@ -1,0 +1,13 @@
+package org.sopt.solply_server.domain.place.dto;
+
+import com.drew.lang.annotations.Nullable;
+import java.util.List;
+import org.sopt.solply_server.global.util.s3.TargetDir;
+
+public record ImageFileKeyUpdateEvent(
+        long targetId,
+        TargetDir targetDir,
+        Long userId,
+        String uploadToken,
+        List<String> stagingKeys
+) {}

--- a/src/main/java/org/sopt/solply_server/domain/place/service/ImageFieldUpdater.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/ImageFieldUpdater.java
@@ -1,0 +1,9 @@
+package org.sopt.solply_server.domain.place.service;
+
+import java.util.List;
+import org.sopt.solply_server.global.util.s3.TargetDir;
+
+public interface ImageFieldUpdater {
+    TargetDir supportedDir();
+    void replaceImages(long targetId, List<String> destKeys);
+}

--- a/src/main/java/org/sopt/solply_server/domain/place/service/ImageFileKeyUpdateListener.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/ImageFileKeyUpdateListener.java
@@ -1,0 +1,64 @@
+package org.sopt.solply_server.domain.place.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.sopt.solply_server.domain.place.dto.ImageFileKeyUpdateEvent;
+import org.sopt.solply_server.global.exception.BusinessException;
+import org.sopt.solply_server.global.exception.ErrorCode;
+import org.sopt.solply_server.global.util.s3.S3FileMoveService;
+import org.sopt.solply_server.global.util.s3.TargetDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+public class ImageFileKeyUpdateListener {
+
+    private final S3FileMoveService s3FileMoveService;
+    private final Map<TargetDir, ImageFieldUpdater> updaterMap;
+
+    @Autowired
+    public ImageFileKeyUpdateListener(
+            S3FileMoveService s3FileMoveService,
+            List<ImageFieldUpdater> updaters
+    ) {
+        this.s3FileMoveService = s3FileMoveService;
+        // TargetDir 별로 ImageFieldUpdater 매핑
+        this.updaterMap = updaters.stream()
+                .collect(Collectors.toMap(ImageFieldUpdater::supportedDir, u -> u));
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onCreated(ImageFileKeyUpdateEvent e) {
+        // 옮길 stagingKey 찾기
+        List<String> stagingKeys = (e.stagingKeys() != null && !e.stagingKeys().isEmpty())
+                ? e.stagingKeys()
+                : s3FileMoveService.listByToken(e.userId(), e.uploadToken());
+
+        if (stagingKeys.isEmpty()) return;
+
+        // 파일 위치 이동
+        List<String> destKeys = new ArrayList<>();
+        for (String stagingKey : stagingKeys) {
+            try {
+                String dest = s3FileMoveService.moveToDir(stagingKey, e.targetId(), e.targetDir());
+                destKeys.add(dest);
+            } catch (Exception ex) {
+            }
+        }
+        if (destKeys.isEmpty()) return;
+
+        // DB에 반영
+        ImageFieldUpdater updater = updaterMap.get(e.targetDir());
+        if (updater == null) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+        updater.replaceImages(e.targetId(), destKeys);
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/place/service/ImageFileKeyUpdateListener.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/ImageFileKeyUpdateListener.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.solply_server.domain.place.dto.ImageFileKeyUpdateEvent;
 import org.sopt.solply_server.global.exception.BusinessException;
 import org.sopt.solply_server.global.exception.ErrorCode;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+@Slf4j
 @Component
 public class ImageFileKeyUpdateListener {
 
@@ -50,6 +52,7 @@ public class ImageFileKeyUpdateListener {
                 String dest = s3FileMoveService.moveToDir(stagingKey, e.targetId(), e.targetDir());
                 destKeys.add(dest);
             } catch (Exception ex) {
+                log.warn("파일 경로 변경 실패 / stagingKey={}, targetId={}, dir={}", stagingKey, e.targetId(), e.targetDir(), ex);
             }
         }
         if (destKeys.isEmpty()) return;

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceReportImageUpdater.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceReportImageUpdater.java
@@ -1,0 +1,32 @@
+package org.sopt.solply_server.domain.place.service;
+
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.solply_server.global.util.s3.TargetDir;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+class PlaceReportImageUpdater implements ImageFieldUpdater {
+
+//    private final PlaceReportRepository repo;
+    @Override
+    public TargetDir supportedDir() {
+        return TargetDir.PLACE_REPORTS;
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void replaceImages(long reportId, List<String> destKeys) {
+//        var report = repo.findById(reportId).orElseThrow();
+//        report.getReportImageInfos().clear();
+        int order = 1;
+//        for (String key : new LinkedHashSet<>(destKeys)) {
+//            report.getReportImageInfos().add(new ReportImageInfo(key, order++));
+    }
+
+}

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceRequestImageUpdater.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceRequestImageUpdater.java
@@ -1,0 +1,37 @@
+package org.sopt.solply_server.domain.place.service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.sopt.solply_server.global.util.s3.TargetDir;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+class PlaceRequestImageUpdater implements ImageFieldUpdater {
+
+//    private final PlaceRequestRepository repo;
+
+    @Override
+    public TargetDir supportedDir() {
+        return TargetDir.PLACE_REQUESTS;
+    }
+
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void replaceImages(long requestId, List<String> destKeys) {
+//        var pr = repo.findById(requestId).orElseThrow();
+//        pr.getPlaceRequestImageInfos().clear();
+        int order = 1;
+        for (String key : new LinkedHashSet<>(destKeys)) {
+//            pr.getPlaceRequestImageInfos().add(new PlaceRequestImageInfo(key, order++));
+        }
+    }
+}

--- a/src/main/java/org/sopt/solply_server/global/util/s3/ImageCategory.java
+++ b/src/main/java/org/sopt/solply_server/global/util/s3/ImageCategory.java
@@ -1,0 +1,14 @@
+package org.sopt.solply_server.global.util.s3;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ImageCategory {
+    PLACE_REQUESTS("place-requests"),
+    PLACE_REPORTS("place-reports");
+
+    private final String dir;
+
+}

--- a/src/main/java/org/sopt/solply_server/global/util/s3/PresignedUrlProvider.java
+++ b/src/main/java/org/sopt/solply_server/global/util/s3/PresignedUrlProvider.java
@@ -20,52 +20,70 @@ public class PresignedUrlProvider {
     @Value("${aws.s3.bucket}")
     private String bucketName;
 
+    @Value("${app.env-prefix}")
+    private String envPrefix; // "dev" or "prod"
+
     @Value("${aws.s3.presigned-url.expiration-seconds}")
     private int expirationSeconds;
 
     private final S3Presigner s3Presigner;
 
-    private final static String TEMPORARY_FILE_PREFIX = "temp/solply-";
-
     private static final Set<String> ALLOWED_MIME = Set.of(
             "image/jpeg", "image/png", "image/webp", "image/gif", "image/heic", "image/heif"
     );
 
-    public String createPresignedUrlToRead(final String fileKey) {
-        if (InputValidator.isBlank(fileKey)) return null;
+    public PresignedUrlInfo createStagingUploadUrl(Long userId, String uploadToken, String originalFileName, Duration ttl) {
+        String ext = guessExt(originalFileName);
+        if (ext == null) return new PresignedUrlInfo(originalFileName, null, null, 0);
 
-        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
-                .signatureDuration(Duration.ofHours(expirationSeconds))
-                .getObjectRequest(req -> req
-                        .bucket(bucketName)
-                        .key(fileKey)
-                        .build())
-                .build();
+        String mime = guessMime(ext);
+        if (!ALLOWED_MIME.contains(mime)) return new PresignedUrlInfo(originalFileName, null, null, 0);
 
-        return s3Presigner.presignGetObject(presignRequest).url().toExternalForm();
+        String key = String.format("%s/uploads/_staging/%d/%s/%s.%s",
+                envPrefix, userId, uploadToken, UUID.randomUUID(), ext);
+
+        return createPutPresignedUrl(key, mime, ttl, originalFileName);
     }
 
-    public PresignedUrlInfo createPresignedUrlInfo(String fileName, Duration ttl) {
-        // 확장자 체크
-        String ext = guessExt(fileName);
-        if (ext == null) {
-            return new PresignedUrlInfo(fileName, null, null, 0);
-        }
 
-        // MIME 체크
-        String mime = guessMime(ext);
-        if (!ALLOWED_MIME.contains(mime)) {
-            return new PresignedUrlInfo(fileName, null, null, 0);
-        }
+//    public PresignedUrlInfo createCategorizedUploadUrl(final ImageCategory imageCategory, final String id, final String originalFileName, final Duration ttl) {
+//        // 확장자 & MIME 확인
+//        String ext = guessExt(originalFileName);
+//        if (ext == null) {
+//            return new PresignedUrlInfo(originalFileName, null, null, 0);
+//        }
+//
+//        String mime = guessMime(ext);
+//        if (!ALLOWED_MIME.contains(mime)) {
+//            return new PresignedUrlInfo(originalFileName, null, null, 0);
+//        }
+//
+//        String uuid = UUID.randomUUID().toString();
+//        String fileKey = buildKey(envPrefix, imageCategory.getDir(), id, uuid, ext);
+//
+//        return createPutPresignedUrl(fileKey, mime, ttl, originalFileName);
+//    }
+
+//    public String createPresignedUrlToRead(final String fileKey) {
+//        if (InputValidator.isBlank(fileKey)) return null;
+//
+//        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+//                // BUGFIX: seconds면 ofSeconds 사용
+//                .signatureDuration(Duration.ofSeconds(expirationSeconds))
+//                .getObjectRequest(req -> req
+//                        .bucket(bucketName)
+//                        .key(fileKey)
+//                        .build())
+//                .build();
+//
+//        return s3Presigner.presignGetObject(presignRequest).url().toExternalForm();
+//    }
 
 
-        String uuid = UUID.randomUUID().toString();
-
-        String tempFileKey = TEMPORARY_FILE_PREFIX + uuid + "." + ext;
-
+    private PresignedUrlInfo createPutPresignedUrl(final String fileKey, final String mime, final Duration ttl, final String originalName) {
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .bucket(bucketName)
-                .key(tempFileKey)
+                .key(fileKey)
                 .contentType(mime)
                 .build();
 
@@ -77,12 +95,18 @@ public class PresignedUrlProvider {
         var preSignedRequest = s3Presigner.presignPutObject(preSignRequest);
 
         return PresignedUrlInfo.of(
-                fileName,
-                tempFileKey,
+                originalName,
+                fileKey,
                 preSignedRequest.url().toExternalForm(),
                 ttl.toSeconds()
         );
     }
+
+    private static String buildKey(String env, String categoryDir, String idSegment, String uuid, String ext) {
+        // env/uploads/{category}/{id}/xxxx.ext
+        return env + "/uploads/" + categoryDir + "/" + idSegment + "/" + uuid + "." + ext;
+    }
+
 
     private static String guessExt(String fileName) {
         if (fileName != null) {
@@ -101,7 +125,7 @@ public class PresignedUrlProvider {
             case "png"         -> "image/png";
             case "gif"         -> "image/gif";
             case "webp"        -> "image/webp";
-            case "heic", "heif"-> "image/heic";
+            case "heic", "heif"-> "image/heic"; // 일부 클라가 image/heif로 보낼 수 있음. 수용 범위는 필요 시 확장.
             default            -> "application/octet-stream";
         };
     }

--- a/src/main/java/org/sopt/solply_server/global/util/s3/S3FileMoveService.java
+++ b/src/main/java/org/sopt/solply_server/global/util/s3/S3FileMoveService.java
@@ -1,5 +1,6 @@
 package org.sopt.solply_server.global.util.s3;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
@@ -7,34 +8,22 @@ import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 
 @RequiredArgsConstructor
 public class S3FileMoveService {
+
     private final S3Client s3;
     private final String bucketName;
     private final String envPrefix;
 
-    // 스테이징 → place-requests/{requestId}
-    public String moveToPlaceRequestDir(String stagingKey, long requestId) {
+    /**
+     * 스테이징 경로에 있는 파일을 최종 경로로 이동
+     * @param stagingKey  ex) env/uploads/_staging/{userId}/{uploadToken}/{uuid}.ext
+     * @param targetId    requestId or placeId
+     * @param targetDir   PLACE_REQUESTS or PLACE_REPORTS
+     * @return            최종 destKey
+     */
+    public String moveToDir(String stagingKey, long targetId, TargetDir targetDir) {
         String fileName = stagingKey.substring(stagingKey.lastIndexOf('/') + 1);
-        String destKey = String.format("%s/uploads/place-requests/%d/%s", envPrefix, requestId, fileName);
-
-        s3.copyObject(CopyObjectRequest.builder()
-                .sourceBucket(bucketName)
-                .sourceKey(stagingKey)
-                .destinationBucket(bucketName)
-                .destinationKey(destKey)
-                .build());
-
-        s3.deleteObject(DeleteObjectRequest.builder()
-                .bucket(bucketName)
-                .key(stagingKey)
-                .build());
-
-        return destKey;
-    }
-
-    // 스테이징 → place-reports/{placeId}
-    public String moveToPlaceReportDir(String stagingKey, long placeId) {
-        String fileName = stagingKey.substring(stagingKey.lastIndexOf('/') + 1);
-        String destKey = String.format("%s/uploads/place-reports/%d/%s", envPrefix, placeId, fileName);
+        String destKey = String.format("%s/uploads/%s/%d/%s",
+                envPrefix, targetDir.getDir(), targetId, fileName);
 
         s3.copyObject(CopyObjectRequest.builder()
                 .sourceBucket(bucketName)

--- a/src/main/java/org/sopt/solply_server/global/util/s3/S3FileMoveService.java
+++ b/src/main/java/org/sopt/solply_server/global/util/s3/S3FileMoveService.java
@@ -1,24 +1,36 @@
 package org.sopt.solply_server.global.util.s3;
 
+import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Object;
 
+
+@Component
 @RequiredArgsConstructor
 public class S3FileMoveService {
 
     private final S3Client s3;
-    private final String bucketName;
-    private final String envPrefix;
+
+    @Value("${app.env-prefix}")
+    private String envPrefix;
+
+    @Value("${aws.s3.bucket}")
+    private String bucketName;
 
     /**
      * 스테이징 경로에 있는 파일을 최종 경로로 이동
-     * @param stagingKey  ex) env/uploads/_staging/{userId}/{uploadToken}/{uuid}.ext
-     * @param targetId    requestId or placeId
-     * @param targetDir   PLACE_REQUESTS or PLACE_REPORTS
-     * @return            최종 destKey
+     *
+     * @param stagingKey ex) env/uploads/_staging/{userId}/{uploadToken}/{uuid}.ext
+     * @param targetId   requestId or placeId
+     * @param targetDir  PLACE_REQUESTS or PLACE_REPORTS
+     * @return 최종 destKey
      */
     public String moveToDir(String stagingKey, long targetId, TargetDir targetDir) {
         String fileName = stagingKey.substring(stagingKey.lastIndexOf('/') + 1);
@@ -39,4 +51,14 @@ public class S3FileMoveService {
 
         return destKey;
     }
+
+    public List<String> listByToken(Long userId, String uploadToken) {
+        if (userId == null || uploadToken == null || uploadToken.isBlank()) return List.of();
+        String prefix = "%s/uploads/_staging/%d/%s/".formatted(envPrefix, userId, uploadToken);
+        var resp = s3.listObjectsV2(b -> b.bucket(bucketName).prefix(prefix));
+        return resp.contents().stream().map(S3Object::key).toList();
+    }
 }
+
+
+

--- a/src/main/java/org/sopt/solply_server/global/util/s3/S3FileMoveService.java
+++ b/src/main/java/org/sopt/solply_server/global/util/s3/S3FileMoveService.java
@@ -1,0 +1,53 @@
+package org.sopt.solply_server.global.util.s3;
+
+import lombok.RequiredArgsConstructor;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+
+@RequiredArgsConstructor
+public class S3FileMoveService {
+    private final S3Client s3;
+    private final String bucketName;
+    private final String envPrefix;
+
+    // 스테이징 → place-requests/{requestId}
+    public String moveToPlaceRequestDir(String stagingKey, long requestId) {
+        String fileName = stagingKey.substring(stagingKey.lastIndexOf('/') + 1);
+        String destKey = String.format("%s/uploads/place-requests/%d/%s", envPrefix, requestId, fileName);
+
+        s3.copyObject(CopyObjectRequest.builder()
+                .sourceBucket(bucketName)
+                .sourceKey(stagingKey)
+                .destinationBucket(bucketName)
+                .destinationKey(destKey)
+                .build());
+
+        s3.deleteObject(DeleteObjectRequest.builder()
+                .bucket(bucketName)
+                .key(stagingKey)
+                .build());
+
+        return destKey;
+    }
+
+    // 스테이징 → place-reports/{placeId}
+    public String moveToPlaceReportDir(String stagingKey, long placeId) {
+        String fileName = stagingKey.substring(stagingKey.lastIndexOf('/') + 1);
+        String destKey = String.format("%s/uploads/place-reports/%d/%s", envPrefix, placeId, fileName);
+
+        s3.copyObject(CopyObjectRequest.builder()
+                .sourceBucket(bucketName)
+                .sourceKey(stagingKey)
+                .destinationBucket(bucketName)
+                .destinationKey(destKey)
+                .build());
+
+        s3.deleteObject(DeleteObjectRequest.builder()
+                .bucket(bucketName)
+                .key(stagingKey)
+                .build());
+
+        return destKey;
+    }
+}

--- a/src/main/java/org/sopt/solply_server/global/util/s3/TargetDir.java
+++ b/src/main/java/org/sopt/solply_server/global/util/s3/TargetDir.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public enum ImageCategory {
+public enum TargetDir {
     PLACE_REQUESTS("place-requests"),
     PLACE_REPORTS("place-reports");
 

--- a/src/test/java/org/sopt/solply_server/domain/place/service/PlaceRequestPromoteListenerTest.java
+++ b/src/test/java/org/sopt/solply_server/domain/place/service/PlaceRequestPromoteListenerTest.java
@@ -1,0 +1,7 @@
+package org.sopt.solply_server.domain.place.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PlaceRequestPromoteListenerTest {
+
+}


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #159 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- ../_staging이라는 경로에 이미지를 업로드 해놓고, 각 객체(PlaceRequest, PlaceReport)가 db에 저장됐을 때 특정 경로로 이미지들을 복사하도록 하는 비동기 로직을 미리 구현해놨습니다.


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 지수랑 영경이 pr merge 하면 만들어놓은 각자 만들어놓은 생성 service에서 비동기 메서드를 호출하도록 하게 할 예정입니다.

<br/>

## 🚀 알게된 점 (선택)

---

-

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 사용자별 임시 업로드 영역을 사용한 사전 서명 업로드 흐름 도입으로 보안성과 추적성 향상.
  - 업로드된 파일을 대상 디렉터리로 복사/이동하고 관련 이미지 필드를 갱신하는 비동기 처리 추가.
  - 장소 요청/신고 이미지 교체를 위한 확장 가능한 업데이트 구조 및 대상 디렉터리 구분 도입.
  - 비동기 실행을 위한 애플리케이션 설정 활성화.

- 테스트
  - 관련 리스너 테스트 스켈레톤 추가.

- 잡무
  - 빌드 플러그인 버전 조정.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->