### PR TITLE
[FIX] 잘못된 토큰인 경우 GlobalExceptionHandler에서 처리하도록 수정

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/auth/service/AuthService.java
+++ b/src/main/java/org/sopt/solply_server/domain/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package org.sopt.solply_server.domain.auth.service;
 
+import io.jsonwebtoken.Claims;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -61,8 +62,8 @@ public class AuthService {
 
     // 토큰 재발급
     public RefreshResponse refreshToken(String refreshToken) {
-        jwtTokenProvider.validateRefreshToken(refreshToken);
-        Long userId = jwtTokenResolver.getUserIdFromToken(refreshToken);
+        Claims claims = jwtTokenProvider.parseRefreshToken(refreshToken);
+        Long userId = claims.get("userId", Long.class);
 
         String storedRefreshToken = refreshTokenRepository.findByMemberId(userId);
         if (storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)) {

--- a/src/main/java/org/sopt/solply_server/global/exception/JwtTokenException.java
+++ b/src/main/java/org/sopt/solply_server/global/exception/JwtTokenException.java
@@ -4,4 +4,5 @@ public class JwtTokenException extends BusinessException {
     public JwtTokenException(ErrorCode errorCode) {
         super(errorCode);
     }
+
 }

--- a/src/main/java/org/sopt/solply_server/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/solply_server/global/handler/GlobalExceptionHandler.java
@@ -117,14 +117,6 @@ public class GlobalExceptionHandler {
         return CustomApiResponse.error(ErrorCode.MISSING_REQUIRED_PARAMETER);
     }
 
-    // 요청에 포함된 파라미터 이름들을 추출하는 헬퍼 메서드
-    private String getReceivedParameterNames(HttpServletRequest request) {
-        if (request.getParameterMap().isEmpty()) {
-            return "없음";
-        }
-        return String.join(", ", request.getParameterMap().keySet());
-    }
-
     // 400: JSON 파싱 자체가 실패한 경우
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<CustomApiResponse<Void>> handleMessageNotReadableException(

--- a/src/main/java/org/sopt/solply_server/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/sopt/solply_server/global/jwt/JwtAuthenticationFilter.java
@@ -51,7 +51,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             if (StringUtils.hasText(accessToken)) {
 
                 Claims claims = jwtTokenProvider.parseAccessToken(accessToken);
-                Long userId = jwtTokenResolver.getUserIdFromToken(accessToken);
+                Long userId = jwtTokenResolver.getUserId(claims);
 
                 UserDetails userDetails = principalDetailsService.loadUserByUsername(userId.toString());
                 UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(

--- a/src/main/java/org/sopt/solply_server/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/sopt/solply_server/global/jwt/JwtAuthenticationFilter.java
@@ -1,11 +1,14 @@
 package org.sopt.solply_server.global.jwt;
 
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.sopt.solply_server.global.exception.JwtTokenException;
 import org.sopt.solply_server.global.security.PrincipalDetailsService;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
@@ -16,34 +19,52 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.Collections;
+import org.springframework.web.servlet.HandlerExceptionResolver;
 
 @Component
-@RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtTokenResolver jwtTokenResolver;
     private final PrincipalDetailsService principalDetailsService;
+    private final HandlerExceptionResolver handlerExceptionResolver;
+
+    public JwtAuthenticationFilter(
+            JwtTokenProvider jwtTokenProvider,
+            JwtTokenResolver jwtTokenResolver,
+            PrincipalDetailsService principalDetailsService,
+            @Qualifier("handlerExceptionResolver") HandlerExceptionResolver handlerExceptionResolver
+    ) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.jwtTokenResolver = jwtTokenResolver;
+        this.principalDetailsService = principalDetailsService;
+        this.handlerExceptionResolver = handlerExceptionResolver;
+    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
-        String accessToken = resolveToken(request);
+        try {
+            String accessToken = resolveToken(request);
 
-        if (StringUtils.hasText(accessToken) && jwtTokenProvider.validateAccessToken(accessToken)) {
-            Long userId = jwtTokenResolver.getUserIdFromToken(accessToken);
+            if (StringUtils.hasText(accessToken)) {
 
-            // 인증 정보 생성
-            UserDetails userDetails = principalDetailsService.loadUserByUsername(userId.toString());
-            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-                    userDetails, null, userDetails.getAuthorities());
+                Claims claims = jwtTokenProvider.parseAccessToken(accessToken);
+                Long userId = jwtTokenResolver.getUserIdFromToken(accessToken);
 
-            // SecurityContext에 인증 정보 저장
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+                UserDetails userDetails = principalDetailsService.loadUserByUsername(userId.toString());
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+
+            filterChain.doFilter(request, response);
+        } catch (JwtTokenException e) {
+            SecurityContextHolder.clearContext(); // 인증 정보 초기화
+            handlerExceptionResolver.resolveException(request, response, null, e);
         }
-
-        filterChain.doFilter(request, response);
     }
 
     // "Authorization" 헤더에서 토큰 추출

--- a/src/main/java/org/sopt/solply_server/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/sopt/solply_server/global/jwt/JwtTokenProvider.java
@@ -31,20 +31,20 @@ public class JwtTokenProvider {
     }
 
     // JwtTokenCollection(AccessToken, RefreshToken) 생성
-    public TokenCollectionDto createTokenCollection(Long memberId) {
+    public TokenCollectionDto createTokenCollection(Long userId) {
         return TokenCollectionDto.of(
-                generateAccessToken(memberId),
-                generateRefreshToken(memberId)
+                generateAccessToken(userId),
+                generateRefreshToken(userId)
         );
     }
 
     // Access Token 생성
-    public String generateAccessToken(Long memberId) {
+    public String generateAccessToken(Long userId) {
         Date now = new Date();
         Date expiryDate = new Date(now.getTime() + accessTokenExpireTime);
 
         return Jwts.builder()
-                .setSubject(String.valueOf(memberId))
+                .setSubject(String.valueOf(userId))
                 .claim("type", "access") // Access Token용 Claim 추가
                 .setIssuedAt(now)
                 .setExpiration(expiryDate)
@@ -53,12 +53,12 @@ public class JwtTokenProvider {
     }
 
     // Refresh Token 생성
-    public String generateRefreshToken(Long memberId) {
+    public String generateRefreshToken(Long userId) {
         Date now = new Date();
         Date expiryDate = new Date(now.getTime() + refreshTokenExpireTime);
 
         return Jwts.builder()
-                .setSubject(String.valueOf(memberId))
+                .setSubject(String.valueOf(userId))
                 .claim("type", "refresh") // Refresh Token용 Claim 추가
                 .setIssuedAt(now)
                 .setExpiration(expiryDate)

--- a/src/main/java/org/sopt/solply_server/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/sopt/solply_server/global/jwt/JwtTokenProvider.java
@@ -66,33 +66,34 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    // Access 토큰 유효성 검증
-    public boolean validateAccessToken(String accessToken) {
-        try {
-            Claims claims = Jwts.parserBuilder().setSigningKey(accessKey).build().parseClaimsJws(accessToken).getBody();
-            if (!"access".equals(claims.get("type"))) {
-                throw new JwtTokenException(ErrorCode.INVALID_ACCESS_TOKEN);
-            }
-            return true;
-        } catch (ExpiredJwtException e) {
-            throw new JwtTokenException(ErrorCode.EXPIRED_ACCESS_TOKEN);
-        } catch (Exception e) {
-            throw new JwtTokenException(ErrorCode.INVALID_ACCESS_TOKEN);
-        }
+    public Claims parseAccessToken(String token) {
+        return parseAndValidate(token, accessKey, TokenType.ACCESS);
     }
 
-    // Refresh 토큰 유효성 검증
-    public boolean validateRefreshToken(String refreshToken) {
+    public Claims parseRefreshToken(String token) {
+        return parseAndValidate(token, refreshKey, TokenType.REFRESH);
+    }
+
+    private Claims parseAndValidate(String token, Key key, TokenType expectedType) {
         try {
-            Claims claims = Jwts.parserBuilder().setSigningKey(refreshKey).build().parseClaimsJws(refreshToken).getBody();
-            if (!"refresh".equals(claims.get("type"))) {
-                throw new JwtTokenException(ErrorCode.INVALID_REFRESH_TOKEN);
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .setAllowedClockSkewSeconds(30)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+            String type = String.valueOf(claims.get("type"));
+            if (!expectedType.name().equalsIgnoreCase(type)) {
+                throw new JwtTokenException(ErrorCode.INVALID_TOKEN);
             }
-            return true;
+            return claims;
         } catch (ExpiredJwtException e) {
-            throw new JwtTokenException(ErrorCode.EXPIRED_REFRESH_TOKEN);
-        } catch (Exception e) {
-            throw new JwtTokenException(ErrorCode.INVALID_REFRESH_TOKEN);
+            throw new JwtTokenException(
+                    expectedType == TokenType.ACCESS ? ErrorCode.EXPIRED_ACCESS_TOKEN
+                            : ErrorCode.EXPIRED_REFRESH_TOKEN);
+        } catch (JwtException e) {
+            throw new JwtTokenException(ErrorCode.INVALID_TOKEN);
         }
     }
 

--- a/src/main/java/org/sopt/solply_server/global/jwt/JwtTokenResolver.java
+++ b/src/main/java/org/sopt/solply_server/global/jwt/JwtTokenResolver.java
@@ -19,47 +19,10 @@ import java.security.Key;
 @RequiredArgsConstructor
 public class JwtTokenResolver {
 
-    private final JwtProperties jwtProperties;
-
-    public Long getUserIdFromToken(String token) {
-        try {
-            Claims claims = getClaimsFromToken(token, getKey(token));
-            return Long.parseLong(claims.getSubject());
-        } catch (ExpiredJwtException e) {
-            // 토큰이 만료되었더라도 재발급을 위해 userId는 추출
-            return Long.parseLong(e.getClaims().getSubject());
-        } catch (Exception e) {
-            throw new JwtTokenException(ErrorCode.INVALID_ACCESS_TOKEN);
-        }
-    }
-
-    private Claims getClaimsFromToken(String token, Key key) {
-        return Jwts.parserBuilder()
-                .setSigningKey(key)
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
-    }
-
-    private Key getKey(String token) {
-        // 간단하게 Base64 디코딩 후 type 필드를 확인하여 키 선택
-        String[] splitToken = token.split("\\.");
-        String unsignedToken = splitToken[0] + "." + splitToken[1] + ".";
-
-        try {
-            Claims claims = (Claims) Jwts.parserBuilder()
-                    .build()
-                    .parse(unsignedToken).getBody();
-            String type = (String) claims.get("type");
-            if ("refresh".equals(type)) {
-                return Keys.hmacShaKeyFor(Decoders.BASE64.decode(jwtProperties.getRefreshSecretKey()));
-            }
-        } catch (JwtException | IllegalArgumentException e) {
-            // 예외 처리: 잘못된 토큰
-            log.error("JWT 파싱 실패", e);
-            throw new JwtTokenException(ErrorCode.INVALID_TOKEN);
-        }
-
-        return Keys.hmacShaKeyFor(Decoders.BASE64.decode(jwtProperties.getAccessSecretKey()));
+    public Long getUserId(Claims c) {
+        Object v = c.get("userId");
+        if (v instanceof Number n) return n.longValue();
+        if (v != null) return Long.parseLong(v.toString());
+        return Long.parseLong(c.getSubject()); // fallback
     }
 }

--- a/src/main/java/org/sopt/solply_server/global/jwt/TokenType.java
+++ b/src/main/java/org/sopt/solply_server/global/jwt/TokenType.java
@@ -1,0 +1,3 @@
+package org.sopt.solply_server.global.jwt;
+
+public enum TokenType { ACCESS, REFRESH }


### PR DESCRIPTION
…alException으로 넘기도록 수정

<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #161 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- wt 필터에 HandlerExceptionResolver 의존성을 주입해서, 잘못된 토큰인 경우 GlobalException으로 넘기도록 수정했습니다.


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- JwtTokenProvider에서 한 번 파싱, JwtTokenResolver에서 한 번 파싱, 총 2번으로 중복 파싱되는 부분이 있어서 리팩토링도 진행했습니다.

<br/>

## 🚀 알게된 점 (선택)

---

-

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 액세스/리프레시 토큰 타입 구분을 명확히 하여 토큰 처리의 일관성 강화.
- 버그 수정
  - 만료·유효하지 않은 토큰에 대한 예외 처리와 에러 응답을 일관되게 반환.
  - 리프레시 토큰 갱신 시 사용자 식별 신뢰성 개선.
  - 인증 필터에서 JWT 예외 발생 시 보안 컨텍스트 정리 및 표준 예외 응답 처리.
- 리팩터
  - 토큰 파싱을 Claims 기반으로 통합해 인증 흐름 단순화 및 안정성 향상.
- 기타
  - 불필요한 코드 제거 및 경미한 포맷 정리.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->