### PR TITLE
[FIX] jwt 필터에도 화이트리스트 추가

### DIFF
--- a/src/main/java/org/sopt/solply_server/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/sopt/solply_server/global/jwt/JwtAuthenticationFilter.java
@@ -1,10 +1,12 @@
 package org.sopt.solply_server.global.jwt;
 
+
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.solply_server.global.exception.JwtTokenException;
 import org.sopt.solply_server.global.security.PrincipalDetailsService;
@@ -13,6 +15,9 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -29,6 +34,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final PrincipalDetailsService principalDetailsService;
     private final HandlerExceptionResolver handlerExceptionResolver;
 
+    private static final RequestMatcher WHITELIST = new OrRequestMatcher(List.of(
+            new AntPathRequestMatcher("/api/auth/**"),
+            new AntPathRequestMatcher("/swagger-ui/**"),
+            new AntPathRequestMatcher("/v3/api-docs/**"),
+            new AntPathRequestMatcher("/api/test/**")
+    ));
+
     public JwtAuthenticationFilter(
             JwtTokenProvider jwtTokenProvider,
             JwtTokenResolver jwtTokenResolver,
@@ -40,6 +52,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         this.principalDetailsService = principalDetailsService;
         this.handlerExceptionResolver = handlerExceptionResolver;
     }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return WHITELIST.matches(request);
+    }
+
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #164 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

-  jwt 필터에도 화이트리스트 경로를 추가해서, 헤더에 상관없이 해당 경로들의 요청이 정상적으로 처리될 수 있도록 수정했습니다.


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
-

<br/>

## 🚀 알게된 점 (선택)

---

-

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 인증 제외 경로에 대한 화이트리스트를 도입해 특정 엔드포인트(예: 인증 관련 경로, API 문서, Swagger UI, 테스트 엔드포인트)에 토큰 없이 접근할 수 있습니다.
  * 로그인 없이 회원가입/로그인 진행 및 API 문서 열람이 더욱 원활해집니다.
  * 보호된 API의 기존 인증 흐름은 그대로 유지되어 보안에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->