### PR TITLE
[HOTFIX] 코스 설명은 null, 공백 문자 허용

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/course/dto/request/CourseCreateRequest.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/dto/request/CourseCreateRequest.java
@@ -12,7 +12,7 @@ public record CourseCreateRequest(
         @Size(max = 50, message = "코스 이름은 50자 이하로 입력해주세요.")
         String courseName,
 
-        @NotBlank(message = "코스 설명은 필수입니다.")
+
         String courseDescription,
 
         @NotEmpty(message = "코스에는 2개 이상의 장소가 포함되어야 합니다.")

--- a/src/main/java/org/sopt/solply_server/domain/course/dto/request/CourseUpdateRequest.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/dto/request/CourseUpdateRequest.java
@@ -13,7 +13,6 @@ public record CourseUpdateRequest(
         @Size(min = 1, max = 18, message = "코스 이름은 1자 이상 18자 이하로 입력해주세요.")
         String courseName,
 
-        @NotBlank(message = "코스 설명은 필수입니다.")
         @Size(max = 27, message = "코스 설명은 27자 이하로 입력해주세요.")
         String courseDescription,
 


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #182 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- dto @NotBlank 제거


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 딱히 없습니다.

<br/>

## 🚀 알게된 점 (선택)

---

-

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 코스 설명 필수 입력 제약을 해제하여 설명 없이도 코스를 생성/수정할 수 있습니다. 빈 문자열·공백만 입력된 설명도 허용되며, 최대 길이 제한은 그대로 적용됩니다.
  - 설명 미입력으로 인한 생성/수정 실패 문제가 해소되었습니다. 다른 필수 항목 및 검증 로직에는 변경이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->