### PR TITLE
[FIX] match_against라는 사용자 정의 함수를 등록, 프로메테우스 세팅 수정

### DIFF
--- a/docker/observability/prometheus.yml
+++ b/docker/observability/prometheus.yml
@@ -6,9 +6,9 @@ scrape_configs:
   - job_name: 'spring-app'
     metrics_path: '/actuator/prometheus'
     static_configs:
-      - targets: ['app:8081']
+      - targets: ['app:8080']
 
   - job_name: 'jmeter'
     metrics_path: '/metrics'
     static_configs:
-      - targets: ['jmeter:9270']   # JMeter 컨테이너 or 호스트
+      - targets: ['host.docker.internal:9270']   # JMeter 컨테이너 or 호스트

--- a/src/main/java/org/sopt/solply_server/domain/file/controller/FileController.java
+++ b/src/main/java/org/sopt/solply_server/domain/file/controller/FileController.java
@@ -2,6 +2,7 @@ package org.sopt.solply_server.domain.file.controller;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.solply_server.domain.file.dto.request.FilesUploadRequest;
@@ -34,5 +35,16 @@ public class FileController {
                 fileService.createPresignedUrlToUpload(userId, request)
         );
     }
+
+
+//    @PostMapping(value = "/presigned-urls/read")
+//    public ResponseEntity<CustomApiResponse<List<String>>> createPresignedUrlsToRead(
+//            @RequestBody List<String> fileKeys
+//    ) {
+//        return CustomApiResponse.success(
+//                "다운로드용 presigned url 생성에 성공했습니다.",
+//                fileService.createPresignedUrlsToRead(fileKeys)
+//        );
+//    }
 
 }

--- a/src/main/java/org/sopt/solply_server/domain/file/service/FileService.java
+++ b/src/main/java/org/sopt/solply_server/domain/file/service/FileService.java
@@ -31,4 +31,10 @@ public class FileService {
                 presignedUrlInfos
         );
     }
+
+//    public List<String> createPresignedUrlsToRead(List<String> fileKeys) {
+//        return fileKeys.stream()
+//                .map(presignedUrlProvider::createPresignedUrlToRead)
+//                .toList();
+//    }
 }

--- a/src/main/java/org/sopt/solply_server/domain/place/dto/PlaceSearchResultDto.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/dto/PlaceSearchResultDto.java
@@ -1,0 +1,37 @@
+package org.sopt.solply_server.domain.place.dto;
+
+import lombok.Builder;
+import org.sopt.solply_server.domain.tag.entity.TagName;
+
+@Builder
+public record PlaceSearchResultDto(
+        long placeId,
+        String placeName,
+        String thumbnailImageUrl,
+        TagName primaryTag,
+        String address,
+        boolean isBookmarked,
+        long townId
+
+) {
+    public static PlaceSearchResultDto of(
+            long placeId,
+            String placeName,
+            String thumbnailImageUrl,
+            TagName primaryTag,
+            String address,
+            boolean isBookmarked,
+            long townId
+    ) {
+        return PlaceSearchResultDto.builder()
+                .placeId(placeId)
+                .placeName(placeName)
+                .thumbnailImageUrl(thumbnailImageUrl)
+                .primaryTag(primaryTag)
+                .address(address)
+                .isBookmarked(isBookmarked)
+                .townId(townId)
+                .build();
+    }
+
+}

--- a/src/main/java/org/sopt/solply_server/domain/place/dto/response/PlaceSearchResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/dto/response/PlaceSearchResponse.java
@@ -1,9 +1,9 @@
 package org.sopt.solply_server.domain.place.dto.response;
 
 import java.util.List;
-import org.sopt.solply_server.domain.place.dto.PlacePreviewDto;
+import org.sopt.solply_server.domain.place.dto.PlaceSearchResultDto;
 
 public record PlaceSearchResponse(
-        List<PlacePreviewDto> places
+        List<PlaceSearchResultDto> places
 ) {
 }

--- a/src/main/java/org/sopt/solply_server/domain/place/repository/querydsl/PlaceRepositoryCustom.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/repository/querydsl/PlaceRepositoryCustom.java
@@ -6,5 +6,5 @@ import org.sopt.solply_server.domain.place.entity.Place;
 
 public interface PlaceRepositoryCustom {
     List<Place> findPlacesByConditions(PlaceSearchConditionDto placeSearchConditionDto);
-    List<Place> findPlacesByKeyword(String keyword);
+    List<Place> findPlacesWithTownByKeyword(String keyword);
 }

--- a/src/main/java/org/sopt/solply_server/domain/place/repository/querydsl/PlaceRepositoryImpl.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/repository/querydsl/PlaceRepositoryImpl.java
@@ -97,43 +97,33 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
         if (kw.isEmpty()) return List.of();
 
         int length = kw.codePointCount(0, kw.length());
-        // 단일 글자면 FULLTEXT 효용이 떨어지니 LIKE로 처리
         boolean useFullText = length >= 2;
 
         if (useFullText) {
+            // 공백 토큰을 BOOLEAN MODE용으로 가공
             String booleanQuery = Arrays.stream(kw.split("\\s+"))
                     .filter(s -> !s.isBlank())
                     .map(tok -> sanitizeForBooleanMode(tok) + "*")
                     .collect(Collectors.joining(" "));
 
-            String sql = """
-              select p.id
-              from places p
-              where match(p.name) against (? in boolean mode)
-              order by match(p.name) against (? in boolean mode) desc, p.name asc, p.id asc
-              limit 10
-            """;
+            // ✅ 여기! 커스텀 함수(match_against) 사용
+            var score = Expressions.numberTemplate(
+                    Double.class,
+                    "match_against({0}, {1})",
+                    qPlace.name, booleanQuery
+            );
 
-            List<?> raw = entityManager.createNativeQuery(sql)
-                    .setParameter(1, booleanQuery)
-                    .setParameter(2, booleanQuery)
-                    .getResultList();
-
-            List<Long> ids = raw.stream()
-                    .filter(Objects::nonNull)
-                    .map(o -> ((Number) o).longValue())
-                    .toList();
-
-            if (ids.isEmpty()) return List.of();
-
-            List<Place> rows = queryFactory.selectFrom(qPlace)
+            return queryFactory
+                    .selectFrom(qPlace)
                     .join(qPlace.town, qTown).fetchJoin()
-                    .where(qPlace.id.in(ids))
+                    .where(score.gt(0)) // 점수 > 0 인 것만
+                    .orderBy(
+                            score.desc(),     // 점수순
+                            qPlace.name.asc(),
+                            qPlace.id.asc()
+                    )
+                    .limit(10)
                     .fetch();
-
-            Map<Long, Place> map = rows.stream().collect(Collectors.toMap(Place::getId, x -> x));
-            List<Place> ordered = ids.stream().map(map::get).filter(Objects::nonNull).toList();
-            return ordered;
         } else {
             // 1글자 → LIKE fallback
             String escaped = kw.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");

--- a/src/main/java/org/sopt/solply_server/domain/place/repository/querydsl/PlaceRepositoryImpl.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/repository/querydsl/PlaceRepositoryImpl.java
@@ -100,13 +100,11 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
         boolean useFullText = length >= 2;
 
         if (useFullText) {
-            // 공백 토큰을 BOOLEAN MODE용으로 가공
             String booleanQuery = Arrays.stream(kw.split("\\s+"))
                     .filter(s -> !s.isBlank())
                     .map(tok -> sanitizeForBooleanMode(tok) + "*")
                     .collect(Collectors.joining(" "));
 
-            // ✅ 여기! 커스텀 함수(match_against) 사용
             var score = Expressions.numberTemplate(
                     Double.class,
                     "match_against({0}, {1})",
@@ -116,9 +114,9 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
             return queryFactory
                     .selectFrom(qPlace)
                     .join(qPlace.town, qTown).fetchJoin()
-                    .where(score.gt(0)) // 점수 > 0 인 것만
+                    .where(score.gt(0))
                     .orderBy(
-                            score.desc(),     // 점수순
+                            score.desc(),
                             qPlace.name.asc(),
                             qPlace.id.asc()
                     )

--- a/src/main/java/org/sopt/solply_server/domain/place/repository/querydsl/PlaceRepositoryImpl.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/repository/querydsl/PlaceRepositoryImpl.java
@@ -15,6 +15,7 @@ import org.sopt.solply_server.domain.place.entity.QPlace;
 import org.sopt.solply_server.domain.place.entity.QPlaceTag;
 import org.sopt.solply_server.domain.tag.entity.QTag;
 import org.sopt.solply_server.domain.tag.entity.TagType;
+import org.sopt.solply_server.domain.town.entity.QTown;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -83,8 +84,9 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
 //        }
 //    }
 
-    public List<Place> findPlacesByKeyword(String keyword) {
-        QPlace p = QPlace.place;
+    public List<Place> findPlacesWithTownByKeyword(String keyword) {
+        QPlace qPlace = QPlace.place;
+        QTown qTown = QTown.town;
 
         String kw = keyword == null ? "" : keyword.trim();
         if (kw.isEmpty()) return List.of();
@@ -103,15 +105,16 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
             var score = Expressions.numberTemplate(
                     Double.class,
                     "MATCH({0}) AGAINST ({1} IN BOOLEAN MODE)",
-                    p.name, booleanQuery
+                    qPlace.name, booleanQuery
             );
 
-            return queryFactory.selectFrom(p)
+            return queryFactory.selectFrom(qPlace)
+                    .join(qPlace.town, qTown).fetchJoin()
                     .where(score.gt(0))
                     .orderBy(
                             score.desc(),
-                            p.name.asc(),
-                            p.id.asc()
+                            qPlace.name.asc(),
+                            qPlace.id.asc()
                     )
                     .limit(10)
                     .fetch();
@@ -123,15 +126,16 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
             var pos = Expressions.numberTemplate(
                     Integer.class,
                     "LOCATE({0}, {1})",
-                    kw, p.name
+                    kw, qPlace.name
             );
 
-            return queryFactory.selectFrom(p)
-                    .where(Expressions.booleanTemplate("{0} LIKE {1} ESCAPE '\\\\'", p.name, pattern))
+            return queryFactory.selectFrom(qPlace)
+                    .join(qPlace.town, qTown).fetchJoin()
+                    .where(Expressions.booleanTemplate("{0} LIKE {1} ESCAPE '\\\\'", qPlace.name, pattern))
                     .orderBy(
                             pos.asc().nullsLast(),
-                            p.name.asc(),
-                            p.id.asc()
+                            qPlace.name.asc(),
+                            qPlace.id.asc()
                     )
                     .limit(10)
                     .fetch();

--- a/src/main/java/org/sopt/solply_server/domain/place/repository/querydsl/PlaceRepositoryImpl.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/repository/querydsl/PlaceRepositoryImpl.java
@@ -89,7 +89,7 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
 //        }
 //    }
 
-    public List<Place> findPlacesWithTownByKeyword(String keyword) {
+    public List<Place> findPlacesWithTownByKeyword(final String keyword) {
         QPlace qPlace = QPlace.place;
         QTown qTown = QTown.town;
 
@@ -146,7 +146,7 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
         }
     }
 
-    private String sanitizeForBooleanMode(String token) {
+    private String sanitizeForBooleanMode(final String token) {
         // BOOLEAN MODE에서 의미 있는 특수문자 제거/공백 치환
         // (+ - @ ~ < > ( ) " * 등의 혼선을 방지)
         return token.replaceAll("[+\\-@~<>\\(\\)\"*]", " ");

--- a/src/main/java/org/sopt/solply_server/domain/place/repository/querydsl/PlaceRepositoryImpl.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/repository/querydsl/PlaceRepositoryImpl.java
@@ -5,7 +5,11 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +28,7 @@ import org.springframework.stereotype.Repository;
 public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
+    private final EntityManager entityManager;
 
     public List<Place> findPlacesByConditions(PlaceSearchConditionDto condition) {
         QPlace place = QPlace.place;
@@ -96,28 +101,39 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
         boolean useFullText = length >= 2;
 
         if (useFullText) {
-            // 공백 기준으로 토큰화 후 각 토큰에 접두 와일드카드(*) 부여
-            String booleanQuery = java.util.Arrays.stream(kw.split("\\s+"))
+            String booleanQuery = Arrays.stream(kw.split("\\s+"))
                     .filter(s -> !s.isBlank())
-                    .map(t -> sanitizeForBooleanMode(t) + "*")
-                    .collect(java.util.stream.Collectors.joining(" "));
+                    .map(tok -> sanitizeForBooleanMode(tok) + "*")
+                    .collect(Collectors.joining(" "));
 
-            var score = Expressions.numberTemplate(
-                    Double.class,
-                    "MATCH({0}) AGAINST ({1} IN BOOLEAN MODE)",
-                    qPlace.name, booleanQuery
-            );
+            String sql = """
+              select p.id
+              from places p
+              where match(p.name) against (? in boolean mode)
+              order by match(p.name) against (? in boolean mode) desc, p.name asc, p.id asc
+              limit 10
+            """;
 
-            return queryFactory.selectFrom(qPlace)
+            List<?> raw = entityManager.createNativeQuery(sql)
+                    .setParameter(1, booleanQuery)
+                    .setParameter(2, booleanQuery)
+                    .getResultList();
+
+            List<Long> ids = raw.stream()
+                    .filter(Objects::nonNull)
+                    .map(o -> ((Number) o).longValue())
+                    .toList();
+
+            if (ids.isEmpty()) return List.of();
+
+            List<Place> rows = queryFactory.selectFrom(qPlace)
                     .join(qPlace.town, qTown).fetchJoin()
-                    .where(score.gt(0))
-                    .orderBy(
-                            score.desc(),
-                            qPlace.name.asc(),
-                            qPlace.id.asc()
-                    )
-                    .limit(10)
+                    .where(qPlace.id.in(ids))
                     .fetch();
+
+            Map<Long, Place> map = rows.stream().collect(Collectors.toMap(Place::getId, x -> x));
+            List<Place> ordered = ids.stream().map(map::get).filter(Objects::nonNull).toList();
+            return ordered;
         } else {
             // 1글자 → LIKE fallback
             String escaped = kw.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceBookmarkService.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceBookmarkService.java
@@ -27,9 +27,7 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class PlaceBookmarkService {
 
-    private final UserRepository userRepository;
     private final PlaceBookmarkRepository placeBookmarkRepository;
-    private final PlaceRepository placeRepository;
     private final CacheService cacheService;
     private final PlaceBookmarkRedisDataManager placeBookmarkRedisDataManager;
     private final EntityLoader entityLoader;

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceReportImageUpdater.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceReportImageUpdater.java
@@ -22,7 +22,7 @@ class PlaceReportImageUpdater implements ImageFieldUpdater {
 
     @Override
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void replaceImages(long reportId, List<String> destKeys) {
+    public void replaceImages(final long reportId, final List<String> destKeys) {
         var report = placeReportRepository.findById(reportId).orElseThrow();
         report.getImageKeys().clear();
         for (String key : new LinkedHashSet<>(destKeys)) {

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceReportService.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceReportService.java
@@ -29,7 +29,7 @@ public class PlaceReportService {
     private final ApplicationEventPublisher applicationEventPublisher;
 
     @Transactional
-    public PlaceReportCreateResponse createPlaceReport(Long userId, Long placeId, PlaceReportCreateRequest request) {
+    public PlaceReportCreateResponse createPlaceReport(final Long userId, final Long placeId, PlaceReportCreateRequest request) {
         User user = entityLoader.getUser(userId);
         Place place = entityLoader.getPlace(placeId);
 

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceRequestImageUpdater.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceRequestImageUpdater.java
@@ -24,7 +24,7 @@ class PlaceRequestImageUpdater implements ImageFieldUpdater {
 
     @Override
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void replaceImages(long requestId, List<String> destKeys) {
+    public void replaceImages(final long requestId, final List<String> destKeys) {
         var pr = placeRequestRepository.findById(requestId).orElseThrow();
         pr.getImages().clear();
         int order = 0;

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceRequestService.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceRequestService.java
@@ -40,7 +40,7 @@ public class PlaceRequestService {
     private final ApplicationEventPublisher applicationEventPublisher;
 
     @Transactional
-    public PlaceRequestCreateResponse createPlaceRequest(final Long userId, final PlaceRequestCreateRequest request) {
+    public PlaceRequestCreateResponse createPlaceRequest(final Long userId, PlaceRequestCreateRequest request) {
         log.info("장소 등록 요청 저장 시작 - placeName: {}", request.placeName());
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_USER));

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
@@ -101,7 +101,7 @@ public class PlaceService {
     /**
      * 사용자가 북마크한 장소의 썸네일 리스트 조회
      */
-    public PlaceFolderPreviewListGetResponse getBookmarkedPlaceFolderPreviewList(Long userId) {
+    public PlaceFolderPreviewListGetResponse getBookmarkedPlaceFolderPreviewList(final Long userId) {
         // Redis에서 활성화된 북마크 장소(가장 최근에 북마크한 장소들) ID 목록 가져오기
         List<PlaceBookmarkRedisDto> placeBookmarkList = placeBookmarkRedisDataManager.getActivePlaceBookmarkDtos(userId);
 
@@ -123,7 +123,7 @@ public class PlaceService {
         );
     }
 
-    public PlaceSearchResponse searchPlaces(String keyword) {
+    public PlaceSearchResponse searchPlaces(final String keyword) {
         if (InputValidator.isBlank(keyword) || keyword.length() < 2) {
             throw new BusinessException(ErrorCode.INVALID_KEYWORD);
         }
@@ -148,7 +148,7 @@ public class PlaceService {
     }
 
 
-    public List<Place> getPlacesWithTownByPlaceIds(List<Long> placeIds) {
+    public List<Place> getPlacesWithTownByPlaceIds(final List<Long> placeIds) {
         // Town 정보까지 함께 조회 (N+1 문제 방지)
         List<Place> places = placeRepository.findAllByIdsWithTown(placeIds);
 
@@ -266,7 +266,7 @@ public class PlaceService {
                 .collect(Collectors.toList());
     }
 
-    private Map<Long, Place> getPlaceMapFromBookmarks(List<PlaceBookmarkRedisDto> bookmarkDtos) {
+    private Map<Long, Place> getPlaceMapFromBookmarks(final List<PlaceBookmarkRedisDto> bookmarkDtos) {
         List<Long> placeIds = bookmarkDtos.stream()
                 .map(PlaceBookmarkRedisDto::placeId)
                 .distinct()

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
@@ -13,6 +13,7 @@ import org.sopt.solply_server.domain.place.dto.PlaceFolderPreviewDto;
 import org.sopt.solply_server.domain.place.dto.PlaceImageInfoDto;
 import org.sopt.solply_server.domain.place.dto.PlaceSearchConditionDto;
 import org.sopt.solply_server.domain.place.dto.PlacePreviewDto;
+import org.sopt.solply_server.domain.place.dto.PlaceSearchResultDto;
 import org.sopt.solply_server.domain.place.dto.response.PlaceAllGetResponse;
 import org.sopt.solply_server.domain.place.dto.response.PlaceFilterGetResponse;
 import org.sopt.solply_server.domain.place.dto.response.PlaceFolderPreviewListGetResponse;
@@ -126,16 +127,21 @@ public class PlaceService {
         if (InputValidator.isBlank(keyword) || keyword.length() < 2) {
             throw new BusinessException(ErrorCode.INVALID_KEYWORD);
         }
-        var places = placeRepository.findPlacesByKeyword(keyword);
-        List<PlacePreviewDto> placePreviews = places.stream()
-                .map(place -> PlacePreviewDto.of(
-                        place.getId(),
-                        place.getName(),
-                        imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
-                        place.getMainTag(),
-                        place.getAddress(),
-                        false // 검색 결과에서는 북마크 여부를 제공 X
-                ))
+        var places = placeRepository.findPlacesWithTownByKeyword(keyword);
+        List<PlaceSearchResultDto> placePreviews = places.stream()
+                .map(place -> {
+                        Town town = place.getTown();
+                        return PlaceSearchResultDto.of(
+                            place.getId(),
+                            place.getName(),
+                            imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
+                            place.getMainTag(),
+                            place.getAddress(),
+                            false, // 검색 결과에서는 북마크 여부를 제공 X,
+                            town.getId()
+                        );
+                    }
+                )
                 .toList();
 
         return new PlaceSearchResponse(placePreviews);

--- a/src/main/java/org/sopt/solply_server/global/config/mysql/MySqlFunctions.java
+++ b/src/main/java/org/sopt/solply_server/global/config/mysql/MySqlFunctions.java
@@ -1,0 +1,22 @@
+package org.sopt.solply_server.global.config.mysql;
+
+
+import org.hibernate.boot.model.FunctionContributions;
+import org.hibernate.boot.model.FunctionContributor;
+import org.hibernate.query.sqm.function.SqmFunctionRegistry;
+import org.hibernate.type.StandardBasicTypes;
+
+public class MySqlFunctions implements FunctionContributor {
+    @Override
+    public void contributeFunctions(FunctionContributions fc) {
+        SqmFunctionRegistry reg = fc.getFunctionRegistry();
+
+        // 반환 타입: DOUBLE
+        // 패턴 기반 등록: match(?1) against (?2 in boolean mode)
+        reg.registerPattern(
+                "match_against",
+                "match(?1) against (?2 in boolean mode)",
+                fc.getTypeConfiguration().getBasicTypeRegistry().resolve(StandardBasicTypes.DOUBLE)
+        );
+    }
+}

--- a/src/main/java/org/sopt/solply_server/global/config/mysql/MySqlFunctions.java
+++ b/src/main/java/org/sopt/solply_server/global/config/mysql/MySqlFunctions.java
@@ -11,8 +11,7 @@ public class MySqlFunctions implements FunctionContributor {
     public void contributeFunctions(FunctionContributions fc) {
         SqmFunctionRegistry reg = fc.getFunctionRegistry();
 
-        // 반환 타입: DOUBLE
-        // 패턴 기반 등록: match(?1) against (?2 in boolean mode)
+
         reg.registerPattern(
                 "match_against",
                 "match(?1) against (?2 in boolean mode)",

--- a/src/main/java/org/sopt/solply_server/global/config/mysql/MySqlFunctions.java
+++ b/src/main/java/org/sopt/solply_server/global/config/mysql/MySqlFunctions.java
@@ -11,7 +11,6 @@ public class MySqlFunctions implements FunctionContributor {
     public void contributeFunctions(FunctionContributions fc) {
         SqmFunctionRegistry reg = fc.getFunctionRegistry();
 
-
         reg.registerPattern(
                 "match_against",
                 "match(?1) against (?2 in boolean mode)",

--- a/src/main/java/org/sopt/solply_server/global/util/s3/PresignedUrlProvider.java
+++ b/src/main/java/org/sopt/solply_server/global/util/s3/PresignedUrlProvider.java
@@ -46,6 +46,7 @@ public class PresignedUrlProvider {
     }
 
 
+
 //    public PresignedUrlInfo createCategorizedUploadUrl(final ImageCategory imageCategory, final String id, final String originalFileName, final Duration ttl) {
 //        // 확장자 & MIME 확인
 //        String ext = guessExt(originalFileName);
@@ -68,7 +69,6 @@ public class PresignedUrlProvider {
 //        if (InputValidator.isBlank(fileKey)) return null;
 //
 //        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
-//                // BUGFIX: seconds면 ofSeconds 사용
 //                .signatureDuration(Duration.ofSeconds(expirationSeconds))
 //                .getObjectRequest(req -> req
 //                        .bucket(bucketName)

--- a/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
+++ b/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
@@ -1,0 +1,1 @@
+org.sopt.solply_server.global.config.mysql.MySqlFunctions


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #184


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- 처음에 MATCH(...) AGAINST(...)를 QueryDSL/HQL 안에서 그대로 쓰니까,
Hibernate 6의 HQL 파서가 AGAINST 토큰을 파싱을 못해서 SyntaxException이 터졌습니다.

- FunctionContributor를 이용해서 match_against라는 사용자 정의 함수를 등록해서, 네이티브 쿼리를 직접 호출할 필요 없이, QueryDSL 안에서 MySQL FULLTEXT 검색을 구현할 수 있게끔 했습니다.


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 원래 jmeter 데이터를 스크랩해오는 걸 세팅해놓으려고 만든 브랜치였는데, 어쩌다보니 장소 검색 관련한 작업도 같이 진행했네요
- 원래는 네이티브 쿼리로 Hibernate 6의 HQL 파서가 AGAINST 토큰을 파싱을 못하는 문제를 해결했었는데, 뭔가 마음에 안들어서 찾아보니, FunctionContributor로 MySql 함수를 직접 구현해서 등록하는 방법이 있어서, 이 방식으로 바꿨습니다.
- Place 검색 결과에서 연관된 Town 엔티티의 id를 fetch join으로 긁어오게 했습니다.
- sanitizeForBooleanMode()가 의미하는게 뭐냐면, fulltext 검색에서 기본 모드가 있고 불리언 연산자를 포함할 수 있는 검색 모드가 있는데, 각 토큰에 *를 붙여서 해당 단어로 시작하는 모든 단어를 조회해오기 위해 만든 메서드입니다.

<br/>

## 🚀 알게된 점 (선택)

---

-

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 장소 검색 결과에 동네 정보가 포함되고, 결과 구조가 개선되었습니다.
  - 풀텍스트 매칭을 활용해 검색 정확도와 정렬 품질이 향상되었습니다.
- Refactor
  - 즐겨찾기 관련 서비스 의존성을 정리하고, 메서드 시그니처를 일관성 있게 개선했습니다.
- Chores
  - 모니터링 스크랩 타깃 및 포트 구성을 업데이트했습니다.
  - 검색 관련 데이터베이스 함수 등록 설정을 추가해 안정적으로 동작하도록 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->