### PR TITLE
[FEAT] 마이페이지 관련 API 구현

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/place/dto/PlacePreviewDto.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/dto/PlacePreviewDto.java
@@ -9,7 +9,6 @@ public record PlacePreviewDto(
         String placeName,
         String thumbnailImageUrl,
         TagName primaryTag,
-        String address,
         boolean isBookmarked
 ) {
     public static PlacePreviewDto of(
@@ -17,7 +16,6 @@ public record PlacePreviewDto(
             String placeName,
             String thumbnailImageUrl,
             TagName primaryTag,
-            String address,
             boolean isBookmarked
     ) {
         return PlacePreviewDto.builder()
@@ -25,7 +23,6 @@ public record PlacePreviewDto(
                 .placeName(placeName)
                 .thumbnailImageUrl(thumbnailImageUrl)
                 .primaryTag(primaryTag)
-                .address(address)
                 .isBookmarked(isBookmarked)
                 .build();
     }

--- a/src/main/java/org/sopt/solply_server/domain/place/entity/Place.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/entity/Place.java
@@ -31,6 +31,7 @@ import org.sopt.solply_server.domain.tag.entity.Tag;
 import org.sopt.solply_server.domain.tag.entity.TagName;
 import org.sopt.solply_server.domain.tag.entity.TagType;
 import org.sopt.solply_server.domain.town.entity.Town;
+import org.sopt.solply_server.domain.user.entity.User;
 import org.sopt.solply_server.global.entity.BaseTimeEntity;
 import org.sopt.solply_server.global.exception.BusinessException;
 import org.sopt.solply_server.global.exception.ErrorCode;
@@ -97,6 +98,9 @@ public class Place extends BaseTimeEntity {
     @JoinColumn(name = "town_id", nullable = false)
     private Town town;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by", nullable = false)
+    private User createdBy;
 
     // === 편의 메서드 추가 ===
 

--- a/src/main/java/org/sopt/solply_server/domain/place/entity/Place.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/entity/Place.java
@@ -42,7 +42,8 @@ import org.sopt.solply_server.global.exception.ErrorCode;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "places",
         indexes = {
-                @Index(name = "idx_places_town_id", columnList = "town_id")
+                @Index(name = "idx_places_town_id", columnList = "town_id"),
+                @Index(name = "idx_places_created_by_created_at", columnList = "created_by, created_at")
         }
 )
 public class Place extends BaseTimeEntity {

--- a/src/main/java/org/sopt/solply_server/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/repository/PlaceRepository.java
@@ -3,8 +3,10 @@ package org.sopt.solply_server.domain.place.repository;
 import com.querydsl.core.Fetchable;
 import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
+import java.util.Optional;
 import org.sopt.solply_server.domain.place.entity.Place;
 import org.sopt.solply_server.domain.place.repository.querydsl.PlaceRepositoryCustom;
+import org.sopt.solply_server.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -23,4 +25,6 @@ public interface PlaceRepository extends JpaRepository<Place, Long>, PlaceReposi
 
     @Query("SELECT p FROM Place p WHERE p.id IN :placeIds")
     List<Place> findByIdIn(@Param("placeIds") List<Long> placeIds);
+
+    List<Place> findTop3ByCreatedByOrderByCreatedAtDesc(User createdBy);
 }

--- a/src/main/java/org/sopt/solply_server/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/repository/PlaceRepository.java
@@ -1,12 +1,12 @@
 package org.sopt.solply_server.domain.place.repository;
 
-import com.querydsl.core.Fetchable;
 import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
-import java.util.Optional;
 import org.sopt.solply_server.domain.place.entity.Place;
 import org.sopt.solply_server.domain.place.repository.querydsl.PlaceRepositoryCustom;
 import org.sopt.solply_server.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -27,4 +27,6 @@ public interface PlaceRepository extends JpaRepository<Place, Long>, PlaceReposi
     List<Place> findByIdIn(@Param("placeIds") List<Long> placeIds);
 
     List<Place> findTop3ByCreatedByOrderByCreatedAtDesc(User createdBy);
+
+    Page<Place> findByCreatedByIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
 }

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
@@ -89,7 +89,6 @@ public class PlaceService {
                         place.getName(),
                         imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
                         place.getMainTag(),
-                        place.getAddress(),
                         placeBookmarkService.isBookmarked(userId, place.getId())
                 ))
                 .toList();

--- a/src/main/java/org/sopt/solply_server/domain/user/controller/UserController.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/controller/UserController.java
@@ -1,7 +1,5 @@
 package org.sopt.solply_server.domain.user.controller;
 
-import static org.springframework.data.domain.Sort.Direction.DESC;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -9,6 +7,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
+import org.sopt.solply_server.domain.user.dto.request.UserWithdrawRequest;
 import org.sopt.solply_server.domain.user.dto.request.UserTownsUpdateRequest;
 import org.sopt.solply_server.domain.user.dto.response.NicknameCheckResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserProfileGetResponse;
@@ -18,9 +17,6 @@ import org.sopt.solply_server.domain.user.dto.response.UserTownsUpdateResponse;
 import org.sopt.solply_server.domain.user.service.UserService;
 import org.sopt.solply_server.global.annotation.CurrentUserId;
 import org.sopt.solply_server.global.dto.CustomApiResponse;
-import org.sopt.solply_server.global.dto.PagedResponse;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -83,6 +79,15 @@ public class UserController {
             @RequestParam(defaultValue = "100") int size) {
         return CustomApiResponse.success("유저가 등록한 장소 조회에 성공했습니다.",
                 userService.getPlacesCreatedBy(userId, page, size));
+    }
+
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<CustomApiResponse<Void>> withdrawUser(
+            @CurrentUserId Long userId,
+            @RequestBody @Valid UserWithdrawRequest request
+    ) {
+        userService.withdraw(userId, request);
+        return CustomApiResponse.success("회원 탈퇴에 성공했습니다", null);
     }
 
 }

--- a/src/main/java/org/sopt/solply_server/domain/user/controller/UserController.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/controller/UserController.java
@@ -1,5 +1,7 @@
 package org.sopt.solply_server.domain.user.controller;
 
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -10,11 +12,15 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.solply_server.domain.user.dto.request.UserTownsUpdateRequest;
 import org.sopt.solply_server.domain.user.dto.response.NicknameCheckResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserProfileGetResponse;
+import org.sopt.solply_server.domain.user.dto.response.UserRequestedPlaceAllGetResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserTownGetResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserTownsUpdateResponse;
 import org.sopt.solply_server.domain.user.service.UserService;
 import org.sopt.solply_server.global.annotation.CurrentUserId;
 import org.sopt.solply_server.global.dto.CustomApiResponse;
+import org.sopt.solply_server.global.dto.PagedResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -68,6 +74,14 @@ public class UserController {
     ) {
         return CustomApiResponse.success("유저의 동네 정보 조회에 성공하였습니다.",
                 userService.getTownsRelatedUser(userId));
+    }
+
+    @GetMapping("/{userId}/places")
+    public ResponseEntity<CustomApiResponse<UserRequestedPlaceAllGetResponse>> getMyPlaces(
+            @PathVariable Long userId,
+            @PageableDefault(size = 100, sort = "createdAt", direction = DESC) Pageable pageable) {
+        return CustomApiResponse.success("유저가 등록한 장소 조회에 성공했습니다.",
+                userService.getPlacesCreatedBy(userId, pageable));
     }
 
 }

--- a/src/main/java/org/sopt/solply_server/domain/user/controller/UserController.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/controller/UserController.java
@@ -14,7 +14,9 @@ import org.sopt.solply_server.domain.user.dto.response.UserProfileGetResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserRequestedPlaceAllGetResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserTownGetResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserTownsUpdateResponse;
+import org.sopt.solply_server.domain.user.dto.response.UserWithdrawReasonAllGetResponse;
 import org.sopt.solply_server.domain.user.service.UserService;
+import org.sopt.solply_server.domain.user.service.UserWithdrawService;
 import org.sopt.solply_server.global.annotation.CurrentUserId;
 import org.sopt.solply_server.global.dto.CustomApiResponse;
 import org.springframework.http.ResponseEntity;
@@ -29,6 +31,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+    private final UserWithdrawService userWithdrawService;
 
     @Operation(summary = "닉네임 중복 검사", description = "닉네임 사용 가능 여부를 확인합니다.")
     @GetMapping("/check-nickname")
@@ -72,6 +75,7 @@ public class UserController {
                 userService.getTownsRelatedUser(userId));
     }
 
+    @Operation(summary = "유저가 등록한 장소 조회", description = "특정 유저가 등록한 장소들을 조회합니다.")
     @GetMapping("/{userId}/places")
     public ResponseEntity<CustomApiResponse<UserRequestedPlaceAllGetResponse>> getMyPlaces(
             @PathVariable Long userId,
@@ -81,6 +85,14 @@ public class UserController {
                 userService.getPlacesCreatedBy(userId, page, size));
     }
 
+    @Operation(summary = "회원 탈퇴 사유 리스트 조회", description = "회원 탈퇴 사유 리스트를 조회합니다.")
+    @GetMapping("/withdraw/reasons")
+    public ResponseEntity<CustomApiResponse<UserWithdrawReasonAllGetResponse>> getUserWithdrawReasons() {
+        return CustomApiResponse.success("회원 탈퇴 사유 리스트 조회에 성공했습니다",
+                userWithdrawService.getAllUserWithdrawReasons());
+    }
+
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 진행합니다.")
     @DeleteMapping("/withdraw")
     public ResponseEntity<CustomApiResponse<Void>> withdrawUser(
             @CurrentUserId Long userId,

--- a/src/main/java/org/sopt/solply_server/domain/user/controller/UserController.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/controller/UserController.java
@@ -79,9 +79,10 @@ public class UserController {
     @GetMapping("/{userId}/places")
     public ResponseEntity<CustomApiResponse<UserRequestedPlaceAllGetResponse>> getMyPlaces(
             @PathVariable Long userId,
-            @PageableDefault(size = 100, sort = "createdAt", direction = DESC) Pageable pageable) {
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "100") int size) {
         return CustomApiResponse.success("유저가 등록한 장소 조회에 성공했습니다.",
-                userService.getPlacesCreatedBy(userId, pageable));
+                userService.getPlacesCreatedBy(userId, page, size));
     }
 
 }

--- a/src/main/java/org/sopt/solply_server/domain/user/dto/UserPlacePreviewDto.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/dto/UserPlacePreviewDto.java
@@ -1,0 +1,20 @@
+package org.sopt.solply_server.domain.user.dto;
+
+public record UserPlacePreviewDto(
+        long placeId,
+        String placeName,
+        String thumbnailImageUrl
+) {
+    public static UserPlacePreviewDto of(
+            long placeId,
+            String placeName,
+            String thumbnailImageUrl
+    ) {
+        return new UserPlacePreviewDto(
+                placeId,
+                placeName,
+                thumbnailImageUrl
+        );
+    }
+
+}

--- a/src/main/java/org/sopt/solply_server/domain/user/dto/WithdrawReasonDto.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/dto/WithdrawReasonDto.java
@@ -1,0 +1,14 @@
+package org.sopt.solply_server.domain.user.dto;
+
+import org.sopt.solply_server.domain.user.entity.WithdrawReason;
+
+public record WithdrawReasonDto(
+        String withdrawType,
+        String description
+) {
+    public static WithdrawReasonDto from(WithdrawReason withdrawReason) {
+        return new WithdrawReasonDto(
+                withdrawReason.name(), withdrawReason.getDescription()
+        );
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/user/dto/request/UserWithdrawRequest.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/dto/request/UserWithdrawRequest.java
@@ -1,0 +1,17 @@
+package org.sopt.solply_server.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import org.sopt.solply_server.domain.user.entity.WithdrawReason;
+
+public record UserWithdrawRequest(
+        @Schema(description = "탈퇴 사유", example = "NOT_USE( \"자주 사용하지 않아서\") /"
+                + " DEFICIENT_INFO(\"원하는 지역과 장소가 부족해서\") /"
+                + " INCONVENIENT(\"앱 기능이 불편해서\") /"
+                + " HATE_RECOMMEND(\"추천 콘텐츠가 나와 맞지 않아서\") /"
+                + " USE_OTHER_SERVICE(\"다른 서비스를 사용하고 있습니다.\"),"
+                + " OTHERS(\"기타 (직접 입력)\")", required = true)
+        @NotNull WithdrawReason withdrawReason,
+        String reasonText
+) {
+}

--- a/src/main/java/org/sopt/solply_server/domain/user/dto/response/UserProfileGetResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/dto/response/UserProfileGetResponse.java
@@ -1,5 +1,7 @@
 package org.sopt.solply_server.domain.user.dto.response;
 
+import java.util.List;
+import org.sopt.solply_server.domain.user.dto.UserPlacePreviewDto;
 import org.sopt.solply_server.domain.user.dto.UserTownInfoDto;
 import org.sopt.solply_server.domain.user.entity.User;
 import org.sopt.solply_server.domain.user.entity.UserPersona;
@@ -8,14 +10,17 @@ public record UserProfileGetResponse(
         Long userId,
         String nickname,
         UserTownInfoDto selectedTown,
-        UserPersona persona
+        UserPersona persona,
+        List<UserPlacePreviewDto> myPlacePreviews
 ) {
-    public static UserProfileGetResponse of(User user, UserTownInfoDto selectedTown) {
+    public static UserProfileGetResponse of(User user, UserTownInfoDto selectedTown,
+            List<UserPlacePreviewDto> myPlacePreviews) {
         return new UserProfileGetResponse(
                 user.getId(),
                 user.getNickname(),
                 selectedTown,
-                user.getPersona()
+                user.getPersona(),
+                myPlacePreviews
         );
     }
 }

--- a/src/main/java/org/sopt/solply_server/domain/user/dto/response/UserRequestedPlaceAllGetResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/dto/response/UserRequestedPlaceAllGetResponse.java
@@ -1,0 +1,11 @@
+package org.sopt.solply_server.domain.user.dto.response;
+
+import org.sopt.solply_server.domain.place.dto.PlacePreviewDto;
+import org.sopt.solply_server.global.dto.PagedResponse;
+import org.springframework.data.domain.Page;
+
+public record UserRequestedPlaceAllGetResponse(
+    PagedResponse<PlacePreviewDto> content
+) {
+
+}

--- a/src/main/java/org/sopt/solply_server/domain/user/dto/response/UserWithdrawReasonAllGetResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/dto/response/UserWithdrawReasonAllGetResponse.java
@@ -1,0 +1,9 @@
+package org.sopt.solply_server.domain.user.dto.response;
+
+import java.util.List;
+import org.sopt.solply_server.domain.user.dto.WithdrawReasonDto;
+
+public record UserWithdrawReasonAllGetResponse(
+        List<WithdrawReasonDto> description
+) {
+}

--- a/src/main/java/org/sopt/solply_server/domain/user/entity/SocialUserInfo.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/entity/SocialUserInfo.java
@@ -2,6 +2,8 @@ package org.sopt.solply_server.domain.user.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import org.sopt.solply_server.domain.auth.entity.SocialPlatform;
 import org.sopt.solply_server.global.entity.BaseTimeEntity;
 
@@ -34,6 +36,9 @@ public class SocialUserInfo extends BaseTimeEntity {
 
     @Column(nullable = false, unique = true, length = 100)
     private String socialCode;
+
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted = false;
 
     // 정적 팩토리 메서드
     public static SocialUserInfo create(User user, SocialPlatform platform, String socialId) {

--- a/src/main/java/org/sopt/solply_server/domain/user/entity/User.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/entity/User.java
@@ -1,11 +1,14 @@
 package org.sopt.solply_server.domain.user.entity;
 
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import org.sopt.solply_server.domain.town.entity.Town;
 import org.sopt.solply_server.global.jwt.dto.TokenCollectionDto;
 
@@ -14,6 +17,8 @@ import org.sopt.solply_server.global.jwt.dto.TokenCollectionDto;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE users SET is_deleted = true, deleted_at = NOW() WHERE id = ?")
+@Where(clause = "is_deleted = false")
 @Table(name = "users")
 public class User {
 
@@ -32,6 +37,11 @@ public class User {
 
     @Enumerated(EnumType.STRING)
     private UserPersona persona;
+
+    @Column(nullable = false)
+    private boolean isDeleted = false;
+
+    private LocalDateTime deletedAt;
 
     private Long selectedTownId; // 사용자가 선택한 동네 ID
 

--- a/src/main/java/org/sopt/solply_server/domain/user/entity/UserWithdraw.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/entity/UserWithdraw.java
@@ -1,0 +1,50 @@
+package org.sopt.solply_server.domain.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_withdraws")
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@AllArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class UserWithdraw {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reason", nullable = false)
+    private WithdrawReason reason;
+
+    @Column(name = "reason_text")
+    private String reasonText;
+
+    @Column(name = "withdrawn_at", nullable = false)
+    private LocalDateTime withdrawnAt = LocalDateTime.now();
+
+    public static UserWithdraw create(User user, WithdrawReason reason, String reasonText) {
+        UserWithdraw userWithdraw = new UserWithdraw();
+        userWithdraw.user = user;
+        userWithdraw.reason = reason;
+        userWithdraw.reasonText = reasonText;
+        return userWithdraw;
+    }
+
+}

--- a/src/main/java/org/sopt/solply_server/domain/user/entity/WithdrawReason.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/entity/WithdrawReason.java
@@ -1,5 +1,6 @@
 package org.sopt.solply_server.domain.user.entity;
 
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/org/sopt/solply_server/domain/user/entity/WithdrawReason.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/entity/WithdrawReason.java
@@ -1,0 +1,18 @@
+package org.sopt.solply_server.domain.user.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum WithdrawReason {
+    NOT_USE( "자주 사용하지 않아서"),
+    DEFICIENT_INFO("원하는 지역과 장소가 부족해서"),
+    INCONVENIENT("앱 기능이 불편해서"),
+    HATE_RECOMMEND("추천 콘텐츠가 나와 맞지 않아서"),
+    USE_OTHER_SERVICE("다른 서비스를 사용하고 있습니다."),
+    OTHERS("기타");
+
+    private final String description;
+
+}

--- a/src/main/java/org/sopt/solply_server/domain/user/repository/SocialUserInfoRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/repository/SocialUserInfoRepository.java
@@ -3,8 +3,14 @@ package org.sopt.solply_server.domain.user.repository;
 import java.util.Optional;
 import org.sopt.solply_server.domain.user.entity.SocialUserInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface SocialUserInfoRepository extends JpaRepository<SocialUserInfo, Long> {
 
     Optional<SocialUserInfo> findBySocialCode(String socialCode);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update SocialUserInfo s set s.isDeleted = true where s.user.id = :userId")
+    void softDeleteByUserId(Long userId);
 }

--- a/src/main/java/org/sopt/solply_server/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/repository/UserRepository.java
@@ -2,10 +2,23 @@ package org.sopt.solply_server.domain.user.repository;
 
 import org.sopt.solply_server.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
     User findByEmail(String email);
 
     boolean existsByNickname(String nickname);
+
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+       update User u
+          set u.email = :email,
+              u.nickname = :nickname,
+              u.isNewUser = true
+        where u.id = :userId
+    """)
+    void withdraw(Long userId, String email, String nickname);
 }

--- a/src/main/java/org/sopt/solply_server/domain/user/repository/UserWithdrawRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/repository/UserWithdrawRepository.java
@@ -1,0 +1,8 @@
+package org.sopt.solply_server.domain.user.repository;
+
+import org.sopt.solply_server.domain.user.entity.UserWithdraw;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserWithdrawRepository extends JpaRepository<UserWithdraw, Long> {
+
+}

--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
@@ -21,6 +21,7 @@ import org.sopt.solply_server.global.exception.BusinessException;
 import org.sopt.solply_server.global.exception.ErrorCode;
 import org.sopt.solply_server.global.util.EntityLoader;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -104,7 +105,8 @@ public class UserService {
         return UserTownGetResponse.of(selectedTown);
     }
 
-    public UserRequestedPlaceAllGetResponse getPlacesCreatedBy(Long userId, Pageable pageable) {
+    public UserRequestedPlaceAllGetResponse getPlacesCreatedBy(final Long userId, final int page, final int size) {
+        Pageable pageable = PageRequest.of(page, size);
         Page<PlacePreviewDto> places = myPageFacade.getPlacesCreatedBy(userId, pageable);
         return new UserRequestedPlaceAllGetResponse(
                 new PagedResponse<>(

--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
@@ -8,6 +8,7 @@ import org.sopt.solply_server.domain.place.dto.PlacePreviewDto;
 import org.sopt.solply_server.domain.town.entity.Town;
 import org.sopt.solply_server.domain.user.dto.UserPlacePreviewDto;
 import org.sopt.solply_server.domain.user.dto.UserTownInfoDto;
+import org.sopt.solply_server.domain.user.dto.request.UserWithdrawRequest;
 import org.sopt.solply_server.domain.user.dto.request.UserTownsUpdateRequest;
 import org.sopt.solply_server.domain.user.dto.response.NicknameCheckResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserProfileGetResponse;
@@ -15,6 +16,11 @@ import org.sopt.solply_server.domain.user.dto.response.UserRequestedPlaceAllGetR
 import org.sopt.solply_server.domain.user.dto.response.UserTownGetResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserTownsUpdateResponse;
 import org.sopt.solply_server.domain.user.entity.User;
+import org.sopt.solply_server.domain.user.entity.UserWithdraw;
+import org.sopt.solply_server.domain.user.entity.WithdrawReason;
+import org.sopt.solply_server.domain.user.repository.SocialUserInfoRepository;
+import org.sopt.solply_server.domain.user.repository.UserRepository;
+import org.sopt.solply_server.domain.user.repository.UserWithdrawRepository;
 import org.sopt.solply_server.domain.user.service.mypage.MyPageFacade;
 import org.sopt.solply_server.global.dto.PagedResponse;
 import org.sopt.solply_server.global.exception.BusinessException;
@@ -36,6 +42,9 @@ public class UserService {
     private final UserInterestTownService userInterestTownService;
     private final EntityLoader entityLoader;
     private final MyPageFacade myPageFacade;
+    private final UserRepository userRepository;
+    private final UserWithdrawRepository userWithdrawRepository;
+    private final SocialUserInfoRepository socialUserInfoRepository;
 
     public NicknameCheckResponse checkNickname(Long userId, String nickname) {
         User user = entityLoader.getUser(userId);
@@ -118,5 +127,26 @@ public class UserService {
                         places.isLast()
                 )
         );
+    }
+
+    @Transactional
+    public void withdraw(Long userId, UserWithdrawRequest userWithdrawRequest) {
+        User user = entityLoader.getUser(userId);
+        // 기타 사유 검증
+        if (userWithdrawRequest.withdrawReason() == WithdrawReason.OTHERS) {
+            if (userWithdrawRequest.reasonText() == null || userWithdrawRequest.reasonText().isBlank()) {
+                throw new BusinessException(ErrorCode.INVALID_REQUEST_BODY);
+            }
+        }
+
+        userWithdrawRepository.save(UserWithdraw.create(user, userWithdrawRequest.withdrawReason(), userWithdrawRequest.reasonText()));
+
+        socialUserInfoRepository.softDeleteByUserId(userId);
+        String suffix = String.valueOf(userId);
+        String email = "deleted+" + suffix + "@example.com";
+        String nickname = "탈퇴회원_" + suffix;
+        userRepository.withdraw(userId, email, nickname);
+
+        userRepository.delete(user);
     }
 }

--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
@@ -4,7 +4,9 @@ import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import lombok.RequiredArgsConstructor;
+import org.sopt.solply_server.domain.place.repository.PlaceRepository;
 import org.sopt.solply_server.domain.town.entity.Town;
+import org.sopt.solply_server.domain.user.dto.UserPlacePreviewDto;
 import org.sopt.solply_server.domain.user.dto.UserTownInfoDto;
 import org.sopt.solply_server.domain.user.dto.request.UserTownsUpdateRequest;
 import org.sopt.solply_server.domain.user.dto.response.NicknameCheckResponse;
@@ -12,6 +14,7 @@ import org.sopt.solply_server.domain.user.dto.response.UserProfileGetResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserTownGetResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserTownsUpdateResponse;
 import org.sopt.solply_server.domain.user.entity.User;
+import org.sopt.solply_server.domain.user.service.mypage.MyPageFacade;
 import org.sopt.solply_server.global.exception.BusinessException;
 import org.sopt.solply_server.global.exception.ErrorCode;
 import org.sopt.solply_server.global.util.EntityLoader;
@@ -27,6 +30,7 @@ public class UserService {
     private final UserValidator userValidator;
     private final UserInterestTownService userInterestTownService;
     private final EntityLoader entityLoader;
+    private final MyPageFacade myPageFacade;
 
     public NicknameCheckResponse checkNickname(Long userId, String nickname) {
         User user = entityLoader.getUser(userId);
@@ -46,7 +50,18 @@ public class UserService {
             throw new BusinessException(ErrorCode.NOT_FOUND_USER_SELECTED_TOWN);
         }
         Town selectedTown = entityLoader.getTown(user.getSelectedTownId());
-        return UserProfileGetResponse.of(user, UserTownInfoDto.of(selectedTown.getId(), selectedTown.getName()));
+
+        List<UserPlacePreviewDto> myPlacePreviews = myPageFacade.getMyPlacesTop3(user)
+                .stream()
+                .map(place -> UserPlacePreviewDto.of(
+                        place.getId(),
+                        place.getName(),
+                        place.getThumbnailFileKey()
+                ))
+                .toList();
+
+        return UserProfileGetResponse.of(
+                user, UserTownInfoDto.of(selectedTown.getId(), selectedTown.getName()), myPlacePreviews);
     }
 
 

--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
@@ -4,20 +4,24 @@ import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import lombok.RequiredArgsConstructor;
-import org.sopt.solply_server.domain.place.repository.PlaceRepository;
+import org.sopt.solply_server.domain.place.dto.PlacePreviewDto;
 import org.sopt.solply_server.domain.town.entity.Town;
 import org.sopt.solply_server.domain.user.dto.UserPlacePreviewDto;
 import org.sopt.solply_server.domain.user.dto.UserTownInfoDto;
 import org.sopt.solply_server.domain.user.dto.request.UserTownsUpdateRequest;
 import org.sopt.solply_server.domain.user.dto.response.NicknameCheckResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserProfileGetResponse;
+import org.sopt.solply_server.domain.user.dto.response.UserRequestedPlaceAllGetResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserTownGetResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserTownsUpdateResponse;
 import org.sopt.solply_server.domain.user.entity.User;
 import org.sopt.solply_server.domain.user.service.mypage.MyPageFacade;
+import org.sopt.solply_server.global.dto.PagedResponse;
 import org.sopt.solply_server.global.exception.BusinessException;
 import org.sopt.solply_server.global.exception.ErrorCode;
 import org.sopt.solply_server.global.util.EntityLoader;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -98,5 +102,19 @@ public class UserService {
 //                .toList();
 
         return UserTownGetResponse.of(selectedTown);
+    }
+
+    public UserRequestedPlaceAllGetResponse getPlacesCreatedBy(Long userId, Pageable pageable) {
+        Page<PlacePreviewDto> places = myPageFacade.getPlacesCreatedBy(userId, pageable);
+        return new UserRequestedPlaceAllGetResponse(
+                new PagedResponse<>(
+                        places.getContent(),
+                        places.getNumber(),
+                        places.getSize(),
+                        places.getTotalElements(),
+                        places.getTotalPages(),
+                        places.isLast()
+                )
+        );
     }
 }

--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserWithdrawService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserWithdrawService.java
@@ -1,0 +1,27 @@
+package org.sopt.solply_server.domain.user.service;
+
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.solply_server.domain.user.dto.WithdrawReasonDto;
+import org.sopt.solply_server.domain.user.dto.response.UserWithdrawReasonAllGetResponse;
+import org.sopt.solply_server.domain.user.entity.WithdrawReason;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserWithdrawService {
+
+    public UserWithdrawReasonAllGetResponse getAllUserWithdrawReasons() {
+        List<WithdrawReasonDto> withdrawReasonDtos = Arrays.stream(WithdrawReason.values())
+                .map(WithdrawReasonDto::from)
+                .toList();
+        return new UserWithdrawReasonAllGetResponse(
+                withdrawReasonDtos
+        );
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/user/service/mypage/MyPageFacade.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/mypage/MyPageFacade.java
@@ -2,10 +2,13 @@ package org.sopt.solply_server.domain.user.service.mypage;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.sopt.solply_server.domain.place.dto.PlacePreviewDto;
 import org.sopt.solply_server.domain.place.entity.Place;
 import org.sopt.solply_server.domain.place.repository.PlaceRepository;
-import org.sopt.solply_server.domain.user.dto.UserPlacePreviewDto;
 import org.sopt.solply_server.domain.user.entity.User;
+import org.sopt.solply_server.global.util.s3.ImageUrlProvider;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,10 +17,24 @@ import org.springframework.transaction.annotation.Transactional;
 public class MyPageFacade {
 
     private final PlaceRepository placeRepository;
+    private final ImageUrlProvider imageUrlProvider;
 
     @Transactional(readOnly = true)
     public List<Place> getMyPlacesTop3(User user) {
         return placeRepository.findTop3ByCreatedByOrderByCreatedAtDesc(user);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<PlacePreviewDto> getPlacesCreatedBy(Long userId, Pageable pageable) {
+        Page<Place> places = placeRepository.findByCreatedByIdOrderByCreatedAtDesc(userId, pageable);
+        return places.map(place -> PlacePreviewDto.of(
+                    place.getId(),
+                    place.getName(),
+                    imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
+                    place.getMainTag(),
+                    false // isBookmarked 정보는 여기에 포함되지 않음
+                )
+        );
     }
 
 }

--- a/src/main/java/org/sopt/solply_server/domain/user/service/mypage/MyPageFacade.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/mypage/MyPageFacade.java
@@ -1,0 +1,23 @@
+package org.sopt.solply_server.domain.user.service.mypage;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.solply_server.domain.place.entity.Place;
+import org.sopt.solply_server.domain.place.repository.PlaceRepository;
+import org.sopt.solply_server.domain.user.dto.UserPlacePreviewDto;
+import org.sopt.solply_server.domain.user.entity.User;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class MyPageFacade {
+
+    private final PlaceRepository placeRepository;
+
+    @Transactional(readOnly = true)
+    public List<Place> getMyPlacesTop3(User user) {
+        return placeRepository.findTop3ByCreatedByOrderByCreatedAtDesc(user);
+    }
+
+}

--- a/src/main/java/org/sopt/solply_server/global/dto/PagedResponse.java
+++ b/src/main/java/org/sopt/solply_server/global/dto/PagedResponse.java
@@ -1,0 +1,13 @@
+package org.sopt.solply_server.global.dto;
+
+import java.util.List;
+
+public record PagedResponse<T> (
+        List<T> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean last
+) {
+}

--- a/src/main/resources/db/migration/V4__add_created_by_to_places.sql
+++ b/src/main/resources/db/migration/V4__add_created_by_to_places.sql
@@ -1,0 +1,12 @@
+DELETE FROM users;
+
+ALTER TABLE users AUTO_INCREMENT = 1;
+
+INSERT INTO users (id, nickname, email, is_new_user, persona, selected_town_id)
+    VALUES (1, 'admin', 'admin@example.com', false, null, NULL);
+
+ALTER TABLE places ADD COLUMN created_by BIGINT NOT NULL DEFAULT 1;
+
+UPDATE places SET created_by = 1;
+
+ALTER TABLE places ADD CONSTRAINT fk_places_created_by FOREIGN KEY (created_by) REFERENCES users(id);

--- a/src/main/resources/db/migration/V4__add_created_by_to_places.sql
+++ b/src/main/resources/db/migration/V4__add_created_by_to_places.sql
@@ -10,3 +10,5 @@ ALTER TABLE places ADD COLUMN created_by BIGINT NOT NULL DEFAULT 1;
 UPDATE places SET created_by = 1;
 
 ALTER TABLE places ADD CONSTRAINT fk_places_created_by FOREIGN KEY (created_by) REFERENCES users(id);
+
+CREATE INDEX idx_places_created_by_created_at ON places (created_by, created_at DESC, id DESC);

--- a/src/main/resources/db/migration/V5__add_user_withdraw.sql
+++ b/src/main/resources/db/migration/V5__add_user_withdraw.sql
@@ -1,0 +1,20 @@
+ALTER TABLE users
+    ADD COLUMN is_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE users
+    ADD COLUMN deleted_at TIMESTAMP NULL AFTER is_deleted;
+
+ALTER TABLE social_user_info ADD COLUMN is_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE TABLE user_withdraws (
+                                id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                user_id BIGINT NOT NULL,
+                                reason VARCHAR(32) NOT NULL,
+                                reason_text VARCHAR(1000) NULL,
+                                user_agent VARCHAR(255) NULL,
+                                ip_address VARCHAR(45) NULL,
+                                withdrawn_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                CONSTRAINT fk_user_withdraws_user
+                                    FOREIGN KEY (user_id) REFERENCES users(id)
+                                        ON DELETE CASCADE
+);


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #186 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- 회원 탈퇴(soft delete)
- 회원 탈퇴 사유 리스트 조회
- 내가 등록한 장소 리스트 조회


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 어떤 도메인에 둬야할지 고민이 많았는데, 유저 도메인 쪽으로 두기로 결정했고, 의존성 주입이 섞이는 경우는 파사드 패턴 활용해서 해봤는데, 현재 아키텍쳐 한계라 완벽한 분리는 좀 어렵네요
- 회원 탈퇴도 완전 삭제가 아닌 soft delete 방식으로 진행했습니다.

<br/>

## 🚀 알게된 점 (선택)

---

-

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 사용자가 등록한 장소 목록 조회 API(페이지네이션) 추가
  - 회원 탈퇴 사유 조회 API 추가
  - 회원 탈퇴 API 추가
  - 프로필에서 내가 등록한 장소 미리보기 최대 3개 노출

- 변경 사항
  - 장소 미리보기에서 주소 항목 제거로 화면 단순화
  - 계정 탈퇴 시 데이터가 안전하게 비활성화되도록 처리(소프트 삭제)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->