### PR TITLE
[FIX] 유저 정보 조회 dto 필드 매칭 오류 수정

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/user/dto/response/UserProfileGetResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/dto/response/UserProfileGetResponse.java
@@ -18,8 +18,8 @@ public record UserProfileGetResponse(
             List<UserPlacePreviewDto> myPlacePreviews) {
         return new UserProfileGetResponse(
                 user.getId(),
-                profileImageUrl,
                 user.getNickname(),
+                profileImageUrl,
                 selectedTown,
                 user.getPersona(),
                 myPlacePreviews


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

-  짜잘한 실수입니다 ㅎ..


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
-

<br/>

## 🚀 알게된 점 (선택)

---

-

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 사용자 프로필 조회 시 닉네임과 프로필 이미지가 서로 바뀌어 표시되던 문제를 수정했습니다. 이제 프로필 화면, 사용자 목록, 댓글/피드 등 전반에서 올바른 닉네임과 이미지가 일관되게 노출됩니다. 캐시 상태와 무관하게 정확한 정보가 표시되어 혼동이 줄어듭니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->