### PR TITLE
[FEAT] 장소 조회 시 townId도 추가

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/place/dto/PlacePreviewDto.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/dto/PlacePreviewDto.java
@@ -9,14 +9,16 @@ public record PlacePreviewDto(
         String placeName,
         String thumbnailImageUrl,
         TagName primaryTag,
-        boolean isBookmarked
+        boolean isBookmarked,
+        long townId
 ) {
     public static PlacePreviewDto of(
             long placeId,
             String placeName,
             String thumbnailImageUrl,
             TagName primaryTag,
-            boolean isBookmarked
+            boolean isBookmarked,
+            long townId
     ) {
         return PlacePreviewDto.builder()
                 .placeId(placeId)
@@ -24,6 +26,7 @@ public record PlacePreviewDto(
                 .thumbnailImageUrl(thumbnailImageUrl)
                 .primaryTag(primaryTag)
                 .isBookmarked(isBookmarked)
+                .townId(townId)
                 .build();
     }
 }

--- a/src/main/java/org/sopt/solply_server/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/repository/PlaceRepository.java
@@ -28,5 +28,4 @@ public interface PlaceRepository extends JpaRepository<Place, Long>, PlaceReposi
 
     List<Place> findTop3ByCreatedByOrderByCreatedAtDesc(User createdBy);
 
-    Page<Place> findByCreatedByIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
 }

--- a/src/main/java/org/sopt/solply_server/domain/place/repository/querydsl/PlaceRepositoryCustom.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/repository/querydsl/PlaceRepositoryCustom.java
@@ -3,8 +3,11 @@ package org.sopt.solply_server.domain.place.repository.querydsl;
 import java.util.List;
 import org.sopt.solply_server.domain.place.dto.PlaceSearchConditionDto;
 import org.sopt.solply_server.domain.place.entity.Place;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface PlaceRepositoryCustom {
     List<Place> findPlacesByConditions(PlaceSearchConditionDto placeSearchConditionDto);
     List<Place> findPlacesWithTownByKeyword(String keyword);
+    Page<Place> findByUserIdWithTown(Long userId, Pageable pageable);
 }

--- a/src/main/java/org/sopt/solply_server/domain/place/repository/querydsl/PlaceRepositoryImpl.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/repository/querydsl/PlaceRepositoryImpl.java
@@ -1,9 +1,13 @@
 package org.sopt.solply_server.domain.place.repository.querydsl;
 
+import static org.sopt.solply_server.domain.place.entity.QPlace.place;
+import static org.sopt.solply_server.domain.town.entity.QTown.town;
+
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import java.util.Arrays;
@@ -20,6 +24,9 @@ import org.sopt.solply_server.domain.place.entity.QPlaceTag;
 import org.sopt.solply_server.domain.tag.entity.QTag;
 import org.sopt.solply_server.domain.tag.entity.TagType;
 import org.sopt.solply_server.domain.town.entity.QTown;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -90,8 +97,8 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
 //    }
 
     public List<Place> findPlacesWithTownByKeyword(final String keyword) {
-        QPlace qPlace = QPlace.place;
-        QTown qTown = QTown.town;
+        QPlace qPlace = place;
+        QTown qTown = town;
 
         String kw = keyword == null ? "" : keyword.trim();
         if (kw.isEmpty()) return List.of();
@@ -144,6 +151,25 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
                     .limit(10)
                     .fetch();
         }
+    }
+
+    @Override
+    public Page<Place> findByUserIdWithTown(Long userId, Pageable pageable) {
+        List<Place> results = queryFactory
+                .selectFrom(place)
+                .join(place.town, town).fetchJoin()
+                .where(place.createdBy.id.eq(userId))
+                .orderBy(place.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(place.count())
+                .from(place)
+                .where(place.createdBy.id.eq(userId));
+
+        return PageableExecutionUtils.getPage(results, pageable, countQuery::fetchOne);
     }
 
     private String sanitizeForBooleanMode(final String token) {

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
@@ -89,7 +89,8 @@ public class PlaceService {
                         place.getName(),
                         imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
                         place.getMainTag(),
-                        placeBookmarkService.isBookmarked(userId, place.getId())
+                        placeBookmarkService.isBookmarked(userId, place.getId()),
+                        townId
                 ))
                 .toList();
 

--- a/src/main/java/org/sopt/solply_server/domain/user/service/mypage/MyPageFacade.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/mypage/MyPageFacade.java
@@ -26,13 +26,14 @@ public class MyPageFacade {
 
     @Transactional(readOnly = true)
     public Page<PlacePreviewDto> getPlacesCreatedBy(Long userId, Pageable pageable) {
-        Page<Place> places = placeRepository.findByCreatedByIdOrderByCreatedAtDesc(userId, pageable);
+        Page<Place> places = placeRepository.findByUserIdWithTown(userId, pageable);
         return places.map(place -> PlacePreviewDto.of(
                     place.getId(),
                     place.getName(),
                     imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
                     place.getMainTag(),
-                    false // isBookmarked 정보는 여기에 포함되지 않음
+                    false, // isBookmarked 정보는 여기에 포함되지 않음
+                    place.getTown().getId()
                 )
         );
     }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #197 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->
- fetch join으로 town 데이터도 가져오게끔 수정했습니다.


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 페이징할때 countquery를 따로 둬서 fetch Join으로 카운트가 혹시라도 잘못될 문제를 방지헀습니다.

<br/>

## 🚀 알게된 점 (선택)

---

-

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새 기능
  - 장소 미리보기 카드에 동네 정보가 포함되어 각 장소의 위치 맥락을 더 쉽게 파악할 수 있습니다.
  - 마이페이지 > 내가 만든 장소 목록에서도 각 장소의 동네 정보를 함께 확인할 수 있습니다.
  - 필터/탐색 결과의 장소 리스트에서도 동네 정보가 노출되어 탐색이 편리해졌습니다.
  - 목록의 정렬과 페이지네이션 동작은 기존과 동일하게 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->