### PR TITLE
[FEAT] 변경된 townDto에 맞게 동네 조회 로직 수정

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/town/dto/TownDto.java
+++ b/src/main/java/org/sopt/solply_server/domain/town/dto/TownDto.java
@@ -7,13 +7,13 @@ import java.util.List;
 public record TownDto(
         Long townId,
         String townName,
-        List<TownDto> subTowns
+        Long parentTownId
 ) {
-    public static TownDto of(Town town, List<TownDto> subTowns) {
+    public static TownDto of(Town town, Town parentTown) {
         return new TownDto(
                 town.getId(),
                 town.getName(),
-                subTowns
+                parentTown != null ? parentTown.getId() : null
         );
     }
 }

--- a/src/main/java/org/sopt/solply_server/domain/town/service/TownService.java
+++ b/src/main/java/org/sopt/solply_server/domain/town/service/TownService.java
@@ -1,5 +1,6 @@
 package org.sopt.solply_server.domain.town.service;
 
+import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.solply_server.domain.town.dto.TownDto;
@@ -21,27 +22,19 @@ public class TownService {
 
     private final TownRepository townRepository;
 
-    public Town findTownById(Long townId) {
-        return townRepository.findById(townId)
-                .orElseThrow(() -> {
-                    log.warn("존재하지 않는 동네 ID: townId={}", townId);
-                    return new BusinessException(ErrorCode.NOT_FOUND_TOWN);
-                });
-    }
-
     public TownAllGetResponse getAllTowns() {
         List<Town> parentTowns = townRepository.findByParentIsNull();
 
-        List<TownDto> allTowns = parentTowns.stream()
-                .map(parent -> {
-                    List<Town> childTowns = townRepository.findByParent(parent);
-                    List<TownDto> childTownDtos = childTowns.stream()
-                            .map(child -> TownDto.of(child, null))
-                            .toList();
+        List<TownDto> allTowns = new ArrayList<>();
 
-                    return TownDto.of(parent, childTownDtos);
-                })
-                .toList();
+        for (Town parent : parentTowns) {
+            allTowns.add(new TownDto(parent.getId(), parent.getName(), null));
+
+            List<Town> childTowns = townRepository.findByParent(parent);
+            for (Town child : childTowns) {
+                allTowns.add(TownDto.of(child, parent));
+            }
+        }
 
         return new TownAllGetResponse(allTowns);
     }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #201 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- 조회 로직을 수정했습니다.


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 기존에 subTowns라는 계층 구조의 형태로 응답해주는게, 클라이언트 입장에서 계층 구조를 다시 풀어야하기도 하고, "연희동"을 선택했다고 했을 때, "서울 -> 연희동"이 선택됐다는 ui. 상태를 유지하는 과정에서 "연희동"의 상위 계층인 "서울"이라는 동네를 찾는게 번거롭다고 해서, 이번에 변경하게 됐네요!

<br/>

## 🚀 알게된 점 (선택)

---

-

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 리팩터링
  - 타운 조회 응답을 중첩 구조에서 평탄화된 리스트로 변경했습니다.
  - 각 타운 항목이 parentTownId를 포함하며, 더 이상 subTowns 필드를 제공하지 않습니다.
  - getAllTowns 결과에서 상위 타운과 하위 타운이 각각 개별 항목으로 반환되고, 상하위 관계는 parentTownId로 식별됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->