### PR TITLE
[FEAT] 서비스 이용약관 관련 API

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/auth/service/AuthService.java
+++ b/src/main/java/org/sopt/solply_server/domain/auth/service/AuthService.java
@@ -30,24 +30,9 @@ public class AuthService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final OAuthServiceProvider oAuthServiceProvider;
 
-    // 관심 지역 임시 처리
-    private final UserInterestTownService userInterestTownService;
-
-
-    private final JwtTokenResolver jwtTokenResolver;
-    private final EntityLoader entityLoader;
-
     public SocialLoginResponse socialLogin(SocialPlatform socialPlatform, SocialLoginRequest request) {
         OAuthService oAuthService = oAuthServiceProvider.getService(socialPlatform);
         User user = oAuthService.socialLogin(request.oauthAccessToken());
-
-//        Town town1 = entityLoader.getTown(Long.parseLong("2")); // 연희동
-//        Town town2 = entityLoader.getTown(Long.parseLong("3")); // 망원동
-//        List<Town> initialTowns = new ArrayList<>();
-//        initialTowns.add(town1);
-//        initialTowns.add(town2);
-
-//        userInterestTownService.updateUserInterestTowns(user, initialTowns);
 
         return SocialLoginResponse.of(
                 saveTokenCollection(user.getId()),

--- a/src/main/java/org/sopt/solply_server/domain/course/repository/CourseRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/repository/CourseRepository.java
@@ -17,18 +17,11 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
      * 코스 상세 조회 - 코스와 관련된 장소 목록 조회 (단계별 조회로 MultipleBagFetchException 해결)
      * Course, CoursePlace, Place 모두 한 번에 로딩
      */
-    @Query("SELECT c FROM Course c " +
+    @Query("SELECT DISTINCT c FROM Course c " +
             "JOIN FETCH c.coursePlaces cp " +
             "JOIN FETCH cp.place p " +
             "WHERE c.id = :courseId")
     Optional<Course> findByIdWithPlaces(@Param("courseId") Long courseId);
-
-    // 필요한 Place들의 태그 정보 배치 로딩
-    @Query("SELECT p FROM Place p " +
-            "LEFT JOIN FETCH p.placeTags pt " +
-            "LEFT JOIN FETCH pt.tag " +
-            "WHERE p.id IN :placeIds")
-    List<Place> findPlacesWithTagsByIds(@Param("placeIds") List<Long> placeIds);
 
     /**
      * 특정 동네의 공유된 코스 목록 조회 (단계별 조회로 MultipleBagFetchException 해결)
@@ -50,16 +43,6 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
             "(SELECT cp.place.id FROM CoursePlace cp WHERE cp.course.id IN :courseIds)")
     List<Place> findPlacesWithTagsByCourseIds(@Param("courseIds") List<Long> courseIds);
 
-    /**
-     * 특정 코스들의 장소 개수 조회
-     * 코스 ID와 해당 코스의 장소 개수를 Map 형태로 반환
-     */
-    @Query("SELECT cp.course.id, COUNT(cp) " +
-            "FROM CoursePlace cp " +
-            "WHERE cp.course.id IN :courseIds " +
-            "GROUP BY cp.course.id")
-    List<Object[]> countPlacesByCourseIds(@Param("courseIds") List<Long> courseIds);
-
 
     /**
      * 사용자의 북마크된 코스 목록 조회
@@ -75,37 +58,21 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
         """)
     List<Course> findBookmarkedCoursesWithPlacesByIds(@Param("courseIds") List<Long> courseIds);
 
-    /**
-     * 동네의 코스명 패턴 조회 (중복 이름 체크용)
-     */
-    @Query("SELECT c.name FROM Course c " +
-            "WHERE c.town.id = :townId " +
-            "AND c.name LIKE :namePattern " +
-            "ORDER BY c.name")
-    List<String> findCourseNamesByTownAndNamePattern(@Param("townId") Long townId,
-                                                     @Param("namePattern") String namePattern);
 
     /**
      * 특정 동네의 북마크된 코스 목록 조회
      * 코스와 코스 내 장소들을 함께 조회
      */
     @Query("""
-    SELECT DISTINCT c FROM Course c
-    JOIN FETCH c.town t
-    JOIN FETCH c.coursePlaces cp
-    JOIN FETCH cp.place p
-    WHERE c.id IN :courseIds 
-    AND c.town.id = :townId
-    ORDER BY c.createdAt DESC
+        SELECT DISTINCT c FROM Course c
+        JOIN FETCH c.town t WITH t.id = :townId
+        LEFT JOIN FETCH c.coursePlaces cp
+        LEFT JOIN FETCH cp.place p
+        WHERE c.id IN :courseIds
     """)
     List<Course> findBookmarkedCoursesByTownId(@Param("courseIds") List<Long> courseIds,
-                                               @Param("townId") Long townId);
+            @Param("townId") Long townId);
 
-    @Query("SELECT c FROM Course c " +
-            "JOIN FETCH c.coursePlaces cp " +
-            "JOIN FETCH cp.place p " +
-            "WHERE c.id IN :courseIds")
-    List<Course> findByIdInWithPlaces(@Param("courseIds") List<Long> courseIds);
 
     @Modifying
     @Query("DELETE FROM CoursePlace cp WHERE cp.course.id = :courseId")
@@ -119,4 +86,9 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
             "AND c.name LIKE :namePattern")
     List<String> findCourseNamesByBookmarkedCourses(
             @Param("courseIds") List<Long> courseIds, @Param("namePattern") String namePattern);
+
+    @Query("SELECT c FROM Course c " +
+            "JOIN FETCH c.town t " +
+            "WHERE c.id IN :courseIds")
+    List<Course> findAllByIdsWithTowns(@Param("courseIds") List<Long> courseIds);
 }

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -182,9 +182,6 @@ public class CourseService {
                 .map(coursePlace -> coursePlace.getPlace().getId())
                 .toList();
 
-        // 장소 태그 정보를 영속성 컨텍스트에 로드
-        courseRepository.findPlacesWithTagsByIds(placeIds);
-
         Map<Long, Boolean> placeBookmarkMap = placeIds.isEmpty() ? Map.of() :
                 placeIds.stream().collect(Collectors.toMap(
                         placeId -> placeId,
@@ -221,13 +218,9 @@ public class CourseService {
             final Long townId,
             final Long candidatePlaceId) {
 
-        if (townId == null && candidatePlaceId == null) {
-            throw new BusinessException(ErrorCode.MISSING_REQUIRED_PARAMETER);
-        }
+        if (townId == null && candidatePlaceId == null) throw new BusinessException(ErrorCode.MISSING_REQUIRED_PARAMETER);
 
-        if (townId != null && candidatePlaceId != null) {
-            throw new BusinessException(ErrorCode.INVALID_REQUEST_BODY);
-        }
+        if (townId != null && candidatePlaceId != null) throw new BusinessException(ErrorCode.INVALID_REQUEST_BODY);
 
         final Long targetTownId;
         final Place candidatePlace;
@@ -269,19 +262,13 @@ public class CourseService {
             return CourseBookmarkListGetResponse.from(List.of());
         }
 
-        List<Long> filteredCourseIds = filteredCourses.stream()
-                .map(Course::getId)
-                .toList();
-
-        // 코스 태그 정보 배치 로딩
-        courseRepository.findPlacesWithTagsByCourseIds(filteredCourseIds);
-
         // 상세 검증 결과 준비 (코스 추가 모드일 때만)
         Map<Long, CourseValidationResult> validationResults = prepareValidationResults(
                 filteredCourses, candidatePlace, candidatePlaceId != null);
 
         List<CourseInfoDto> courseInfoDtos = filteredCourses.stream()
-                .map(course -> createCourseInfoDto(course, validationResults, candidatePlaceId != null))
+                .map(course -> createCourseInfoDto(
+                        course, validationResults, candidatePlaceId != null))
                 .sorted(
                         (dto1, dto2) -> {
                             LocalDateTime createdAt1 = courseIdCreatedAtMap.get(dto1.courseId());
@@ -296,75 +283,6 @@ public class CourseService {
         return CourseBookmarkListGetResponse.from(courseInfoDtos);
     }
 
-
-    /**
-     * 사용자가 북마크한 코스 목록 조회 (동네 기준 필터링 + 장소 추가 가능 여부)
-     */
-    @Deprecated
-    public CourseBookmarkListGetResponse getBookmarkedCoursesByTownByLatest(final Long userId, final Long townId, final Long placeId) {
-        townValidator.validateTownId(townId);
-
-        // placeId가 있는 경우에만 장소 조회 및 검증
-        Place candidatePlace = null;
-        boolean checkCanAddPlaceToCourse = (placeId != null);
-
-        if (checkCanAddPlaceToCourse) {
-            candidatePlace = entityLoader.getPlace(placeId);
-        }
-
-        // Redis에서 활성화된 코스 북마크 데이터 조회
-        List<CourseBookmarkRedisDto> activeBookmarks = courseBookmarkRedisDataManager.getActiveCourseBookmarks(userId);
-
-        if (activeBookmarks.isEmpty()) {
-            log.info("사용자 {}의 북마크된 코스가 없습니다.", userId);
-            return CourseBookmarkListGetResponse.from(List.of());
-        }
-
-        // 코스 ID와 북마크 저장 시간을 매핑하여 저장
-        Map<Long, LocalDateTime> courseIdCreatedAtMap = activeBookmarks.stream()
-                .collect(Collectors.toMap(
-                        CourseBookmarkRedisDto::courseId,
-                        CourseBookmarkRedisDto::createdAt
-                ));
-
-        List<Long> courseIds = activeBookmarks.stream()
-                .map(CourseBookmarkRedisDto::courseId)
-                .toList();
-
-        // 동네 ID와 북마크된 코스 ID로 필터링
-        List<Course> filteredCourses = courseRepository.findBookmarkedCoursesByTownId(courseIds, townId);
-
-        if (filteredCourses.isEmpty()) {
-            log.info("동네 {}에 북마크된 코스가 없습니다.", townId);
-            return CourseBookmarkListGetResponse.from(List.of());
-        }
-
-        List<Long> filteredCourseIds = filteredCourses.stream()
-                .map(Course::getId)
-                .toList();
-
-        // 코스 태그 정보 배치 로딩
-        courseRepository.findPlacesWithTagsByCourseIds(filteredCourseIds);
-
-        // 상세 검증 결과 준비
-        Map<Long, CourseValidationResult> validationResults = prepareValidationResults(
-                filteredCourses, candidatePlace, checkCanAddPlaceToCourse);
-
-        // DTO 변환
-        List<CourseInfoDto> courseInfoDtos = filteredCourses.stream()
-                .map(course -> createCourseInfoDto(course, validationResults, checkCanAddPlaceToCourse))
-                .sorted( // 최신 순으로 정렬
-                        (dto1, dto2) -> {
-                            LocalDateTime createdAt1 = courseIdCreatedAtMap.get(dto1.courseId());
-                            LocalDateTime createdAt2 = courseIdCreatedAtMap.get(dto2.courseId());
-                            return createdAt2.compareTo(createdAt1);
-                        }
-                )
-                .toList();
-
-        log.info("북마크 코스 {}개 조회 완료", courseInfoDtos.size());
-        return CourseBookmarkListGetResponse.from(courseInfoDtos);
-    }
 
 
     /**
@@ -478,7 +396,7 @@ public class CourseService {
                 .map(CourseBookmarkRedisDto::courseId)
                 .toList();
 
-        Map<Long, Long> courseToTownMap = courseRepository.findAllById(courseIds).stream()
+        Map<Long, Long> courseToTownMap = entityLoader.getCourseWithTowns(courseIds).stream()
                 .collect(Collectors.toMap(
                         Course::getId,
                         course -> course.getTown().getId()

--- a/src/main/java/org/sopt/solply_server/domain/place/controller/PlaceController.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/controller/PlaceController.java
@@ -9,7 +9,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.solply_server.domain.place.dto.request.PlaceFilterGetRequest;
 import org.sopt.solply_server.domain.place.dto.request.PlaceRequestCreateRequest;
-import org.sopt.solply_server.domain.place.dto.response.PlaceAllGetResponse;
+import org.sopt.solply_server.domain.place.dto.response.PlaceDetailsGetResponse;
 import org.sopt.solply_server.domain.place.dto.response.PlaceFilterGetResponse;
 import org.sopt.solply_server.domain.place.dto.response.PlaceFolderPreviewListGetResponse;
 import org.sopt.solply_server.domain.place.dto.response.PlaceRequestCreateResponse;
@@ -40,7 +40,7 @@ public class PlaceController {
 
     @Operation(summary = "장소 상세 조회", description = "장소 ID를 통해 장소의 상세 정보를 조회합니다.")
     @GetMapping("/{placeId}")
-    public ResponseEntity<CustomApiResponse<PlaceAllGetResponse>> getPlaceDetailsbyId(
+    public ResponseEntity<CustomApiResponse<PlaceDetailsGetResponse>> getPlaceDetailsbyId(
             @CurrentUserId Long userId,
             @PathVariable Long placeId) {
         return CustomApiResponse.success(

--- a/src/main/java/org/sopt/solply_server/domain/place/dto/response/PlaceDetailsGetResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/dto/response/PlaceDetailsGetResponse.java
@@ -6,9 +6,10 @@ import org.sopt.solply_server.domain.place.dto.PlaceImageInfoDto;
 import org.sopt.solply_server.domain.place.dto.SnsLinkDto;
 import org.sopt.solply_server.domain.place.entity.Place;
 import org.sopt.solply_server.domain.tag.entity.TagName;
+import org.sopt.solply_server.domain.town.entity.Town;
 
 @Builder
-public record PlaceAllGetResponse(
+public record PlaceDetailsGetResponse(
         long placeId,
         String placeName,
         TagName mainTag,
@@ -22,11 +23,14 @@ public record PlaceAllGetResponse(
         List<SnsLinkDto> snsLinks,
         boolean isBookmarked,
         String placeType,
-        long placeDefaultId
+        long placeDefaultId,
+        long townId,
+        String townName
 ) {
 
-    public static PlaceAllGetResponse of(Place place, TagName mainTag, List<PlaceImageInfoDto> placeImageInfos, boolean isBookmarked) {
-        return PlaceAllGetResponse.builder()
+    public static PlaceDetailsGetResponse of(Place place, TagName mainTag, List<PlaceImageInfoDto> placeImageInfos,
+            boolean isBookmarked, Town town) {
+        return PlaceDetailsGetResponse.builder()
                 .placeId(place.getId())
                 .placeName(place.getName())
                 .mainTag(mainTag)
@@ -41,6 +45,8 @@ public record PlaceAllGetResponse(
                 .isBookmarked(isBookmarked)
                 .placeType(place.getPlaceType())
                 .placeDefaultId(place.getPlaceDefaultId())
+                .townId(town.getId())
+                .townName(town.getName())
                 .build();
     }
 }

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
@@ -14,7 +14,7 @@ import org.sopt.solply_server.domain.place.dto.PlaceImageInfoDto;
 import org.sopt.solply_server.domain.place.dto.PlaceSearchConditionDto;
 import org.sopt.solply_server.domain.place.dto.PlacePreviewDto;
 import org.sopt.solply_server.domain.place.dto.PlaceSearchResultDto;
-import org.sopt.solply_server.domain.place.dto.response.PlaceAllGetResponse;
+import org.sopt.solply_server.domain.place.dto.response.PlaceDetailsGetResponse;
 import org.sopt.solply_server.domain.place.dto.response.PlaceFilterGetResponse;
 import org.sopt.solply_server.domain.place.dto.response.PlaceFolderPreviewListGetResponse;
 import org.sopt.solply_server.domain.place.dto.response.PlaceSearchResponse;
@@ -50,7 +50,7 @@ public class PlaceService {
     /**
      * 장소 상세 정보 조회
      */
-    public PlaceAllGetResponse getPlaceDetailsById(final Long userId, final Long placeId) {
+    public PlaceDetailsGetResponse getPlaceDetailsById(final Long userId, final Long placeId) {
         Place place = entityLoader.getPlace(placeId);
 
         List<PlaceImageInfoDto> imageInfos = place.getPlaceImageInfos().stream()
@@ -62,11 +62,14 @@ public class PlaceService {
 
         boolean isBookmarked = placeBookmarkService.isBookmarked(userId, placeId);
 
-        return PlaceAllGetResponse.of(
+        Town town = place.getTown();
+
+        return PlaceDetailsGetResponse.of(
                 place,
                 place.getMainTag(),
                 imageInfos,
-                isBookmarked
+                isBookmarked,
+                town
         );
     }
 

--- a/src/main/java/org/sopt/solply_server/domain/user/controller/UserController.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/controller/UserController.java
@@ -13,6 +13,7 @@ import org.sopt.solply_server.domain.user.dto.request.UserWithdrawRequest;
 import org.sopt.solply_server.domain.user.dto.request.UserTownsUpdateRequest;
 import org.sopt.solply_server.domain.user.dto.response.NicknameCheckResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserInOnboardingUpdateResponse;
+import org.sopt.solply_server.domain.user.dto.response.UserPolicyAllGetResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserUpdateResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserPersonaListGetResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserProfileGetResponse;
@@ -20,6 +21,7 @@ import org.sopt.solply_server.domain.user.dto.response.UserRequestedPlaceAllGetR
 import org.sopt.solply_server.domain.user.dto.response.UserTownGetResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserTownsUpdateResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserWithdrawReasonAllGetResponse;
+import org.sopt.solply_server.domain.user.service.UserPolicyService;
 import org.sopt.solply_server.domain.user.service.UserService;
 import org.sopt.solply_server.domain.user.service.UserWithdrawService;
 import org.sopt.solply_server.global.annotation.CurrentUserId;
@@ -37,6 +39,7 @@ public class UserController {
 
     private final UserService userService;
     private final UserWithdrawService userWithdrawService;
+    private final UserPolicyService userPolicyService;
 
     @Operation(summary = "닉네임 중복 검사", description = "닉네임 사용 가능 여부를 확인합니다.")
     @GetMapping("/check-nickname")
@@ -94,6 +97,14 @@ public class UserController {
                 userService.getUserPersonaList());
     }
 
+    @Operation(summary = "사용자 약관 정보 조회", description = "사용자 약관 정보를 조회합니다.")
+    @GetMapping("/policies")
+    public ResponseEntity<CustomApiResponse<UserPolicyAllGetResponse>> getUserPolicies() {
+        return CustomApiResponse.success("사용자 약관 정보 조회에 성공했습니다.",
+                userPolicyService.getAllUserPolicies()
+        );
+    }
+
 
     @Operation(summary = "회원 정보 업데이트", description = "회원 정보를 업데이트합니다.")
     @PatchMapping()
@@ -114,6 +125,7 @@ public class UserController {
         return CustomApiResponse.success("온보딩 기반 회원 정보 업데이트에 성공했습니다",
                 userService.updateUserInfoInOnboarding(userId, request));
     }
+
 
 
 

--- a/src/main/java/org/sopt/solply_server/domain/user/dto/UserPolicyDto.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/dto/UserPolicyDto.java
@@ -1,0 +1,10 @@
+package org.sopt.solply_server.domain.user.dto;
+
+public record UserPolicyDto(
+        Long id,
+        String policyType,
+        String title,
+        String content,
+        boolean required
+) {
+}

--- a/src/main/java/org/sopt/solply_server/domain/user/dto/request/UserInOnboardingUpdateRequest.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/dto/request/UserInOnboardingUpdateRequest.java
@@ -3,6 +3,7 @@ package org.sopt.solply_server.domain.user.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.util.List;
 import org.sopt.solply_server.domain.user.entity.UserPersona;
 
 public record UserInOnboardingUpdateRequest(
@@ -14,7 +15,10 @@ public record UserInOnboardingUpdateRequest(
 
         @NotBlank(message = "닉네임은 필수입니다")
         @Size(min = 2, max = 8, message = "닉네임은 2자 이상 8자 이하여야 합니다")
-        String nickname
+        String nickname,
+
+        @NotNull(message = "정책 동의 정보는 필수입니다")
+        List<UserPolicyAgreementRequest> policyAgreementInfos
 ) {
 
 }

--- a/src/main/java/org/sopt/solply_server/domain/user/dto/request/UserPolicyAgreementRequest.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/dto/request/UserPolicyAgreementRequest.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record UserPolicyAgreementRequest(
-        @NotBlank(message = "policyId은 필수입니다")
+        @NotNull(message = "policyId은 필수입니다")
         Long policyId,
 
         @NotNull(message = "isAgree는 필수입니다")

--- a/src/main/java/org/sopt/solply_server/domain/user/dto/request/UserPolicyAgreementRequest.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/dto/request/UserPolicyAgreementRequest.java
@@ -1,0 +1,12 @@
+package org.sopt.solply_server.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record UserPolicyAgreementRequest(
+        @NotBlank(message = "policyId은 필수입니다")
+        Long policyId,
+
+        @NotNull(message = "isAgree는 필수입니다")
+        Boolean isAgree
+) {}

--- a/src/main/java/org/sopt/solply_server/domain/user/dto/response/UserPolicyAllGetResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/dto/response/UserPolicyAllGetResponse.java
@@ -1,0 +1,24 @@
+package org.sopt.solply_server.domain.user.dto.response;
+
+import java.util.List;
+import org.sopt.solply_server.domain.user.dto.UserPolicyDto;
+import org.sopt.solply_server.domain.user.entity.UserPolicy;
+
+public record UserPolicyAllGetResponse(
+        List<UserPolicyDto> userPolicies
+) {
+
+    public static UserPolicyAllGetResponse of(List<UserPolicy> userActivePolicies) {
+        return new UserPolicyAllGetResponse(
+                userActivePolicies.stream()
+                        .map(userPolicy -> new UserPolicyDto(
+                                userPolicy.getId(),
+                                userPolicy.getPolicyType().name(),
+                                userPolicy.getTitle(),
+                                userPolicy.getContent(),
+                                userPolicy.isRequired()
+                        ))
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/user/entity/PolicyType.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/entity/PolicyType.java
@@ -1,0 +1,7 @@
+package org.sopt.solply_server.domain.user.entity;
+
+public enum PolicyType {
+    AGE_POLICY,
+    SERVICE_POLICY,
+    PRIVACY_POLICY,
+}

--- a/src/main/java/org/sopt/solply_server/domain/user/entity/UserPolicy.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/entity/UserPolicy.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
@@ -20,7 +21,7 @@ import lombok.NoArgsConstructor;
 public class UserPolicy {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false, name = "policy_type")

--- a/src/main/java/org/sopt/solply_server/domain/user/entity/UserPolicy.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/entity/UserPolicy.java
@@ -1,0 +1,41 @@
+package org.sopt.solply_server.domain.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "user_policies")
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserPolicy {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Column(nullable = false, name = "policy_type")
+    @Enumerated(value = EnumType.STRING)
+    private PolicyType policyType;
+
+    private String version;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Lob
+    private String content;
+
+    private boolean required; // 필수/선택
+
+    private boolean active;   // 현재 유효한 약관인지
+}

--- a/src/main/java/org/sopt/solply_server/domain/user/entity/UserPolicyAgreement.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/entity/UserPolicyAgreement.java
@@ -24,7 +24,7 @@ import org.sopt.solply_server.global.entity.BaseTimeEntity;
 @Getter
 @Table(name = "user_policy_agreements",
         uniqueConstraints = {
-                @UniqueConstraint(name = "uk_user_policy", columnNames = {"user_id", "policy_id"})
+                @UniqueConstraint(name = "uk_user_policy", columnNames = {"user_id", "user_policy_id"})
         }
 )
 @Builder

--- a/src/main/java/org/sopt/solply_server/domain/user/entity/UserPolicyAgreement.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/entity/UserPolicyAgreement.java
@@ -1,0 +1,63 @@
+package org.sopt.solply_server.domain.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+import org.sopt.solply_server.global.entity.BaseTimeEntity;
+
+@Entity
+@Getter
+@Table(name = "user_policy_agreements",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_user_policy", columnNames = {"user_id", "policy_id"})
+        }
+)
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@DynamicInsert
+public class UserPolicyAgreement extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_policy_agreement_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "policy_id", nullable = false)
+    private UserPolicy policy;
+
+    @Column(nullable = false)
+    private Boolean isAgree;
+
+
+    public static UserPolicyAgreement create(User newUser, UserPolicy policy) {
+        return UserPolicyAgreement.builder()
+                .user(newUser)
+                .policy(policy)
+                .isAgree(true)
+                .build();
+    }
+
+    public void updateIsAgree(Boolean isAgree) {
+        this.isAgree = isAgree;
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/user/entity/UserPolicyAgreement.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/entity/UserPolicyAgreement.java
@@ -35,25 +35,25 @@ public class UserPolicyAgreement extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "user_policy_agreement_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "policy_id", nullable = false)
-    private UserPolicy policy;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_policy_id", nullable = false)
+    private UserPolicy userPolicy;
 
     @Column(nullable = false)
     private Boolean isAgree;
 
 
-    public static UserPolicyAgreement create(User newUser, UserPolicy policy) {
+    public static UserPolicyAgreement create(User user, UserPolicy userPolicy, Boolean isAgree) {
         return UserPolicyAgreement.builder()
-                .user(newUser)
-                .policy(policy)
-                .isAgree(true)
+                .user(user)
+                .userPolicy(userPolicy)
+                .isAgree(isAgree)
                 .build();
     }
 

--- a/src/main/java/org/sopt/solply_server/domain/user/repository/UserPolicyAgreementRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/repository/UserPolicyAgreementRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.solply_server.domain.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserPolicyAgreementRepository extends JpaRepository<UserPolicyAgreementRepository, Long> {
+
+}

--- a/src/main/java/org/sopt/solply_server/domain/user/repository/UserPolicyAgreementRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/repository/UserPolicyAgreementRepository.java
@@ -1,7 +1,10 @@
 package org.sopt.solply_server.domain.user.repository;
 
+import java.util.Optional;
+import org.sopt.solply_server.domain.user.entity.UserPolicyAgreement;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserPolicyAgreementRepository extends JpaRepository<UserPolicyAgreementRepository, Long> {
+public interface UserPolicyAgreementRepository extends JpaRepository<UserPolicyAgreement, Long> {
+    Optional<UserPolicyAgreement> findByUserIdAndUserPolicyId(Long userId, Long userPolicyId);
 
 }

--- a/src/main/java/org/sopt/solply_server/domain/user/repository/UserPolicyRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/repository/UserPolicyRepository.java
@@ -1,0 +1,12 @@
+package org.sopt.solply_server.domain.user.repository;
+
+import java.util.List;
+import org.sopt.solply_server.domain.user.dto.response.UserPolicyAllGetResponse;
+import org.sopt.solply_server.domain.user.entity.UserPolicy;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface UserPolicyRepository extends JpaRepository<UserPolicy, Long> {
+
+    List<UserPolicy> findAllByActiveTrueOrderByPolicyTypeAscIdDesc();
+}

--- a/src/main/java/org/sopt/solply_server/domain/user/repository/UserPolicyRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/repository/UserPolicyRepository.java
@@ -1,6 +1,7 @@
 package org.sopt.solply_server.domain.user.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.sopt.solply_server.domain.user.dto.response.UserPolicyAllGetResponse;
 import org.sopt.solply_server.domain.user.entity.UserPolicy;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +10,6 @@ import org.springframework.data.jpa.repository.Query;
 public interface UserPolicyRepository extends JpaRepository<UserPolicy, Long> {
 
     List<UserPolicy> findAllByActiveTrueOrderByPolicyTypeAscIdDesc();
+
+    Optional<UserPolicy> findByIdAndActiveTrue(Long id);
 }

--- a/src/main/java/org/sopt/solply_server/domain/user/service/SocialUserService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/SocialUserService.java
@@ -5,7 +5,9 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.solply_server.domain.auth.entity.SocialPlatform;
 import org.sopt.solply_server.domain.user.entity.SocialUserInfo;
 import org.sopt.solply_server.domain.user.entity.User;
+import org.sopt.solply_server.domain.user.entity.UserPolicyAgreement;
 import org.sopt.solply_server.domain.user.repository.SocialUserInfoRepository;
+import org.sopt.solply_server.domain.user.repository.UserPolicyAgreementRepository;
 import org.sopt.solply_server.domain.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,6 +45,8 @@ public class SocialUserService {
         // 신규 이용자
         User newUser = User.create(email);
         userRepository.save(newUser);
+        UserPolicyAgreement userPolicyAgreement = UserPolicyAgreement.create(newUser);
+
         linkSocialAccount(newUser, socialPlatform, socialId);
 
         return newUser;

--- a/src/main/java/org/sopt/solply_server/domain/user/service/SocialUserService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/SocialUserService.java
@@ -1,10 +1,12 @@
 package org.sopt.solply_server.domain.user.service;
 
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.sopt.solply_server.domain.auth.entity.SocialPlatform;
 import org.sopt.solply_server.domain.user.entity.SocialUserInfo;
 import org.sopt.solply_server.domain.user.entity.User;
+import org.sopt.solply_server.domain.user.entity.UserPolicy;
 import org.sopt.solply_server.domain.user.entity.UserPolicyAgreement;
 import org.sopt.solply_server.domain.user.repository.SocialUserInfoRepository;
 import org.sopt.solply_server.domain.user.repository.UserPolicyAgreementRepository;
@@ -45,7 +47,6 @@ public class SocialUserService {
         // 신규 이용자
         User newUser = User.create(email);
         userRepository.save(newUser);
-        UserPolicyAgreement userPolicyAgreement = UserPolicyAgreement.create(newUser);
 
         linkSocialAccount(newUser, socialPlatform, socialId);
 

--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserPolicyAgreementService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserPolicyAgreementService.java
@@ -1,0 +1,5 @@
+package org.sopt.solply_server.domain.user.service;
+
+public class UserPolicyAgreementService {
+
+}

--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserPolicyAgreementService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserPolicyAgreementService.java
@@ -1,5 +1,0 @@
-package org.sopt.solply_server.domain.user.service;
-
-public class UserPolicyAgreementService {
-
-}

--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserPolicyService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserPolicyService.java
@@ -3,8 +3,13 @@ package org.sopt.solply_server.domain.user.service;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.solply_server.domain.user.dto.response.UserPolicyAllGetResponse;
+import org.sopt.solply_server.domain.user.entity.User;
 import org.sopt.solply_server.domain.user.entity.UserPolicy;
+import org.sopt.solply_server.domain.user.entity.UserPolicyAgreement;
+import org.sopt.solply_server.domain.user.repository.UserPolicyAgreementRepository;
 import org.sopt.solply_server.domain.user.repository.UserPolicyRepository;
+import org.sopt.solply_server.global.exception.BusinessException;
+import org.sopt.solply_server.global.exception.ErrorCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,11 +19,33 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserPolicyService {
 
     private final UserPolicyRepository userPolicyRepository;
+    private final UserPolicyAgreementRepository userPolicyAgreementRepository;
 
     public UserPolicyAllGetResponse getAllUserPolicies() {
         List<UserPolicy> userActivePolicies = userPolicyRepository.findAllByActiveTrueOrderByPolicyTypeAscIdDesc();
         return UserPolicyAllGetResponse.of(userActivePolicies);
     }
 
+    @Transactional
+    public void updateUserPolicyAgreement(final User user, final Long policyId, final Boolean isAgree) {
+
+        UserPolicy userPolicy = userPolicyRepository.findByIdAndActiveTrue(policyId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_USER_POLICY));
+
+        if (userPolicy.isRequired() && !isAgree) {
+            throw new BusinessException(ErrorCode.REQUIRED_USER_POLICY_NOT_AGREED);
+        }
+
+        UserPolicyAgreement userPolicyAgreement
+                = userPolicyAgreementRepository.findByUserIdAndUserPolicyId(user.getId(), policyId)
+                .orElse(null);
+
+        if (userPolicyAgreement == null) {
+            UserPolicyAgreement newUserPolicyAgreement = UserPolicyAgreement.create(user, userPolicy, isAgree);
+            userPolicyAgreementRepository.save(newUserPolicyAgreement);
+        } else {
+            userPolicyAgreement.updateIsAgree(isAgree);
+        }
+    }
 
 }

--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserPolicyService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserPolicyService.java
@@ -1,0 +1,24 @@
+package org.sopt.solply_server.domain.user.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.solply_server.domain.user.dto.response.UserPolicyAllGetResponse;
+import org.sopt.solply_server.domain.user.entity.UserPolicy;
+import org.sopt.solply_server.domain.user.repository.UserPolicyRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserPolicyService {
+
+    private final UserPolicyRepository userPolicyRepository;
+
+    public UserPolicyAllGetResponse getAllUserPolicies() {
+        List<UserPolicy> userActivePolicies = userPolicyRepository.findAllByActiveTrueOrderByPolicyTypeAscIdDesc();
+        return UserPolicyAllGetResponse.of(userActivePolicies);
+    }
+
+
+}

--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
@@ -23,6 +23,7 @@ import org.sopt.solply_server.domain.user.dto.response.UserTownGetResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserTownsUpdateResponse;
 import org.sopt.solply_server.domain.user.entity.User;
 import org.sopt.solply_server.domain.user.entity.UserPersona;
+import org.sopt.solply_server.domain.user.repository.UserPolicyRepository;
 import org.sopt.solply_server.domain.user.repository.UserRepository;
 import org.sopt.solply_server.domain.user.service.mypage.MyPageFacade;
 import org.sopt.solply_server.global.dto.PagedResponse;
@@ -51,6 +52,8 @@ public class UserService {
     private final UserRepository userRepository;
     private final PresignedUrlProvider presignedUrlProvider;
     private final S3FileMoveService s3FileMoveService;
+    private final UserPolicyRepository userPolicyRepository;
+    private final UserPolicyService userPolicyService;
 
     public NicknameCheckResponse checkNickname(Long userId, String nickname) {
         User user = entityLoader.getUser(userId);
@@ -140,8 +143,9 @@ public class UserService {
 
         user.updateOnboardingInfo(request.persona(), request.nickname(), request.selectedTownId());
 
+        // 약관 동의 여부 저장
         for (var policyInfo : request.policyAgreementInfos()) {
-
+            userPolicyService.updateUserPolicyAgreement(user, policyInfo.policyId(), policyInfo.isAgree());
         }
 
         try {

--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
@@ -12,7 +12,6 @@ import org.sopt.solply_server.domain.user.dto.UserPlacePreviewDto;
 import org.sopt.solply_server.domain.user.dto.UserTownInfoDto;
 import org.sopt.solply_server.domain.user.dto.request.UserInOnboardingUpdateRequest;
 import org.sopt.solply_server.domain.user.dto.request.UserUpdateRequest;
-import org.sopt.solply_server.domain.user.dto.request.UserWithdrawRequest;
 import org.sopt.solply_server.domain.user.dto.request.UserTownsUpdateRequest;
 import org.sopt.solply_server.domain.user.dto.response.NicknameCheckResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserInOnboardingUpdateResponse;
@@ -24,11 +23,7 @@ import org.sopt.solply_server.domain.user.dto.response.UserTownGetResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserTownsUpdateResponse;
 import org.sopt.solply_server.domain.user.entity.User;
 import org.sopt.solply_server.domain.user.entity.UserPersona;
-import org.sopt.solply_server.domain.user.entity.UserWithdraw;
-import org.sopt.solply_server.domain.user.entity.WithdrawReason;
-import org.sopt.solply_server.domain.user.repository.SocialUserInfoRepository;
 import org.sopt.solply_server.domain.user.repository.UserRepository;
-import org.sopt.solply_server.domain.user.repository.UserWithdrawRepository;
 import org.sopt.solply_server.domain.user.service.mypage.MyPageFacade;
 import org.sopt.solply_server.global.dto.PagedResponse;
 import org.sopt.solply_server.global.exception.BusinessException;
@@ -144,6 +139,10 @@ public class UserService {
         userValidator.validateNickname(user.getNickname(), request.nickname());
 
         user.updateOnboardingInfo(request.persona(), request.nickname(), request.selectedTownId());
+
+        for (var policyInfo : request.policyAgreementInfos()) {
+
+        }
 
         try {
             userRepository.flush();

--- a/src/main/java/org/sopt/solply_server/global/exception/ErrorCode.java
+++ b/src/main/java/org/sopt/solply_server/global/exception/ErrorCode.java
@@ -50,6 +50,8 @@ public enum ErrorCode {
     ONBOARDING_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "USER-003", "이미 온보딩이 완료된 사용자입니다."),
     NOT_FOUND_PERSONA(HttpStatus.NOT_FOUND, "USER-004" , "페르소나가 설정돼있지 않은 사용자입니다." ),
     NOT_FOUND_USER_SELECTED_TOWN(HttpStatus.NOT_FOUND, "USER-005" , "유저가 선택한 동네가 없습니다."),
+    INVALID_USER_POLICY(HttpStatus.BAD_REQUEST, "USER-006", "유효하지 않은 약관 정보입니다."),
+    REQUIRED_USER_POLICY_NOT_AGREED(HttpStatus.BAD_REQUEST, "USER-007" , "필수 동의 항목에 대한 동의가 필요합니다." ),
 
 
     // 장소 관련 (PLACE-xxx)

--- a/src/main/java/org/sopt/solply_server/global/util/EntityLoader.java
+++ b/src/main/java/org/sopt/solply_server/global/util/EntityLoader.java
@@ -1,6 +1,7 @@
 package org.sopt.solply_server.global.util;
 
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.sopt.solply_server.domain.course.entity.Course;
 import org.sopt.solply_server.domain.course.repository.CourseRepository;
@@ -49,6 +50,10 @@ public class EntityLoader {
     public Town getTown(Long townId) {
         return townRepository.findById(townId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_TOWN));
+    }
+
+    public List<Course> getCourseWithTowns(List<Long> courseIds) {
+        return courseRepository.findAllByIdsWithTowns(courseIds);
     }
 
 //    public List<UserInterestTown> getInterestTownsWithTownsByIds(Long userId) {

--- a/src/main/resources/db/migration/V9__create_tables_related_user_policy.sql
+++ b/src/main/resources/db/migration/V9__create_tables_related_user_policy.sql
@@ -1,0 +1,22 @@
+CREATE TABLE user_policies (
+                               id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                               policy_type VARCHAR(50) NOT NULL,
+                               version VARCHAR(50),
+                               title VARCHAR(255) NOT NULL,
+                               content LONGTEXT,
+                               required BOOLEAN NOT NULL DEFAULT FALSE,
+                               active BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+
+CREATE TABLE user_policy_agreements (
+                                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                        user_id BIGINT NOT NULL,
+                                        user_policy_id BIGINT NOT NULL,
+                                        is_agree BOOLEAN NOT NULL DEFAULT FALSE,
+                                        created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                                        updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+                                        CONSTRAINT uk_user_policy UNIQUE (user_id, user_policy_id),
+                                        CONSTRAINT fk_user_policy_agreements_user FOREIGN KEY (user_id) REFERENCES users(id),
+                                        CONSTRAINT fk_user_policy_agreements_policy FOREIGN KEY (user_policy_id) REFERENCES user_policies(id)
+);


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #207 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- 서비스 이용약관 관련 테이블들을 생성했습니다.
- 약관 관련 테이블 생성
- 온보딩 과정에서 약관 동의 여부도 함께 받아 저장하는 로직 추가
- 약관에 대한 내용를 조회하는 api 생성


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 추후에 약관이 수정되거나 추가될 수 있는 부분을 고려해서 테이블을 따로 뒀습니다.

<br/>

## 🚀 알게된 점 (선택)

---

-

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 약관 조회 API 및 약관 목록 표시 추가
  * 온보딩 중 약관 동의 정보 제출 및 저장 기능 추가
  * 장소 상세 정보에 동네(town) ID·이름 노출 추가

* **개선 사항**
  * 소셜 로그인 흐름 간소화 — 반환되는 토큰/신규 사용자 플래그가 직접 제공됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->