### PR TITLE
[FEAT] 마이페이지에서 내가 등록한 장소 썸네일 조회에 메인 태그, 북마크 여부도 포함

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 //	implementation 'org.postgresql:postgresql'
 	implementation "com.mysql:mysql-connector-j:8.4.0"
+	implementation 'net.bytebuddy:byte-buddy'
+	implementation 'net.bytebuddy:byte-buddy-agent'
 
 	// ✅ Querydsl
 	implementation "io.github.openfeign.querydsl:querydsl-jpa:${querydslVersion}"

--- a/src/main/java/org/sopt/solply_server/domain/place/entity/Place.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/entity/Place.java
@@ -27,6 +27,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 import org.sopt.solply_server.domain.tag.entity.Tag;
 import org.sopt.solply_server.domain.tag.entity.TagName;
 import org.sopt.solply_server.domain.tag.entity.TagType;
@@ -90,6 +91,8 @@ public class Place extends BaseTimeEntity {
     @Column(name = "url", columnDefinition = "TEXT")
     private Map<SnsPlatform, String> snsLinks = new HashMap<>();
 
+
+    @BatchSize(size = 50)
     @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(name = "place_images", joinColumns = @JoinColumn(name = "place_id"))
     @OrderBy("displayOrder ASC") // displayOrder가 낮은 순서로 DB 내에서 정렬

--- a/src/main/java/org/sopt/solply_server/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/repository/PlaceRepository.java
@@ -7,6 +7,7 @@ import org.sopt.solply_server.domain.place.repository.querydsl.PlaceRepositoryCu
 import org.sopt.solply_server.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -26,6 +27,10 @@ public interface PlaceRepository extends JpaRepository<Place, Long>, PlaceReposi
     @Query("SELECT p FROM Place p WHERE p.id IN :placeIds")
     List<Place> findByIdIn(@Param("placeIds") List<Long> placeIds);
 
+    @EntityGraph(attributePaths = {
+            "placeTags",
+            "placeTags.tag"
+    })
     List<Place> findTop3ByCreatedByOrderByCreatedAtDesc(User createdBy);
 
 }

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceBookmarkQueryServiceImpl.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceBookmarkQueryServiceImpl.java
@@ -1,0 +1,49 @@
+package org.sopt.solply_server.domain.place.service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.sopt.solply_server.domain.place.dto.PlaceBookmarkRedisDto;
+import org.sopt.solply_server.domain.place.repository.PlaceBookmarkRepository;
+import org.sopt.solply_server.domain.place.service.cache.PlaceBookmarkRedisDataManager;
+import org.sopt.solply_server.domain.user.service.mypage.PlaceBookmarkQueryService;
+import org.sopt.solply_server.global.cache.RedisKeyGenerator;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PlaceBookmarkQueryServiceImpl implements PlaceBookmarkQueryService {
+
+    private final PlaceBookmarkRedisDataManager placeBookmarkRedisDataManager;
+    private final PlaceBookmarkRepository placeBookmarkRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<Long, Boolean> getBookmarkStatus(Long userId, List<Long> placeIds) {
+
+        Map<Long, Boolean> result = new HashMap<>();
+        if (placeIds.isEmpty()) {
+            return result;
+        }
+
+        // TODO: 성능 최적화 필요 (bulk 조회)
+        for (Long placeId : placeIds) {
+            String bookmarkKey = RedisKeyGenerator.generatePlaceBookmarkKey(userId, placeId);
+            PlaceBookmarkRedisDto bookmarkData = placeBookmarkRedisDataManager.getBookmarkDto(bookmarkKey);
+
+            boolean isBookmarked;
+            if (bookmarkData != null) {
+                isBookmarked = bookmarkData.isActive();
+            } else {
+                isBookmarked = placeBookmarkRepository.existsByPlaceIdAndUserId(placeId, userId);
+            }
+            result.put(placeId, isBookmarked);
+        }
+
+        return result;
+    }
+
+}

--- a/src/main/java/org/sopt/solply_server/domain/user/dto/UserPlacePreviewDto.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/dto/UserPlacePreviewDto.java
@@ -1,19 +1,28 @@
 package org.sopt.solply_server.domain.user.dto;
 
+import org.sopt.solply_server.domain.tag.entity.TagName;
+
 public record UserPlacePreviewDto(
         long placeId,
         String placeName,
-        String thumbnailImageUrl
+        String thumbnailImageUrl,
+        TagName mainTag,
+        boolean isBookmarked
 ) {
     public static UserPlacePreviewDto of(
             long placeId,
             String placeName,
-            String thumbnailImageUrl
+            String thumbnailImageUrl,
+            TagName mainTag,
+            boolean isBookmarked
     ) {
         return new UserPlacePreviewDto(
                 placeId,
                 placeName,
-                thumbnailImageUrl
+                thumbnailImageUrl,
+                mainTag,
+                isBookmarked
+
         );
     }
 

--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
@@ -74,14 +74,7 @@ public class UserService {
         }
         Town selectedTown = entityLoader.getTown(user.getSelectedTownId());
 
-        List<UserPlacePreviewDto> myPlacePreviews = myPageFacade.getMyPlacesTop3(user)
-                .stream()
-                .map(place -> UserPlacePreviewDto.of(
-                        place.getId(),
-                        place.getName(),
-                        place.getThumbnailFileKey()
-                ))
-                .toList();
+        List<UserPlacePreviewDto> myPlacePreviews = myPageFacade.getMyPlacePreviewsTop3(user);
 
         return UserProfileGetResponse.of(
                 user,

--- a/src/main/java/org/sopt/solply_server/domain/user/service/mypage/MyPageFacade.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/mypage/MyPageFacade.java
@@ -1,10 +1,12 @@
 package org.sopt.solply_server.domain.user.service.mypage;
 
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.sopt.solply_server.domain.place.dto.PlacePreviewDto;
 import org.sopt.solply_server.domain.place.entity.Place;
 import org.sopt.solply_server.domain.place.repository.PlaceRepository;
+import org.sopt.solply_server.domain.user.dto.UserPlacePreviewDto;
 import org.sopt.solply_server.domain.user.entity.User;
 import org.sopt.solply_server.global.util.s3.ImageUrlProvider;
 import org.springframework.data.domain.Page;
@@ -14,17 +16,34 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MyPageFacade {
 
     private final PlaceRepository placeRepository;
     private final ImageUrlProvider imageUrlProvider;
+    private final PlaceBookmarkQueryService placeBookmarkQueryService;
 
-    @Transactional(readOnly = true)
-    public List<Place> getMyPlacesTop3(User user) {
-        return placeRepository.findTop3ByCreatedByOrderByCreatedAtDesc(user);
+    public List<UserPlacePreviewDto> getMyPlacePreviewsTop3(User user) {
+        List<Place> places = placeRepository.findTop3ByCreatedByOrderByCreatedAtDesc(user);
+
+        List<Long> placeIds = places.stream()
+                .map(Place::getId)
+                .toList();
+
+        Map<Long, Boolean> bookmarkMap =
+                placeBookmarkQueryService.getBookmarkStatus(user.getId(), placeIds);
+
+        return places.stream()
+                .map(place -> UserPlacePreviewDto.of(
+                        place.getId(),
+                        place.getName(),
+                        imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
+                        place.getMainTag(),
+                        bookmarkMap.getOrDefault(place.getId(), false)
+                ))
+                .toList();
     }
 
-    @Transactional(readOnly = true)
     public Page<PlacePreviewDto> getPlacesCreatedBy(Long userId, Pageable pageable) {
         Page<Place> places = placeRepository.findByUserIdWithTown(userId, pageable);
         return places.map(place -> PlacePreviewDto.of(

--- a/src/main/java/org/sopt/solply_server/domain/user/service/mypage/PlaceBookmarkQueryService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/mypage/PlaceBookmarkQueryService.java
@@ -1,0 +1,8 @@
+package org.sopt.solply_server.domain.user.service.mypage;
+
+import java.util.List;
+import java.util.Map;
+
+public interface PlaceBookmarkQueryService {
+    Map<Long, Boolean> getBookmarkStatus(Long userId, List<Long> placeIds);
+}


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
resolves #213 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- 필요한 정보들을 포함해서 보내도록 했습니다.


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 이런 저런 도메인에 걸쳐있는 데이터들이 많아서, 인터페이스를 따로 만들어서 구현체는 각 도메인에서 구현해놓도록 했고, 장소 이미지랑 태그를 같이 fetch join으로 가져오면 데이터 수가 많지는 않지만 카타시안 곱 문제가 생겨서, 이미지쪽에 batch size를 달아놨습니다.

<br/>

## 🚀 알게된 점 (선택)

---

-

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 장소 미리보기에 북마크 상태 정보 추가

## 성능 개선

* 배치 로딩 및 캐싱을 통한 장소 데이터 조회 최적화
* 앱 응답 속도 및 로딩 성능 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->