### PR TITLE
[FIX] 태그 없는 장소 조회 시 에러 던지는 부분 제거

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -22,6 +22,7 @@ import org.sopt.solply_server.domain.place.entity.Place;
 import org.sopt.solply_server.domain.place.service.PlaceBookmarkService;
 import org.sopt.solply_server.domain.course.util.CourseNameGenerator;
 import org.sopt.solply_server.domain.place.service.PlaceService;
+import org.sopt.solply_server.domain.tag.entity.Tag;
 import org.sopt.solply_server.domain.tag.entity.TagName;
 import org.sopt.solply_server.domain.town.entity.Town;
 import org.sopt.solply_server.domain.town.util.TownValidator;
@@ -198,7 +199,7 @@ public class CourseService {
                     return CoursePlaceDetailsDto.of(
                             place,
                             thumbnailUrl,
-                            place.getMainTag(),
+                            place.getMainTag().map(Tag::getName).orElse(null),
                             placeBookmarkMap.getOrDefault(place.getId(), false),
                             coursePlace.getPlaceOrder()
                     );

--- a/src/main/java/org/sopt/solply_server/domain/place/entity/Place.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/entity/Place.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -74,8 +75,7 @@ public class Place extends BaseTimeEntity {
     @Column(name = "longitude")
     private Double longitude;
 
-    @Column(nullable = false)
-    private Long placeDefaultId;
+    @Column(nullable = false) private Long placeDefaultId;
 
     @Column(nullable = false)
     private String placeType;
@@ -111,13 +111,11 @@ public class Place extends BaseTimeEntity {
     /**
      * 장소의 1차 태그(MAIN) 추출
      */
-    public TagName getMainTag() {
+    public Optional<Tag> getMainTag() {
         return this.placeTags.stream()
                 .map(PlaceTag::getTag)
                 .filter(tag -> tag.getType() == TagType.MAIN)
-                .findFirst()
-                .map(Tag::getName)
-                .orElseThrow(() -> new BusinessException(ErrorCode.PLACE_TAG_REQUIRED));
+                .findFirst();
     }
 
     /**

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
@@ -21,6 +21,7 @@ import org.sopt.solply_server.domain.place.dto.response.PlaceSearchResponse;
 import org.sopt.solply_server.domain.place.entity.Place;
 import org.sopt.solply_server.domain.place.repository.PlaceRepository;
 import org.sopt.solply_server.domain.place.service.cache.PlaceBookmarkRedisDataManager;
+import org.sopt.solply_server.domain.tag.entity.Tag;
 import org.sopt.solply_server.domain.tag.util.TagValidator;
 import org.sopt.solply_server.domain.town.entity.Town;
 import org.sopt.solply_server.domain.town.util.TownValidator;
@@ -66,7 +67,7 @@ public class PlaceService {
 
         return PlaceDetailsGetResponse.of(
                 place,
-                place.getMainTag(),
+                place.getMainTag().map(Tag::getName).orElse(null),
                 imageInfos,
                 isBookmarked,
                 town
@@ -91,7 +92,7 @@ public class PlaceService {
                         place.getId(),
                         place.getName(),
                         imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
-                        place.getMainTag(),
+                        place.getMainTag().map(Tag::getName).orElse(null),
                         placeBookmarkService.isBookmarked(userId, place.getId()),
                         townId
                 ))
@@ -138,7 +139,7 @@ public class PlaceService {
                             place.getId(),
                             place.getName(),
                             imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
-                            place.getMainTag(),
+                                place.getMainTag().map(Tag::getName).orElse(null),
                             place.getAddress(),
                             false, // 검색 결과에서는 북마크 여부를 제공 X,
                             town.getId()

--- a/src/main/java/org/sopt/solply_server/domain/recommend/service/RecommendService.java
+++ b/src/main/java/org/sopt/solply_server/domain/recommend/service/RecommendService.java
@@ -16,6 +16,7 @@ import org.sopt.solply_server.domain.place.entity.Place;
 import org.sopt.solply_server.domain.place.repository.PlaceRepository;
 import org.sopt.solply_server.domain.recommend.dto.PlaceInfoDto;
 import org.sopt.solply_server.domain.recommend.dto.response.PlaceRecommendationGetResponse;
+import org.sopt.solply_server.domain.tag.entity.Tag;
 import org.sopt.solply_server.domain.tag.entity.TagName;
 import org.sopt.solply_server.domain.town.util.TownValidator;
 import org.sopt.solply_server.domain.user.entity.User;
@@ -77,7 +78,7 @@ public class RecommendService {
                         place.getId(),
                         place.getName(),
                         imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
-                        place.getMainTag(),
+                        place.getMainTag().map(Tag::getName).orElse(null),
                         place.getIntroduction()
                 ))
                 .collect(Collectors.toList());

--- a/src/main/java/org/sopt/solply_server/domain/user/service/mypage/MyPageFacade.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/mypage/MyPageFacade.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.solply_server.domain.place.dto.PlacePreviewDto;
 import org.sopt.solply_server.domain.place.entity.Place;
 import org.sopt.solply_server.domain.place.repository.PlaceRepository;
+import org.sopt.solply_server.domain.tag.entity.Tag;
 import org.sopt.solply_server.domain.user.dto.UserPlacePreviewDto;
 import org.sopt.solply_server.domain.user.entity.User;
 import org.sopt.solply_server.global.util.s3.ImageUrlProvider;
@@ -38,7 +39,7 @@ public class MyPageFacade {
                         place.getId(),
                         place.getName(),
                         imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
-                        place.getMainTag(),
+                        place.getMainTag().map(Tag::getName).orElse(null),
                         bookmarkMap.getOrDefault(place.getId(), false)
                 ))
                 .toList();
@@ -50,7 +51,7 @@ public class MyPageFacade {
                     place.getId(),
                     place.getName(),
                     imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
-                    place.getMainTag(),
+                    place.getMainTag().map(Tag::getName).orElse(null),
                     false, // isBookmarked 정보는 여기에 포함되지 않음
                     place.getTown().getId()
                 )


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
resolves #219 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- 장소의 태그를 조회할 때 아무런 태그가 없으면 에러를 던지는 로직을 제거했습니다.


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
-

<br/>

## 🚀 알게된 점 (선택)

---

-

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 태그 정보 조회 및 처리 방식을 개선하여 시스템 안정성을 강화했습니다.
  * 장소 정보 조회, 장소 검색, 추천 기능, 사용자 페이지 등 다양한 영역에서 태그 데이터 처리 로직을 최적화했습니다.
  * 코드 일관성을 개선하여 더욱 견고한 기반을 마련했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->