### PR TITLE
Fix/#249 fix bookmark data in redis and recommend cooldown logic

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/bookmark/service/BookmarkCacheManager.java
+++ b/src/main/java/org/sopt/solply_server/domain/bookmark/service/BookmarkCacheManager.java
@@ -1,6 +1,7 @@
 package org.sopt.solply_server.domain.bookmark.service;
 
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.solply_server.domain.bookmark.entity.BookmarkTargetType;
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Component;
 public class BookmarkCacheManager {
 
     private final CacheService cacheService;
+    private static final long ACTIVE_SET_TTL_DAYS = 1;
 
     private String createActiveSetKey(Long userId, BookmarkTargetType type) {
         return "bookmark:active-set:%d:%s".formatted(userId, type.name());
@@ -20,12 +22,17 @@ public class BookmarkCacheManager {
 
     /** 활성 북마크 set에 targetId 추가 (SADD) */
     public void addActive(Long userId, BookmarkTargetType type, Long targetId) {
-        cacheService.sAdd(createActiveSetKey(userId, type), targetId);
+        String key = createActiveSetKey(userId, type);
+        cacheService.sAdd(key, targetId);
+        cacheService.expire(key, ACTIVE_SET_TTL_DAYS, TimeUnit.DAYS);
     }
 
     /** 활성 북마크 set에서 targetId 제거 (SREM) */
+
     public void removeActive(Long userId, BookmarkTargetType type, Long targetId) {
-        cacheService.sRem(createActiveSetKey(userId, type), targetId);
+        String key = createActiveSetKey(userId, type);
+        cacheService.sRem(key, targetId);
+        cacheService.expire(key, ACTIVE_SET_TTL_DAYS, TimeUnit.DAYS);
     }
 
     /** 활성 북마크 targetId들 반환 (SMEMBERS) */
@@ -40,8 +47,12 @@ public class BookmarkCacheManager {
 
     /** 여러 개 한번에 추가 */
     public void addActiveAll(Long userId, BookmarkTargetType type, Set<Long> targetIds) {
-        cacheService.sAddAll(createActiveSetKey(userId, type), targetIds);
+        String key = createActiveSetKey(userId, type);
+        cacheService.sAddAll(key, targetIds);
+        cacheService.expire(key, ACTIVE_SET_TTL_DAYS, TimeUnit.DAYS);
     }
 
-
+    public boolean hasActiveSet(Long userId, BookmarkTargetType type) {
+        return Boolean.TRUE.equals(cacheService.hasKey(createActiveSetKey(userId, type)));
+    }
 }

--- a/src/main/java/org/sopt/solply_server/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/org/sopt/solply_server/domain/bookmark/service/BookmarkService.java
@@ -39,6 +39,7 @@ public class BookmarkService {
         validatorRegistry.validator(type).validate(targetId);
 
         bookmarkRepository.save(Bookmark.create(user, type, targetId));
+
         eventPublisher.publishEvent(new BookmarkCreatedEvent(userId, type, targetId));
     }
 
@@ -56,13 +57,19 @@ public class BookmarkService {
 
     /** 단건 체크: Redis set 우선 -> DB fallback -> Redis backfill */
     public boolean isBookmarked(Long userId, BookmarkTargetType type, Long targetId) {
+        // 1) ttl로 인해 데이터가 없으면: DB에서 전체 backfill
+        if (!bookmarkCacheManager.hasActiveSet(userId, type)) {
+            Set<Long> ids = getBookmarkedTargetIds(userId, type);
+            bookmarkCacheManager.addActiveAll(userId, type, ids);
+            return ids.contains(targetId);
+        }
+
+        // 2) key 있으면: Redis 우선
         if (bookmarkCacheManager.isActive(userId, type, targetId)) return true;
 
+        // 3) 그래도 없으면 DB 확인 후 단건 보정
         boolean exists = bookmarkRepository.existsByUserIdAndTargetTypeAndTargetId(userId, type, targetId);
-        // DB에 있으면 Redis에 재적재
-        if (exists)
-            bookmarkCacheManager.addActive(userId, type, targetId);
-
+        if (exists) bookmarkCacheManager.addActive(userId, type, targetId);
         return exists;
     }
 
@@ -70,7 +77,7 @@ public class BookmarkService {
     public Map<Long, Boolean> getBookmarkStatusMap(Long userId, BookmarkTargetType type, List<Long> targetIds) {
         if (targetIds == null || targetIds.isEmpty()) return Map.of();
 
-        Set<Long> activeIds = findBookmarkedTargetIds(userId, type);
+        Set<Long> activeIds = getBookmarkedTargetIds(userId, type);
 
         Map<Long, Boolean> result = new HashMap<>();
         for (Long id : targetIds) {
@@ -81,7 +88,7 @@ public class BookmarkService {
 
     /** “활성 북마크 id들 가져오는 메서드” */
     public Set<Long> getActiveBookmarkedIds(Long userId, BookmarkTargetType type) {
-        return findBookmarkedTargetIds(userId, type);
+        return getBookmarkedTargetIds(userId, type);
     }
 
     @Transactional(readOnly = true)
@@ -89,7 +96,7 @@ public class BookmarkService {
             Long userId,
             BookmarkTargetType type
     ) {
-        Set<Long> activeIds = findBookmarkedTargetIds(userId, type);
+        Set<Long> activeIds = getBookmarkedTargetIds(userId, type);
         if (activeIds == null || activeIds.isEmpty()) return Map.of();
         List<Bookmark> bookmarks = bookmarkRepository.findByUserIdAndTargetTypeAndTargetIdIn(
                 userId, type, activeIds
@@ -107,7 +114,7 @@ public class BookmarkService {
     }
 
     /** 북마크한 targetId 조회: 캐시 -> DB fallback (실패시) -> Redis backfill */
-    private Set<Long> findBookmarkedTargetIds(Long userId, BookmarkTargetType type) {
+    private Set<Long> getBookmarkedTargetIds(Long userId, BookmarkTargetType type) {
         Set<Long> activeIds = bookmarkCacheManager.getActiveTargetIds(userId, type);
         // 캐시 미스
         if (activeIds == null) {

--- a/src/main/java/org/sopt/solply_server/domain/bookmark/service/event/BookmarkEventHandler.java
+++ b/src/main/java/org/sopt/solply_server/domain/bookmark/service/event/BookmarkEventHandler.java
@@ -1,7 +1,10 @@
 package org.sopt.solply_server.domain.bookmark.service.event;
 
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.sopt.solply_server.domain.bookmark.entity.BookmarkTargetType;
+import org.sopt.solply_server.domain.bookmark.repository.BookmarkRepository;
 import org.sopt.solply_server.domain.bookmark.service.BookmarkCacheManager;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -13,11 +16,23 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class BookmarkEventHandler {
 
     private final BookmarkCacheManager bookmarkCacheManager;
+    private final BookmarkRepository bookmarkRepository;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onCreated(BookmarkCreatedEvent event) {
         try {
-            bookmarkCacheManager.addActive(event.userId(), event.type(), event.targetId());
+            Long userId = event.userId();
+            BookmarkTargetType type = event.type();
+            Long targetId = event.targetId();
+
+            // key 없으면 backfill, 있으면 SADD
+            if (!bookmarkCacheManager.hasActiveSet(userId, type)) {
+                Set<Long> ids = bookmarkRepository.findBookmarkedTargetIds(userId, type);
+                bookmarkCacheManager.addActiveAll(userId, type, ids);
+            } else {
+                bookmarkCacheManager.addActive(userId, type, targetId);
+            }
+
         } catch (Exception e) {
             log.warn("[Redis] 커밋 이후 addActive 실패 - {}", event, e);
         }

--- a/src/main/java/org/sopt/solply_server/domain/recommend/cache/DailyRecommendCache.java
+++ b/src/main/java/org/sopt/solply_server/domain/recommend/cache/DailyRecommendCache.java
@@ -6,6 +6,12 @@ import java.util.Set;
 
 public interface DailyRecommendCache {
     List<Long> getTodayPlaceIds(Long userId, Long townId, LocalDate date);
-    void saveTodayRecommendedPlaceIds(Long userId, Long townId, LocalDate date, List<Long> placeIds);
-    Set<Long> getCooldownPlaceIds(Long userId, Long townId, LocalDate date, int days); // 최근 n일 추천된 placeIds 합집합
+    void saveTodayRecommendedPlaceIds(
+            Long userId,
+            Long townId,
+            LocalDate date,
+            List<Long> placeIds,
+            int retentionDays
+    );
+    Set<Long> getCooldownPlaceIds(Long userId, Long townId, LocalDate date, int cooldownDays); // 최근 n일 추천된 placeIds 합집합
 }

--- a/src/main/java/org/sopt/solply_server/domain/recommend/cache/RedisDailyRecommendCache.java
+++ b/src/main/java/org/sopt/solply_server/domain/recommend/cache/RedisDailyRecommendCache.java
@@ -23,7 +23,7 @@ public class RedisDailyRecommendCache implements DailyRecommendCache {
     private final CacheService cacheService;
 
     @Override
-    public List<Long> getTodayPlaceIds(Long userId, Long townId, LocalDate date) {
+    public List<Long> getTodayPlaceIds(final Long userId, final Long townId, final LocalDate date) {
         if (userId == null || townId == null || date == null) return List.of();
 
         String key = key(userId, townId, date);
@@ -32,7 +32,8 @@ public class RedisDailyRecommendCache implements DailyRecommendCache {
     }
 
     @Override
-    public void saveTodayRecommendedPlaceIds(Long userId, Long townId, LocalDate date, List<Long> placeIds) {
+    public void saveTodayRecommendedPlaceIds(final Long userId, final Long townId, final LocalDate date,
+            final List<Long> placeIds, final int retentionDays) {
         if (userId == null || townId == null || date == null) return;
         if (placeIds == null || placeIds.isEmpty()) return;
 
@@ -45,24 +46,23 @@ public class RedisDailyRecommendCache implements DailyRecommendCache {
 
         String key = key(userId, townId, date);
 
-        long ttlSeconds = ttlSecondsUntilEndOfDay();
+        long ttlSeconds = ttlSecondsUntilExpireDate(date, retentionDays);
         if (ttlSeconds <= 0) {
-            // 혹시나 자정이 지났거나 계산이 꼬였을 때: 그냥 저장(또는 저장하지 않기)
-            cacheService.setList(key, normalized);
+            cacheService.setList(key, placeIds);
             return;
         }
 
-        cacheService.setList(key, normalized, (int) ttlSeconds, TimeUnit.SECONDS);
+        cacheService.setList(key, placeIds, (int) ttlSeconds, TimeUnit.SECONDS);
     }
 
     @Override
-    public Set<Long> getCooldownPlaceIds(Long userId, Long townId, LocalDate date, int days) {
+    public Set<Long> getCooldownPlaceIds(final Long userId, final Long townId, final LocalDate date, final int cooldownDays) {
         if (userId == null || townId == null || date == null) return Set.of();
-        if (days <= 0) return Set.of();
+        if (cooldownDays <= 0) return Set.of();
 
-        // 오늘 제외: date-1 ~ date-days
+        // 오늘 제외: date-1 ~ date-cooldownDays
         Set<Long> result = new HashSet<>();
-        for (int i = 1; i <= days; i++) {
+        for (int i = 1; i <= cooldownDays; i++) {
             LocalDate d = date.minusDays(i);
             String key = key(userId, townId, d);
 
@@ -76,21 +76,22 @@ public class RedisDailyRecommendCache implements DailyRecommendCache {
 
     // ---------------- helpers ----------------
 
-    private String key(Long userId, Long townId, LocalDate date) {
+    private String key(final Long userId, final Long townId, final LocalDate date) {
         return KEY_PREFIX + ":" + userId + ":" + townId + ":" + yyyymmdd(date);
     }
 
-    private String yyyymmdd(LocalDate date) {
+    private String yyyymmdd(final LocalDate date) {
         return date.toString().replace("-", "");
     }
 
     /**
-     * "오늘 자정(다음날 00:00)"까지 남은 TTL(초)
+     * "오늘 자정(3일 후 00:00)"까지 남은 TTL(초)
      * - date 파라미터와 무관하게 '지금 기준 오늘'로 계산 (RecommendService도 LocalDate.now() 쓰는 전제)
      */
-    private long ttlSecondsUntilEndOfDay() {
+    private long ttlSecondsUntilExpireDate(LocalDate date, int days) {
         ZonedDateTime now = ZonedDateTime.now(KST);
-        ZonedDateTime endExclusive = now.toLocalDate().plusDays(1).atStartOfDay(KST);
-        return Duration.between(now, endExclusive).getSeconds();
+        ZonedDateTime expireAt =
+                date.plusDays(days).plusDays(1).atStartOfDay(KST);
+        return Duration.between(now, expireAt).getSeconds();
     }
 }

--- a/src/main/java/org/sopt/solply_server/domain/recommend/service/RecommendService.java
+++ b/src/main/java/org/sopt/solply_server/domain/recommend/service/RecommendService.java
@@ -118,18 +118,13 @@ public class RecommendService {
                                         Integer::sum
                                 ));
 
-        // 5) 최근 3일 추천 쿨다운 제외
-        final Set<Long> cooldownIds  = Optional.ofNullable(
-                dailyRecommendCache.getCooldownPlaceIds(userId, townId, today, COOLDOWN_DAYS)
-        ).orElse(Set.of());
-
-        // 6) 동네 장소 조회(+tags)
+        // 5) 동네 장소 조회(+tags)
         List<Place> townPlaces = placeRepository.findPlacesByTownIdWithTags(townId);
         if (townPlaces == null || townPlaces.isEmpty()) {
             return new PlaceRecommendationGetResponse(List.of());
         }
 
-        // 7) 점수 계산 → 후보 Top10 추림 (쿨다운 적용 + 필요시 완화)
+        // 6) 점수 계산 → 후보 Top10 추림 (쿨다운 적용 + 필요시 완화)
         List<ScoredPlace> topCandidates = buildTopCandidates(
                 townPlaces,
                 personaTagIds,
@@ -141,16 +136,16 @@ public class RecommendService {
             return new PlaceRecommendationGetResponse(List.of());
         }
 
-        // 8) Top10에서 가중치 랜덤으로 3개 뽑기(중복 없이)
+        // 7) Top10에서 가중치 랜덤으로 3개 뽑기(중복 없이)
         List<ScoredPlace> picked = pickWeightedRandomWithoutDup(topCandidates, PICK_K);
 
-        // 9) 오늘 결과 저장(하루 고정)
+        // 8) 오늘 결과 저장(하루 고정)
         List<Long> pickedIds = picked.stream()
                 .map(sp -> sp.place().getId())
                 .toList();
-        dailyRecommendCache.saveTodayRecommendedPlaceIds(userId, townId, today, pickedIds);
+        dailyRecommendCache.saveTodayRecommendedPlaceIds(userId, townId, today, pickedIds, COOLDOWN_DAYS);
 
-        // 10) 응답
+        // 9) 응답
         List<PlaceInfoDto> placeInfos = picked.stream()
                 .map(sp -> toDto(sp.place()))
                 .toList();

--- a/src/main/java/org/sopt/solply_server/global/cache/CacheService.java
+++ b/src/main/java/org/sopt/solply_server/global/cache/CacheService.java
@@ -59,4 +59,7 @@ public interface CacheService {
     Boolean sIsMember(String key, Long targetId);
 
     void sAddAll(String key, Set<Long> targetIds);
+
+    void expire(String key, long timeout, TimeUnit unit);
+    Boolean hasKey(String key);
 }

--- a/src/main/java/org/sopt/solply_server/global/cache/RedisCacheService.java
+++ b/src/main/java/org/sopt/solply_server/global/cache/RedisCacheService.java
@@ -380,6 +380,25 @@ public class RedisCacheService implements CacheService {
                 .collect(Collectors.toUnmodifiableSet());
     }
 
+    @Override
+    public void expire(String key, long timeout, TimeUnit unit) {
+        try {
+            stringRedisTemplate.expire(key, timeout, unit);
+        } catch (DataAccessException e) {
+            log.error("[Redis] expire failed. key={}, timeout={}{}", key, timeout, unit, e);
+        }
+    }
+
+    @Override
+    public Boolean hasKey(String key) {
+        try {
+            return stringRedisTemplate.hasKey(key);
+        } catch (DataAccessException e) {
+            log.error("[Redis] hasKey failed. key={}", key, e);
+            return false;
+        }
+    }
+
     // == Private Helper Methods == //
     private <T> T safeGet(String key, Class<T> clazz) {
         try {


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
resolves #249 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- 최근 3일 동안 추천된 장소는 다시 노출되지 않도록 쿨다운 로직을 조정
(Redis 키를 recommend:place:{userId}:{townId}:{yyyyMMdd} 형태로 관리)
- Redis에 저장되는 북마크 active-set에 TTL(1일) 적용
- 북마크 추가/삭제 시:
	•	Redis Set 갱신 후 TTL을 다시 설정해 슬라이딩 TTL 형태로 유지
- TTL 만료로 캐시가 사라진 경우:
	•	다음 조회 시 DB에서 다시 로드(backfill)하여 Redis에 재적재하도록 설계
- TTL 정책은 BookmarkCacheManager에서 관리하도록 역할을 분리


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
-

<br/>

## 🚀 알게된 점 (선택)

---

-

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 성능 개선
* 북마크 캐시 자동 만료 설정 (1일 TTL) 적용
* 북마크 캐시 백필 메커니즘 강화
* 추천 장소 알고리즘 점수 계산 및 필터링 로직 개선
* 캐시 키 존재 여부 확인 및 만료 설정 기능 추가

## 새로운 기능
* 북마크 생성 이벤트 게시 기능 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->