### PR TITLE
[FIX] 온보딩 과정에서 선택한 동네 인자 제거

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/user/dto/request/UserInOnboardingUpdateRequest.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/dto/request/UserInOnboardingUpdateRequest.java
@@ -7,9 +7,6 @@ import java.util.List;
 import org.sopt.solply_server.domain.user.entity.UserPersona;
 
 public record UserInOnboardingUpdateRequest(
-        @NotNull(message = "동네 선택은 필수입니다")
-        Long selectedTownId,
-
         @NotNull(message = "유저 성향은 필수입니다")
         UserPersona persona,
 

--- a/src/main/java/org/sopt/solply_server/domain/user/dto/response/UserProfileGetResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/dto/response/UserProfileGetResponse.java
@@ -10,7 +10,6 @@ public record UserProfileGetResponse(
         Long userId,
         String nickname,
         String profileImageUrl,
-        UserTownInfoDto selectedTown,
         UserPersona persona,
         List<UserPlacePreviewDto> myPlacePreviews
 ) {
@@ -20,7 +19,6 @@ public record UserProfileGetResponse(
                 user.getId(),
                 user.getNickname(),
                 profileImageUrl,
-                selectedTown,
                 user.getPersona(),
                 myPlacePreviews
         );

--- a/src/main/java/org/sopt/solply_server/domain/user/dto/response/UserProfileGetResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/dto/response/UserProfileGetResponse.java
@@ -10,6 +10,7 @@ public record UserProfileGetResponse(
         Long userId,
         String nickname,
         String profileImageUrl,
+        UserTownInfoDto selectedTown,
         UserPersona persona,
         List<UserPlacePreviewDto> myPlacePreviews
 ) {
@@ -19,6 +20,7 @@ public record UserProfileGetResponse(
                 user.getId(),
                 user.getNickname(),
                 profileImageUrl,
+                selectedTown,
                 user.getPersona(),
                 myPlacePreviews
         );

--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
@@ -23,7 +23,6 @@ import org.sopt.solply_server.domain.user.dto.response.UserTownGetResponse;
 import org.sopt.solply_server.domain.user.dto.response.UserTownsUpdateResponse;
 import org.sopt.solply_server.domain.user.entity.User;
 import org.sopt.solply_server.domain.user.entity.UserPersona;
-import org.sopt.solply_server.domain.user.repository.UserPolicyRepository;
 import org.sopt.solply_server.domain.user.repository.UserRepository;
 import org.sopt.solply_server.domain.user.service.mypage.MyPageFacade;
 import org.sopt.solply_server.global.dto.PagedInfo;
@@ -52,8 +51,9 @@ public class UserService {
     private final UserRepository userRepository;
     private final PresignedUrlProvider presignedUrlProvider;
     private final S3FileMoveService s3FileMoveService;
-    private final UserPolicyRepository userPolicyRepository;
     private final UserPolicyService userPolicyService;
+
+    private final int INITIAL_TOWN_ID = 2;
 
     public NicknameCheckResponse checkNickname(Long userId, String nickname) {
         User user = entityLoader.getUser(userId);
@@ -129,12 +129,12 @@ public class UserService {
     public UserInOnboardingUpdateResponse updateUserInfoInOnboarding(
             final Long userId, UserInOnboardingUpdateRequest request) {
         User user = entityLoader.getUser(userId);
-        Town selectedTown = entityLoader.getTown(request.selectedTownId());
+        Town selectedTown = entityLoader.getTown((long)INITIAL_TOWN_ID);
 
         userValidator.validateOnboardingAvailable(user);
         userValidator.validateNickname(user.getNickname(), request.nickname());
 
-        user.updateOnboardingInfo(request.persona(), request.nickname(), request.selectedTownId());
+        user.updateOnboardingInfo(request.persona(), request.nickname(), (long)INITIAL_TOWN_ID);
 
         // 약관 동의 여부 저장
         for (var policyInfo : request.policyAgreementInfos()) {

--- a/src/main/java/org/sopt/solply_server/global/util/EntityLoader.java
+++ b/src/main/java/org/sopt/solply_server/global/util/EntityLoader.java
@@ -52,10 +52,6 @@ public class EntityLoader {
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_TOWN));
     }
 
-    public List<Course> getCourseWithTowns(List<Long> courseIds) {
-        return courseRepository.findAllByIdsWithTowns(courseIds);
-    }
-
 //    public List<UserInterestTown> getInterestTownsWithTownsByIds(Long userId) {
 //        return userInterestTownRepository.findAllByUserWithTown(userId);
 //    }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #251 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- 온보딩 과정에서의 동네 선택을 제거하는 방향으로 수정했습니다.


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
-

<br/>

## 🚀 알게된 점 (선택)

---

-

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **기능 변경**
  * 회원가입 프로세스에서 동네 선택 단계가 제거되었습니다. 이제 사용자에게 기본 동네가 자동으로 할당됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->