### PR TITLE
[FIX] apple login처럼 OIDC의 ID Token(JWT)을 Nimbus로 검증하는 방식으로 변경

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/auth/dto/request/SocialLoginRequest.java
+++ b/src/main/java/org/sopt/solply_server/domain/auth/dto/request/SocialLoginRequest.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 public record SocialLoginRequest(
-        @Schema(example = "Kakao/Google - AccessToken, Apple - ID Token")
+        @Schema(example = "Kakao - AccessToken, Google/Apple - ID Token")
         @NotBlank String token
 ) {
 

--- a/src/main/java/org/sopt/solply_server/domain/auth/service/oauth/IdTokenProvider.java
+++ b/src/main/java/org/sopt/solply_server/domain/auth/service/oauth/IdTokenProvider.java
@@ -1,0 +1,12 @@
+package org.sopt.solply_server.domain.auth.service.oauth;
+
+import org.sopt.solply_server.domain.auth.entity.SocialPlatform;
+
+public interface IdTokenProvider {
+
+    SocialPlatform platform();
+
+    Payload parseAndValidate(String idToken);
+
+    record Payload(String sub, String email) {}
+}

--- a/src/main/java/org/sopt/solply_server/domain/auth/service/oauth/apple/AppleIdTokenProvider.java
+++ b/src/main/java/org/sopt/solply_server/domain/auth/service/oauth/apple/AppleIdTokenProvider.java
@@ -1,0 +1,89 @@
+package org.sopt.solply_server.domain.auth.service.oauth.apple;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.jwk.source.RemoteJWKSet;
+import com.nimbusds.jose.proc.JWSKeySelector;
+import com.nimbusds.jose.proc.JWSVerificationKeySelector;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jose.util.DefaultResourceRetriever;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+import java.net.URI;
+import java.net.URL;
+import org.sopt.solply_server.domain.auth.entity.SocialPlatform;
+import org.sopt.solply_server.domain.auth.service.oauth.IdTokenProvider;
+import org.sopt.solply_server.global.exception.BusinessException;
+import org.sopt.solply_server.global.exception.ErrorCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AppleIdTokenProvider implements IdTokenProvider {
+
+    private static final String ISSUER = "https://appleid.apple.com";
+    private static final String JWK_SET_URL = "https://appleid.apple.com/auth/keys";
+    private final JWKSource<SecurityContext> keySource;
+
+    @Value("${oauth.apple.client-id}")
+    private String clientId;
+
+    public AppleIdTokenProvider() {
+        try {
+            URL jwkSetUrl = URI.create(JWK_SET_URL).toURL();
+
+            DefaultResourceRetriever resourceRetriever = new DefaultResourceRetriever(
+                    2000,  // connect timeout (ms)
+                    2000,  // read timeout (ms)
+                    1024 * 1024 // size limit (1MB)
+            );
+
+            this.keySource = new RemoteJWKSet<>(jwkSetUrl, resourceRetriever);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to initialize ApplePublicKeyProvider", e);
+        }
+    }
+
+    @Override
+    public SocialPlatform platform() {
+        return SocialPlatform.APPLE;
+    }
+
+    @Override
+    public Payload parseAndValidate(String idToken) {
+        try {
+            DefaultJWTProcessor<SecurityContext> jwtProcessor = new DefaultJWTProcessor<>();
+            JWSKeySelector<SecurityContext> keySelector =
+                    new JWSVerificationKeySelector<>(JWSAlgorithm.RS256, keySource);
+            jwtProcessor.setJWSKeySelector(keySelector);
+
+            JWTClaimsSet claimsSet = jwtProcessor.process(idToken, null);
+
+            if (!ISSUER.equals(claimsSet.getIssuer())) {
+                throw new BusinessException(ErrorCode.APPLE_INVALID_ISSUER);
+            }
+
+            var audience = claimsSet.getAudience();
+            if (audience == null || !audience.contains(clientId)) {
+                throw new BusinessException(ErrorCode.INVALID_AUDIENCE);
+            }
+
+            // exp 확인
+            if (claimsSet.getExpirationTime() == null ||
+                    claimsSet.getExpirationTime().getTime() < System.currentTimeMillis()) {
+                throw new BusinessException(ErrorCode.EXPIRED_TOKEN);
+            }
+
+            String sub = claimsSet.getSubject();
+            String email = claimsSet.getStringClaim("email");
+
+            return new Payload(sub, email);
+
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.INVALID_TOKEN);
+        }
+    }
+
+}

--- a/src/main/java/org/sopt/solply_server/domain/auth/service/oauth/apple/AppleOAuthServiceImpl.java
+++ b/src/main/java/org/sopt/solply_server/domain/auth/service/oauth/apple/AppleOAuthServiceImpl.java
@@ -13,12 +13,12 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class AppleOAuthServiceImpl implements OAuthService {
 
-    private final ApplePublicKeyProvider applePublicKeyProvider;
+    private final AppleIdTokenProvider applePublicKeyProvider;
     private final SocialUserService socialUserService;
 
     @Override
     public User socialLogin(String idToken) {
-        ApplePublicKeyProvider.Payload payload = applePublicKeyProvider.parseAndValidate(idToken);
+        AppleIdTokenProvider.Payload payload = applePublicKeyProvider.parseAndValidate(idToken);
         return socialUserService.createOrLoginSocialUser(
                 SocialPlatform.APPLE,
                 payload.sub(),

--- a/src/main/java/org/sopt/solply_server/domain/auth/service/oauth/google/GoogleIdTokenProvider.java
+++ b/src/main/java/org/sopt/solply_server/domain/auth/service/oauth/google/GoogleIdTokenProvider.java
@@ -1,4 +1,4 @@
-package org.sopt.solply_server.domain.auth.service.oauth.apple;
+package org.sopt.solply_server.domain.auth.service.oauth.google;
 
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.jwk.source.JWKSource;
@@ -11,66 +11,86 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.proc.DefaultJWTProcessor;
 import java.net.URI;
 import java.net.URL;
+import java.util.Set;
+import org.sopt.solply_server.domain.auth.entity.SocialPlatform;
+import org.sopt.solply_server.domain.auth.service.oauth.IdTokenProvider;
 import org.sopt.solply_server.global.exception.BusinessException;
 import org.sopt.solply_server.global.exception.ErrorCode;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
-public class ApplePublicKeyProvider {
+public class GoogleIdTokenProvider implements IdTokenProvider {
 
-    private static final String ISSUER = "https://appleid.apple.com";
-    private static final String JWK_SET_URL = "https://appleid.apple.com/auth/keys";
+    private static final Set<String> ISSUERS = Set.of(
+            "https://accounts.google.com",
+            "accounts.google.com"
+    );
+
+    private static final String JWK_SET_URL = "https://www.googleapis.com/oauth2/v3/certs";
     private final JWKSource<SecurityContext> keySource;
 
-    @Value("${oauth.apple.client-id}")
+    @Value("${oauth.google.client-id}")
     private String clientId;
 
-    public ApplePublicKeyProvider() {
+    public GoogleIdTokenProvider() {
         try {
             URL jwkSetUrl = URI.create(JWK_SET_URL).toURL();
 
             DefaultResourceRetriever resourceRetriever = new DefaultResourceRetriever(
-                    2000,  // connect timeout (ms)
-                    2000,  // read timeout (ms)
-                    1024 * 1024 // size limit (1MB)
+                    2000,
+                    2000,
+                    1024 * 1024
             );
 
             this.keySource = new RemoteJWKSet<>(jwkSetUrl, resourceRetriever);
         } catch (Exception e) {
-            throw new RuntimeException("Failed to initialize ApplePublicKeyProvider", e);
+            throw new RuntimeException("Failed to initialize GoogleIdTokenProvider", e);
         }
     }
 
+    @Override
+    public SocialPlatform platform() {
+        return SocialPlatform.GOOGLE;
+    }
+
+    @Override
     public Payload parseAndValidate(String idToken) {
         try {
             DefaultJWTProcessor<SecurityContext> jwtProcessor = new DefaultJWTProcessor<>();
-            JWSKeySelector<SecurityContext> keySelector = new JWSVerificationKeySelector<>(
-                    JWSAlgorithm.RS256, keySource);
+            JWSKeySelector<SecurityContext> keySelector =
+                    new JWSVerificationKeySelector<>(JWSAlgorithm.RS256, keySource);
             jwtProcessor.setJWSKeySelector(keySelector);
 
             JWTClaimsSet claimsSet = jwtProcessor.process(idToken, null);
 
-            if (!ISSUER.equals(claimsSet.getIssuer())) {
-                throw new BusinessException(ErrorCode.APPLE_INVALID_ISSUER);
+            // iss 검증
+            String issuer = claimsSet.getIssuer();
+            if (issuer == null || !ISSUERS.contains(issuer)) {
+                throw new BusinessException(ErrorCode.GOOGLE_INVALID_ISSUER);
             }
 
+            // aud 검증
             var audience = claimsSet.getAudience();
             if (audience == null || !audience.contains(clientId)) {
-                // aud가 우리 앱 번들 아이디가 아니면 무조건 잘못된 토큰
                 throw new BusinessException(ErrorCode.INVALID_AUDIENCE);
+            }
+
+            // exp 확인
+            if (claimsSet.getExpirationTime() == null ||
+                    claimsSet.getExpirationTime().getTime() < System.currentTimeMillis()) {
+                throw new BusinessException(ErrorCode.EXPIRED_TOKEN);
             }
 
             String sub = claimsSet.getSubject();
             String email = claimsSet.getStringClaim("email");
 
             return new Payload(sub, email);
+
         } catch (BusinessException e) {
             throw e;
         } catch (Exception e) {
             throw new BusinessException(ErrorCode.INVALID_TOKEN);
         }
     }
-
-    public record Payload(String sub, String email) { }
 }

--- a/src/main/java/org/sopt/solply_server/domain/auth/service/oauth/google/GoogleOAuthServiceImpl.java
+++ b/src/main/java/org/sopt/solply_server/domain/auth/service/oauth/google/GoogleOAuthServiceImpl.java
@@ -1,16 +1,12 @@
 package org.sopt.solply_server.domain.auth.service.oauth.google;
 
-import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.solply_server.domain.auth.entity.SocialPlatform;
 import org.sopt.solply_server.domain.auth.service.OAuthService;
+import org.sopt.solply_server.domain.auth.service.oauth.IdTokenProvider;
 import org.sopt.solply_server.domain.user.entity.User;
 import org.sopt.solply_server.domain.user.service.SocialUserService;
-import org.sopt.solply_server.global.exception.BusinessException;
-import org.sopt.solply_server.global.exception.ErrorCode;
-import org.sopt.solply_server.global.feign.oauth.google.GoogleServerClient;
-import org.sopt.solply_server.global.feign.oauth.google.dto.GoogleSocialUserProfile;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -19,58 +15,71 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class GoogleOAuthServiceImpl implements OAuthService {
 
-    private final GoogleServerClient googleServerClient;
-    private final SocialUserService socialUserService;
+//    private final GoogleServerClient googleServerClient;
 
     @Value("${oauth.google.client-id}")
     private String googleClientId;
 
+    private final GoogleIdTokenProvider googleIdTokenProvider;
+    private final SocialUserService socialUserService;
+
     @Override
-    public User socialLogin(final String googleAccessToken) {
-        // tokeninfo로 access token 검증
-        GoogleSocialUserProfile googleSocialUserProfile;
-        try {
-            googleSocialUserProfile = googleServerClient.getUserInformation(googleAccessToken);
-        } catch (FeignException e) {
-            log.warn("Google tokeninfo 요청 실패", e);
-            // access token 자체가 유효하지 않음
-            throw new BusinessException(ErrorCode.INVALID_TOKEN);
-        }
+    public User socialLogin(final String googleIdToken) {
+        IdTokenProvider.Payload payload = googleIdTokenProvider.parseAndValidate(googleIdToken);
 
-        // aud 검증
-        if (!googleClientId.equals(googleSocialUserProfile.getAud())) {
-            log.warn("Google aud mismatch. expected={}, actual={}", googleClientId, googleSocialUserProfile .getAud());
-            throw new BusinessException(ErrorCode.INVALID_AUDIENCE);
-        }
-
-        // exp 검증 (만료 여부)
-        long expEpochSeconds = Long.parseLong(googleSocialUserProfile.getExp());
-        long nowEpochSeconds = System.currentTimeMillis() / 1000;
-        if (expEpochSeconds < nowEpochSeconds) {
-            log.warn("Google access token expired. exp={}", expEpochSeconds);
-            throw new BusinessException(ErrorCode.EXPIRED_TOKEN);
-        }
-
-        // userinfo 호출해서 프로필 가져오기
-        GoogleSocialUserProfile profile;
-        try {
-            profile = googleServerClient.getUserInformation("Bearer " + googleAccessToken);
-        } catch (FeignException e) {
-            log.warn("Google userinfo 요청 실패", e);
-            throw e;
-        }
-
-        // 유저 생성/로그인
         return socialUserService.createOrLoginSocialUser(
                 SocialPlatform.GOOGLE,
-                String.valueOf(profile.getSub()),
-                profile.getEmail()
+                payload.sub(),
+                payload.email()
         );
     }
-
 
     @Override
     public boolean support(final SocialPlatform socialPlatform) {
         return socialPlatform == SocialPlatform.GOOGLE;
     }
+
+    // ID Token 방식으로 변경
+//    @Override
+//    public User socialLogin(final String googleAccessToken) {
+//        // tokeninfo로 access token 검증
+//        GoogleSocialUserProfile googleSocialUserProfile;
+//        try {
+//            googleSocialUserProfile = googleServerClient.getUserInformation(googleAccessToken);
+//        } catch (FeignException e) {
+//            log.warn("Google tokeninfo 요청 실패", e);
+//            // access token 자체가 유효하지 않음
+//            throw new BusinessException(ErrorCode.INVALID_TOKEN);
+//        }
+//
+//        // aud 검증
+//        if (!googleClientId.equals(googleSocialUserProfile.getAud())) {
+//            log.warn("Google aud mismatch. expected={}, actual={}", googleClientId, googleSocialUserProfile .getAud());
+//            throw new BusinessException(ErrorCode.INVALID_AUDIENCE);
+//        }
+//
+//        // exp 검증 (만료 여부)
+//        long expEpochSeconds = Long.parseLong(googleSocialUserProfile.getExp());
+//        long nowEpochSeconds = System.currentTimeMillis() / 1000;
+//        if (expEpochSeconds < nowEpochSeconds) {
+//            log.warn("Google access token expired. exp={}", expEpochSeconds);
+//            throw new BusinessException(ErrorCode.EXPIRED_TOKEN);
+//        }
+//
+//        // userinfo 호출해서 프로필 가져오기
+//        GoogleSocialUserProfile profile;
+//        try {
+//            profile = googleServerClient.getUserInformation("Bearer " + googleAccessToken);
+//        } catch (FeignException e) {
+//            log.warn("Google userinfo 요청 실패", e);
+//            throw e;
+//        }
+//
+//        // 유저 생성/로그인
+//        return socialUserService.createOrLoginSocialUser(
+//                SocialPlatform.GOOGLE,
+//                String.valueOf(profile.getSub()),
+//                profile.getEmail()
+//        );
+//    }
 }

--- a/src/main/java/org/sopt/solply_server/global/exception/ErrorCode.java
+++ b/src/main/java/org/sopt/solply_server/global/exception/ErrorCode.java
@@ -48,6 +48,7 @@ public enum ErrorCode {
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "SOCIAL-007", "만료된 토큰입니다."),
     INVALID_SOCIAL_LOGIN_PAYLOAD(HttpStatus.BAD_REQUEST, "SOCIAL-008" , "이메일 혹은 socailId 값이 비어있습니다." ),
     SOCIAL_ACCOUNT_ALREADY_LINKED(HttpStatus.BAD_REQUEST, "SOCIAL-009" , "이미 해당 소셜 계정으로 가입되어 있는 사용장입니다." ),
+    GOOGLE_INVALID_ISSUER(HttpStatus.UNAUTHORIZED, "SOCIAL-010" , "구글 토큰의 발급자(issuer)가 유효하지 않습니다." ),
 
     // 유저 관련 (USER-xxx)
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "USER-001", "사용자를 찾을 수 없습니다."),

--- a/src/main/java/org/sopt/solply_server/global/feign/oauth/google/GoogleServerClient.java
+++ b/src/main/java/org/sopt/solply_server/global/feign/oauth/google/GoogleServerClient.java
@@ -7,6 +7,7 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 
+@Deprecated
 @FeignClient(name = "googleServerClient", url = "https://www.googleapis.com")
 public interface GoogleServerClient {
 

--- a/src/main/java/org/sopt/solply_server/global/feign/oauth/google/dto/GoogleSocialUserProfile.java
+++ b/src/main/java/org/sopt/solply_server/global/feign/oauth/google/dto/GoogleSocialUserProfile.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Deprecated
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)

--- a/src/main/java/org/sopt/solply_server/global/jwt/util/JwtHeaderUtils.java
+++ b/src/main/java/org/sopt/solply_server/global/jwt/util/JwtHeaderUtils.java
@@ -1,0 +1,35 @@
+package org.sopt.solply_server.global.jwt.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.sopt.solply_server.global.exception.BusinessException;
+import org.sopt.solply_server.global.exception.ErrorCode;
+
+import java.util.Base64;
+
+public final class JwtHeaderUtils {
+
+    private static final ObjectMapper OM = new ObjectMapper();
+
+    private JwtHeaderUtils() {}
+
+    public static String extractKid(final String jwt) {
+        try {
+            String[] parts = jwt.split("\\.");
+            if (parts.length != 3) throw new BusinessException(ErrorCode.INVALID_TOKEN);
+
+            String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]));
+            JsonNode node = OM.readTree(headerJson);
+
+            JsonNode kidNode = node.get("kid");
+            if (kidNode == null || kidNode.asText().isBlank()) {
+                throw new BusinessException(ErrorCode.INVALID_TOKEN);
+            }
+            return kidNode.asText();
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.INVALID_TOKEN);
+        }
+    }
+}

--- a/src/main/java/org/sopt/solply_server/global/jwt/util/RsaKeyUtils.java
+++ b/src/main/java/org/sopt/solply_server/global/jwt/util/RsaKeyUtils.java
@@ -1,0 +1,30 @@
+package org.sopt.solply_server.global.jwt.util;
+
+import org.sopt.solply_server.global.exception.BusinessException;
+import org.sopt.solply_server.global.exception.ErrorCode;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+
+public final class RsaKeyUtils {
+
+    private RsaKeyUtils() {}
+
+    public static PublicKey toPublicKey(final String n, final String e) {
+        try {
+            byte[] nBytes = Base64.getUrlDecoder().decode(n);
+            byte[] eBytes = Base64.getUrlDecoder().decode(e);
+
+            BigInteger modulus = new BigInteger(1, nBytes);
+            BigInteger exponent = new BigInteger(1, eBytes);
+
+            RSAPublicKeySpec spec = new RSAPublicKeySpec(modulus, exponent);
+            return KeyFactory.getInstance("RSA").generatePublic(spec);
+        } catch (Exception ex) {
+            throw new BusinessException(ErrorCode.INVALID_TOKEN);
+        }
+    }
+}


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
resolves #253 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- 애플로그인처럼 모바일/SPA에서 받은 id_token을 서버에서 ‘로컬 검증(서명검증)’해서 로그인 처리하는 Provider(전략) 패턴을 사용했습니다.


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- Nimbus로 id token을 검증하는 작업은 다음과 같습니다.
	1.	JWK Set 가져오기 (구글/애플 공개키 목록)
	2.	JWT 헤더의 kid 보고 맞는 키 선택
	3.	서명 검증(RS256)
	4.	iss / aud / exp 검증
	5.	sub, email 추출해서 우리 유저로 로그인/회원가입

<br/>

## 🚀 알게된 점 (선택)

---

-

<br/>

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!

---

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * OAuth 인증에서 ID 토큰 기반 검증 추가로 보안 강화

* **개선 사항**
  * Apple 및 Google 소셜 로그인 검증 로직 개선
  * 토큰 만료 및 발급자 검증 추가

* **지원 중단**
  * 기존 Google OAuth 검증 방식 지원 중단

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->