### PR TITLE
[FEAT] 정보 제보 관련 api 구현

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/admin/place/controller/AdminPlaceReportController.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/place/controller/AdminPlaceReportController.java
@@ -58,7 +58,7 @@ public class AdminPlaceReportController {
             summary = "제보 해결 처리",
             description = "제보 상태를 RESOLVED로 변경합니다."
     )
-    @PatchMapping("/{id}/resolve")
+    @PatchMapping("/{id}/resolution")
     public ResponseEntity<CustomApiResponse<AdminPlaceReportResolveResponse>> resolvePlaceReport(
             @Parameter(description = "제보 ID", required = true, example = "10")
             @PathVariable("id") Long id

--- a/src/main/java/org/sopt/solply_server/domain/admin/place/controller/AdminPlaceReportController.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/place/controller/AdminPlaceReportController.java
@@ -1,0 +1,71 @@
+// package org.sopt.solply_server.domain.admin.place.controller;
+
+package org.sopt.solply_server.domain.admin.place.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.sopt.solply_server.domain.admin.place.dto.response.AdminPlaceReportDetailsGetResponse;
+import org.sopt.solply_server.domain.admin.place.dto.response.AdminPlaceReportListGetResponse;
+import org.sopt.solply_server.domain.admin.place.dto.response.AdminPlaceReportResolveResponse;
+import org.sopt.solply_server.domain.admin.place.service.AdminPlaceReportService;
+import org.sopt.solply_server.domain.place.entity.PlaceReportStatus;
+import org.sopt.solply_server.global.dto.CustomApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Admin(잘못된 정보 제보) API", description = "잘못된 정보(장소) 제보 관련 Admin용 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/place-reports")
+public class AdminPlaceReportController {
+
+    private final AdminPlaceReportService adminPlaceReportService;
+
+    @Operation(
+            summary = "제보 목록 조회",
+            description = """
+                    사용자들에 보낸 제보 리스트를 조회합니다.
+                    """
+    )
+    @GetMapping
+    public ResponseEntity<CustomApiResponse<AdminPlaceReportListGetResponse>> getPlaceReports(
+            @RequestParam(required = false) PlaceReportStatus status
+    ) {
+        return CustomApiResponse.success(
+                "장소 제보 목록 조회 성공",
+                adminPlaceReportService.getPlaceReports(status)
+        );
+    }
+
+    @Operation(
+            summary = "제보 상세 조회",
+            description = "제보한 내용을 상세 조회합니다."
+    )
+    @GetMapping("/{id}")
+    public ResponseEntity<CustomApiResponse<AdminPlaceReportDetailsGetResponse>> getPlaceReportDetails(
+            @Parameter(description = "제보 ID", required = true, example = "10")
+            @PathVariable("id") Long id
+    ) {
+        return CustomApiResponse.success(
+                "장소 제보 상세 조회 성공",
+                adminPlaceReportService.getPlaceReportDetails(id)
+        );
+    }
+
+    @Operation(
+            summary = "제보 해결 처리",
+            description = "제보 상태를 RESOLVED로 변경합니다."
+    )
+    @PatchMapping("/{id}/resolve")
+    public ResponseEntity<CustomApiResponse<AdminPlaceReportResolveResponse>> resolvePlaceReport(
+            @Parameter(description = "제보 ID", required = true, example = "10")
+            @PathVariable("id") Long id
+    ) {
+        return CustomApiResponse.success(
+                "장소 제보 해결 처리 성공",
+                adminPlaceReportService.resolvePlaceReport(id)
+        );
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/admin/place/dto/AdminPlaceReportSummaryDto.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/place/dto/AdminPlaceReportSummaryDto.java
@@ -1,0 +1,24 @@
+package org.sopt.solply_server.domain.admin.place.dto;
+
+import java.time.LocalDateTime;
+import org.sopt.solply_server.domain.place.entity.PlaceReport;
+import org.sopt.solply_server.domain.place.entity.PlaceReportStatus;
+import org.sopt.solply_server.domain.place.entity.PlaceReportType;
+
+public record AdminPlaceReportSummaryDto(
+        Long id,
+        PlaceReportType reportType,
+        String placeName,
+        LocalDateTime createdAt,
+        PlaceReportStatus status
+) {
+    public static AdminPlaceReportSummaryDto from(PlaceReport report) {
+        return new AdminPlaceReportSummaryDto(
+                report.getId(),
+                report.getReportType(),
+                report.getPlace().getName(),
+                report.getCreatedAt(),
+                report.getStatus()
+        );
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/admin/place/dto/response/AdminPlaceReportDetailsGetResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/place/dto/response/AdminPlaceReportDetailsGetResponse.java
@@ -1,0 +1,31 @@
+package org.sopt.solply_server.domain.admin.place.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.sopt.solply_server.domain.place.entity.PlaceReport;
+import org.sopt.solply_server.domain.place.entity.PlaceReportStatus;
+import org.sopt.solply_server.domain.place.entity.PlaceReportType;
+
+public record AdminPlaceReportDetailsGetResponse(
+        Long id,
+        LocalDateTime createdAt,
+        String placeName,
+        PlaceReportType reportType,
+        PlaceReportStatus status,
+        String content,
+        List<String> imageKeys
+) {
+    public static AdminPlaceReportDetailsGetResponse of(
+            Long id,
+            LocalDateTime createdAt,
+            String placeName,
+            PlaceReportType reportType,
+            PlaceReportStatus status,
+            String content,
+            List<String> imageUrls
+    ) {
+        return new AdminPlaceReportDetailsGetResponse(
+                id, createdAt, placeName, reportType, status, content, imageUrls
+        );
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/admin/place/dto/response/AdminPlaceReportDetailsGetResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/place/dto/response/AdminPlaceReportDetailsGetResponse.java
@@ -2,7 +2,6 @@ package org.sopt.solply_server.domain.admin.place.dto.response;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import org.sopt.solply_server.domain.place.entity.PlaceReport;
 import org.sopt.solply_server.domain.place.entity.PlaceReportStatus;
 import org.sopt.solply_server.domain.place.entity.PlaceReportType;
 
@@ -13,7 +12,7 @@ public record AdminPlaceReportDetailsGetResponse(
         PlaceReportType reportType,
         PlaceReportStatus status,
         String content,
-        List<String> imageKeys
+        List<String> imageUrls
 ) {
     public static AdminPlaceReportDetailsGetResponse of(
             Long id,

--- a/src/main/java/org/sopt/solply_server/domain/admin/place/dto/response/AdminPlaceReportListGetResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/place/dto/response/AdminPlaceReportListGetResponse.java
@@ -1,0 +1,15 @@
+package org.sopt.solply_server.domain.admin.place.dto.response;
+
+import java.util.List;
+import org.sopt.solply_server.domain.admin.place.dto.AdminPlaceReportSummaryDto;
+import org.sopt.solply_server.domain.place.entity.PlaceReport;
+
+public record AdminPlaceReportListGetResponse(
+        List<AdminPlaceReportSummaryDto> reports
+) {
+    public static AdminPlaceReportListGetResponse of(List<PlaceReport> reports) {
+        return new AdminPlaceReportListGetResponse(
+                reports.stream().map(AdminPlaceReportSummaryDto::from).toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/admin/place/dto/response/AdminPlaceReportResolveResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/place/dto/response/AdminPlaceReportResolveResponse.java
@@ -1,0 +1,13 @@
+package org.sopt.solply_server.domain.admin.place.dto.response;
+
+import org.sopt.solply_server.domain.place.entity.PlaceReport;
+import org.sopt.solply_server.domain.place.entity.PlaceReportStatus;
+
+public record AdminPlaceReportResolveResponse(
+        Long id,
+        PlaceReportStatus status
+) {
+    public static AdminPlaceReportResolveResponse from(PlaceReport report) {
+        return new AdminPlaceReportResolveResponse(report.getId(), report.getStatus());
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/admin/place/service/AdminPlaceReportService.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/place/service/AdminPlaceReportService.java
@@ -1,0 +1,82 @@
+// package org.sopt.solply_server.domain.admin.place.service;
+
+package org.sopt.solply_server.domain.admin.place.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.solply_server.domain.admin.place.dto.response.AdminPlaceReportDetailsGetResponse;
+import org.sopt.solply_server.domain.admin.place.dto.response.AdminPlaceReportListGetResponse;
+import org.sopt.solply_server.domain.admin.place.dto.response.AdminPlaceReportResolveResponse;
+import org.sopt.solply_server.domain.place.entity.PlaceReport;
+import org.sopt.solply_server.domain.place.entity.PlaceReportStatus;
+import org.sopt.solply_server.domain.place.repository.PlaceReportRepository;
+import org.sopt.solply_server.global.exception.BusinessException;
+import org.sopt.solply_server.global.exception.ErrorCode;
+import org.sopt.solply_server.global.util.s3.PresignedUrlProvider;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminPlaceReportService {
+
+    private final PlaceReportRepository placeReportRepository;
+    private final PresignedUrlProvider presignedUrlProvider;
+
+    /**
+     * 어드민: 제보 목록 조회
+     */
+    public AdminPlaceReportListGetResponse getPlaceReports(PlaceReportStatus status) {
+        PlaceReportStatus targetStatus =
+                status != null ? status : PlaceReportStatus.PENDING;
+
+        List<PlaceReport> reports =
+                placeReportRepository.findAllWithPlaceByStatusOrderByCreatedAtDesc(targetStatus);
+
+        return AdminPlaceReportListGetResponse.of(reports);
+    }
+
+    /**
+     * 어드민: 제보 상세 조회
+     */
+
+    public AdminPlaceReportDetailsGetResponse getPlaceReportDetails(final Long reportId) {
+        PlaceReport report = placeReportRepository.findByIdWithPlace(reportId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_REPORT));
+
+        List<String> imageUrls = (report.getImageKeys() == null ? List.<String>of() : report.getImageKeys())
+                .stream()
+                .map(presignedUrlProvider::createPresignedUrlToRead) // null일 수 있음
+                .filter(url -> url != null && !url.isBlank())  // 업로드 미완료/blank 제거
+                .toList();
+
+        return AdminPlaceReportDetailsGetResponse.of(
+                report.getId(),
+                report.getCreatedAt(),
+                report.getPlace().getName(),
+                report.getReportType(),
+                report.getStatus(),
+                report.getContent(),
+                imageUrls
+        );
+    }
+
+    /**
+     * 어드민: 제보 해결 처리(RESOLVED)
+     */
+    @Transactional
+    public AdminPlaceReportResolveResponse resolvePlaceReport(final Long reportId) {
+        PlaceReport report = placeReportRepository.findById(reportId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_REPORT));
+
+        if (report.getStatus() != PlaceReportStatus.RESOLVED) {
+            report.updateStatus(PlaceReportStatus.RESOLVED);
+            log.info("장소 제보 해결 처리 - reportId: {}", reportId);
+        }
+
+        return AdminPlaceReportResolveResponse.from(report);
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/place/entity/PlaceReportStatus.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/entity/PlaceReportStatus.java
@@ -7,8 +7,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum PlaceReportStatus {
     PENDING("검토 대기"),
-    APPROVED("승인됨"),
-    REJECTED("거부됨"),
     RESOLVED("해결됨");
 
     private final String description;

--- a/src/main/java/org/sopt/solply_server/domain/place/repository/PlaceReportRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/repository/PlaceReportRepository.java
@@ -1,18 +1,35 @@
 package org.sopt.solply_server.domain.place.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 import org.sopt.solply_server.domain.place.entity.PlaceReport;
 import org.sopt.solply_server.domain.place.entity.PlaceReportStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.time.LocalDateTime;
-import java.util.List;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PlaceReportRepository extends JpaRepository<PlaceReport, Long> {
 
-    List<PlaceReport> findByPlaceIdAndStatus(Long placeId, PlaceReportStatus status);
-
-    List<PlaceReport> findByUserIdOrderByCreatedAtDesc(Long userId);
 
     // 사용자가 특정 장소에 특정 시간 이후 신고했는지 확인 (중복 신고 방지)
     boolean existsByUserIdAndPlaceIdAndCreatedAtAfter(Long userId, Long placeId, LocalDateTime since);
+
+    // ===== Admin용 (N+1 방지 위해 place fetch) =====
+
+    @Query("""
+        select pr
+        from PlaceReport pr
+        join fetch pr.place p
+        where pr.status = :status
+        order by pr.createdAt desc
+       """)
+    List<PlaceReport> findAllWithPlaceByStatusOrderByCreatedAtDesc(PlaceReportStatus status);
+
+    @Query("""
+            select pr
+            from PlaceReport pr
+            join fetch pr.place p
+            where pr.id = :reportId
+           """)
+    Optional<PlaceReport> findByIdWithPlace(Long reportId);
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
resolves #271 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- 단순 CRUD 구현


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 지금 기명세엔 모든 장소 제보 리스트만 불러오게 되어있는데, 제보 완료 처리 기능이랑 미완료/완료 구분해서 필터링 조회 기능이 필요할 것 같아서 일단은 구현해뒀습니다,,

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 관리자용 장소 신고 관리 기능 추가
    * 신고 목록 조회(상태 필터 지원)
    * 신고 상세 조회(유형, 내용, 첨부 이미지, 신고 일시 등)
    * 신고를 해결 상태로 처리 가능
* **변경사항**
  * 신고 상태 옵션 축소: 표시 가능한 상태가 검토 대기(PENDING)와 해결됨(RESOLVED)으로 단순화되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->