### PR TITLE
[FEAT] 장소 관리 관련 어드민 기능 구현

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/admin/place/controller/AdminPlaceController.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/place/controller/AdminPlaceController.java
@@ -1,0 +1,75 @@
+package org.sopt.solply_server.domain.admin.place.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.sopt.solply_server.domain.admin.place.dto.request.AdminPlaceUpsertRequest;
+import org.sopt.solply_server.domain.admin.place.dto.response.AdminPlaceListResponse;
+import org.sopt.solply_server.domain.admin.place.dto.response.AdminPlaceUpsertResponse;
+import org.sopt.solply_server.domain.admin.place.service.AdminPlaceService;
+import org.sopt.solply_server.global.annotation.CurrentUserId;
+import org.sopt.solply_server.global.dto.CustomApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "어드민(장소 데이터 관리) API", description = "장소 데이터 관리 Admin용 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/places")
+public class AdminPlaceController {
+
+    private final AdminPlaceService adminPlaceService;
+
+    @Operation(summary = "어드민 장소 생성", description = "어드민이 새 장소를 생성합니다.")
+    @PostMapping
+    public ResponseEntity<CustomApiResponse<AdminPlaceUpsertResponse>> createPlace(
+            @CurrentUserId Long adminUserId,
+            @Valid @RequestBody AdminPlaceUpsertRequest request
+    ) {
+        return CustomApiResponse.success(
+                "장소 생성 성공",
+                adminPlaceService.createPlace(adminUserId, request)
+        );
+    }
+
+    @Operation(summary = "어드민 장소 수정", description = "placeId 기준으로 장소 정보를 수정합니다.")
+    @PatchMapping("/{id}")
+    public ResponseEntity<CustomApiResponse<AdminPlaceUpsertResponse>> updatePlace(
+            @Parameter(description = "장소 ID", required = true, example = "10")
+            @PathVariable("id") Long placeId,
+            @Valid @RequestBody AdminPlaceUpsertRequest request
+    ) {
+        return CustomApiResponse.success(
+                "장소 수정 성공",
+                adminPlaceService.updatePlace(placeId, request)
+        );
+    }
+
+    @Operation(summary = "어드민 키워드 기반 장소 검색", description = "키워드를 기반으로 장소를 검색합니다.")
+    @GetMapping("/search")
+    public ResponseEntity<CustomApiResponse<AdminPlaceListResponse>> searchPlaces(
+            @Parameter(description = "검색 키워드(최소 2글자)", required = true, example = "연남")
+            @RequestParam("keyword") String keyword
+    ) {
+        return CustomApiResponse.success(
+                "장소 검색 성공",
+                adminPlaceService.searchPlaces(keyword)
+        );
+    }
+
+    @Operation(summary = "어드민 장소 리스트 조회", description = "townId 기준으로 장소 리스트를 조회합니다.")
+    @GetMapping
+    public ResponseEntity<CustomApiResponse<AdminPlaceListResponse>> getPlacesByTown(
+            @Parameter(description = "동네 ID", required = true, example = "1")
+            @RequestParam("townId") Long townId
+    ) {
+        return CustomApiResponse.success(
+                "장소 리스트 조회 성공",
+                adminPlaceService.getPlacesByTown(townId)
+        );
+    }
+
+
+}

--- a/src/main/java/org/sopt/solply_server/domain/admin/place/controller/AdminPlaceController.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/place/controller/AdminPlaceController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.sopt.solply_server.domain.admin.place.dto.request.AdminPlaceUpsertRequest;
+import org.sopt.solply_server.domain.admin.place.dto.response.AdminPlaceDetailsGetResponse;
 import org.sopt.solply_server.domain.admin.place.dto.response.AdminPlaceListResponse;
 import org.sopt.solply_server.domain.admin.place.dto.response.AdminPlaceUpsertResponse;
 import org.sopt.solply_server.domain.admin.place.service.AdminPlaceService;
@@ -46,6 +47,19 @@ public class AdminPlaceController {
                 adminPlaceService.updatePlace(placeId, request)
         );
     }
+
+    @Operation(summary = "어드민 장소 상세 조회", description = "placeId 기준으로 장소 상세 정보를 조회합니다.")
+    @GetMapping("/{id}")
+    public ResponseEntity<CustomApiResponse<AdminPlaceDetailsGetResponse>> getPlaceDetails(
+            @Parameter(description = "장소 ID", required = true, example = "10")
+            @PathVariable("id") Long placeId
+    ) {
+        return CustomApiResponse.success(
+                "장소 상세 조회 성공",
+                adminPlaceService.getPlaceDetails(placeId)
+        );
+    }
+
 
     @Operation(summary = "어드민 키워드 기반 장소 검색", description = "키워드를 기반으로 장소를 검색합니다.")
     @GetMapping("/search")

--- a/src/main/java/org/sopt/solply_server/domain/admin/place/dto/AdminPlaceSummaryDto.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/place/dto/AdminPlaceSummaryDto.java
@@ -1,0 +1,12 @@
+package org.sopt.solply_server.domain.admin.place.dto;
+
+public record AdminPlaceSummaryDto(
+    Long id,
+    String placeName,
+    String townName,
+    String mainTagName
+) {
+    public static AdminPlaceSummaryDto of(Long id, String placeName, String townName, String mainTagName) {
+            return new AdminPlaceSummaryDto(id, placeName, townName, mainTagName);
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/admin/place/dto/request/AdminPlaceUpsertRequest.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/place/dto/request/AdminPlaceUpsertRequest.java
@@ -1,0 +1,58 @@
+package org.sopt.solply_server.domain.admin.place.dto.request;
+
+import jakarta.validation.constraints.*;
+import java.util.List;
+import java.util.Map;
+import org.sopt.solply_server.domain.place.entity.SnsPlatform;
+
+public record AdminPlaceUpsertRequest(
+
+        @NotBlank(message = "장소명은 필수입니다.")
+        @Size(max = 100, message = "장소명은 100자를 초과할 수 없습니다.")
+        String name,
+
+        @NotBlank(message = "소개는 필수입니다.")
+        @Size(max = 500, message = "소개는 500자를 초과할 수 없습니다.")
+        String introduction,
+
+        @Size(max = 255, message = "주소는 255자를 초과할 수 없습니다.")
+        String address,
+
+        @NotNull(message = "placeDefaultId는 필수입니다.")
+        Long placeDefaultId,
+
+        @NotNull(message = "위도는 필수입니다.")
+        @DecimalMin(value = "-90.0", message = "위도 범위가 올바르지 않습니다.")
+        @DecimalMax(value = "90.0", message = "위도 범위가 올바르지 않습니다.")
+        Double latitude,
+
+        @NotNull(message = "경도는 필수입니다.")
+        @DecimalMin(value = "-180.0", message = "경도 범위가 올바르지 않습니다.")
+        @DecimalMax(value = "180.0", message = "경도 범위가 올바르지 않습니다.")
+        Double longitude,
+
+        @NotNull(message = "townId는 필수입니다.")
+        Long townId,
+
+        @NotNull(message = "mainTagId는 필수입니다.")
+        Long mainTagId,
+
+        @NotEmpty(message = "option1TagIds는 1개 이상 필수입니다.")
+        List<@NotNull Long> option1TagIds,
+
+        List<@NotNull Long> option2TagIds,
+
+        List<@NotBlank(message = "imageFileKeys에는 공백 문자열이 올 수 없습니다.") String> imageFileKeys,
+
+        @Size(max = 30, message = "연락처는 30자를 초과할 수 없습니다.")
+        String contactNumber,
+
+        @Size(max = 255, message = "영업시간은 255자를 초과할 수 없습니다.")
+        String openingHours,
+
+        @NotBlank(message = "placeType은 필수입니다.")
+        @Size(max = 50, message = "placeType은 50자를 초과할 수 없습니다.")
+        String placeType,
+
+        Map<SnsPlatform, String> snsLinks
+) {}

--- a/src/main/java/org/sopt/solply_server/domain/admin/place/dto/response/AdminPlaceDetailsGetResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/place/dto/response/AdminPlaceDetailsGetResponse.java
@@ -1,0 +1,59 @@
+package org.sopt.solply_server.domain.admin.place.dto.response;
+
+import java.util.List;
+import java.util.Map;
+import org.sopt.solply_server.domain.place.dto.PlaceImageInfoDto;
+import org.sopt.solply_server.domain.place.entity.SnsPlatform;
+
+public record AdminPlaceDetailsGetResponse(
+        Long id,
+        String name,
+        String introduction,
+        String address,
+        Long placeDefaultId,
+        Double latitude,
+        Double longitude,
+        String contactNumber,
+        String openingHours,
+        String placeType,
+
+        Long townId,
+        String townName,
+
+        Long mainTagId,
+
+        List<Long> option1TagIds,
+        List<Long> option2TagIds,
+
+        Map<SnsPlatform, String> snsLinks,
+
+        List<PlaceImageInfoDto> imageInfos
+) {
+    public static AdminPlaceDetailsGetResponse of(
+            Long id,
+            String name,
+            String introduction,
+            String address,
+            Long placeDefaultId,
+            Double latitude,
+            Double longitude,
+            String contactNumber,
+            String openingHours,
+            String placeType,
+            Long townId,
+            String townName,
+            Long mainTagId,
+            List<Long> option1TagIds,
+            List<Long> option2TagIds,
+            Map<SnsPlatform, String> snsLinks,
+            List<PlaceImageInfoDto> imageInfos
+    ) {
+        return new AdminPlaceDetailsGetResponse(
+                id, name, introduction, address, placeDefaultId,
+                latitude, longitude, contactNumber, openingHours, placeType,
+                townId, townName, mainTagId,
+                option1TagIds, option2TagIds,
+                snsLinks, imageInfos
+        );
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/admin/place/dto/response/AdminPlaceListResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/place/dto/response/AdminPlaceListResponse.java
@@ -1,0 +1,10 @@
+package org.sopt.solply_server.domain.admin.place.dto.response;
+
+import java.util.List;
+import org.sopt.solply_server.domain.admin.place.dto.AdminPlaceSummaryDto;
+
+public record AdminPlaceListResponse(List<AdminPlaceSummaryDto> places) {
+    public static AdminPlaceListResponse of(List<AdminPlaceSummaryDto> places) {
+        return new AdminPlaceListResponse(places);
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/admin/place/dto/response/AdminPlaceUpsertResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/place/dto/response/AdminPlaceUpsertResponse.java
@@ -1,0 +1,7 @@
+package org.sopt.solply_server.domain.admin.place.dto.response;
+
+public record AdminPlaceUpsertResponse(Long placeId) {
+    public static AdminPlaceUpsertResponse of(Long placeId) {
+        return new AdminPlaceUpsertResponse(placeId);
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/admin/place/service/AdminPlaceService.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/place/service/AdminPlaceService.java
@@ -6,10 +6,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.solply_server.domain.admin.place.dto.AdminPlaceSummaryDto;
 import org.sopt.solply_server.domain.admin.place.dto.request.AdminPlaceUpsertRequest;
+import org.sopt.solply_server.domain.admin.place.dto.response.AdminPlaceDetailsGetResponse;
 import org.sopt.solply_server.domain.admin.place.dto.response.AdminPlaceListResponse;
 import org.sopt.solply_server.domain.admin.place.dto.response.AdminPlaceUpsertResponse;
 import org.sopt.solply_server.domain.place.dto.ImageFileKeyUpdateEvent;
+import org.sopt.solply_server.domain.place.dto.PlaceImageInfoDto;
 import org.sopt.solply_server.domain.place.entity.Place;
+import org.sopt.solply_server.domain.place.entity.PlaceTag;
 import org.sopt.solply_server.domain.place.repository.PlaceRepository;
 import org.sopt.solply_server.domain.tag.entity.Tag;
 import org.sopt.solply_server.domain.tag.entity.TagType;
@@ -20,6 +23,7 @@ import org.sopt.solply_server.global.exception.BusinessException;
 import org.sopt.solply_server.global.exception.ErrorCode;
 import org.sopt.solply_server.global.util.EntityLoader;
 import org.sopt.solply_server.global.util.s3.ImageFileKeyValidator;
+import org.sopt.solply_server.global.util.s3.ImageUrlProvider;
 import org.sopt.solply_server.global.util.s3.TargetDir;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -34,9 +38,10 @@ public class AdminPlaceService {
     private final PlaceRepository placeRepository;
     private final EntityLoader entityLoader;
 
-    private final TagValidator tagValidator;                 // ✅ 추가
+    private final TagValidator tagValidator;
     private final ImageFileKeyValidator imageFileKeyValidator;
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final ImageUrlProvider imageUrlProvider;
 
     @Transactional
     public AdminPlaceUpsertResponse createPlace(final Long adminUserId, final AdminPlaceUpsertRequest req) {
@@ -119,6 +124,55 @@ public class AdminPlaceService {
         log.info("어드민 장소 수정 - placeId: {}", placeId);
 
         return AdminPlaceUpsertResponse.of(place.getId());
+    }
+
+    public AdminPlaceDetailsGetResponse getPlaceDetails(final Long placeId) {
+        Place place = entityLoader.getPlace(placeId);
+
+        Town town = place.getTown();
+
+        // 이미지 URL 변환
+        List<PlaceImageInfoDto> imageInfos = place.getPlaceImageInfos().stream()
+                .map(info -> PlaceImageInfoDto.of(
+                        info.getDisplayOrder(),
+                        imageUrlProvider.getImageUrl(info.getImageFileKey())
+                ))
+                .toList();
+
+        // 태그 id 추출
+        Long mainTagId = place.getMainTag().map(Tag::getId).orElse(null);
+
+        List<Long> option1TagIds = place.getPlaceTags().stream()
+                .map(PlaceTag::getTag)
+                .filter(t -> t.getType() == TagType.OPTION1)
+                .map(Tag::getId)
+                .toList();
+
+        List<Long> option2TagIds = place.getPlaceTags().stream()
+                .map(PlaceTag::getTag)
+                .filter(t -> t.getType() == TagType.OPTION2)
+                .map(Tag::getId)
+                .toList();
+
+        return AdminPlaceDetailsGetResponse.of(
+                place.getId(),
+                place.getName(),
+                place.getIntroduction(),
+                place.getAddress(),
+                place.getPlaceDefaultId(),
+                place.getLatitude(),
+                place.getLongitude(),
+                place.getContactNumber(),
+                place.getOpeningHours(),
+                place.getPlaceType(),
+                town.getId(),
+                town.getName(),
+                mainTagId,
+                option1TagIds,
+                option2TagIds,
+                place.getSnsLinks(),
+                imageInfos
+        );
     }
 
     public AdminPlaceListResponse searchPlaces(final String keyword) {

--- a/src/main/java/org/sopt/solply_server/domain/admin/place/service/AdminPlaceService.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/place/service/AdminPlaceService.java
@@ -1,0 +1,189 @@
+package org.sopt.solply_server.domain.admin.place.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.solply_server.domain.admin.place.dto.AdminPlaceSummaryDto;
+import org.sopt.solply_server.domain.admin.place.dto.request.AdminPlaceUpsertRequest;
+import org.sopt.solply_server.domain.admin.place.dto.response.AdminPlaceListResponse;
+import org.sopt.solply_server.domain.admin.place.dto.response.AdminPlaceUpsertResponse;
+import org.sopt.solply_server.domain.place.dto.ImageFileKeyUpdateEvent;
+import org.sopt.solply_server.domain.place.entity.Place;
+import org.sopt.solply_server.domain.place.repository.PlaceRepository;
+import org.sopt.solply_server.domain.tag.entity.Tag;
+import org.sopt.solply_server.domain.tag.entity.TagType;
+import org.sopt.solply_server.domain.tag.util.TagValidator;
+import org.sopt.solply_server.domain.town.entity.Town;
+import org.sopt.solply_server.domain.user.entity.User;
+import org.sopt.solply_server.global.exception.BusinessException;
+import org.sopt.solply_server.global.exception.ErrorCode;
+import org.sopt.solply_server.global.util.EntityLoader;
+import org.sopt.solply_server.global.util.s3.ImageFileKeyValidator;
+import org.sopt.solply_server.global.util.s3.TargetDir;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminPlaceService {
+
+    private final PlaceRepository placeRepository;
+    private final EntityLoader entityLoader;
+
+    private final TagValidator tagValidator;                 // ✅ 추가
+    private final ImageFileKeyValidator imageFileKeyValidator;
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @Transactional
+    public AdminPlaceUpsertResponse createPlace(final Long adminUserId, final AdminPlaceUpsertRequest req) {
+        User admin = entityLoader.getUser(adminUserId);
+        Town town = entityLoader.getTown(req.townId());
+
+        // 태그 검증(타입 + 관계)
+        tagValidator.validateTagConditions(req.mainTagId(), req.option1TagIds(), req.option2TagIds());
+
+        Tag mainTag = entityLoader.getTag(req.mainTagId());
+        List<Tag> opt1 = loadTags(req.option1TagIds());
+        List<Tag> opt2 = req.option2TagIds() == null ? List.of() : loadTags(req.option2TagIds());
+
+        // 이미지 키 검증
+        List<String> imageKeys = normalizeKeys(req.imageFileKeys());
+        imageFileKeyValidator.validateFileKeys(imageKeys);
+
+        Place place = Place.create(
+                req.name(),
+                req.introduction(),
+                req.address(),
+                req.placeDefaultId(),
+                req.latitude(),
+                req.longitude(),
+                req.contactNumber(),
+                req.openingHours(),
+                req.placeType(),
+                req.snsLinks(),
+                imageKeys,
+                town,
+                admin,
+                mainTag,
+                opt1,
+                opt2
+        );
+
+        Place saved = placeRepository.save(place);
+
+        publishImageMoveEvent(admin.getId(), saved.getId(), imageKeys);
+
+        log.info("어드민 장소 생성 - adminId: {}, placeId: {}", adminUserId, saved.getId());
+        return AdminPlaceUpsertResponse.of(saved.getId());
+    }
+
+    @Transactional
+    public AdminPlaceUpsertResponse updatePlace(final Long placeId, final AdminPlaceUpsertRequest req) {
+        Place place = entityLoader.getPlace(placeId);
+        Town town = entityLoader.getTown(req.townId());
+
+        // 태그 검증(타입 + 관계)
+        tagValidator.validateTagConditions(req.mainTagId(), req.option1TagIds(), req.option2TagIds());
+
+        Tag mainTag = entityLoader.getTag(req.mainTagId());
+        List<Tag> opt1 = loadTags(req.option1TagIds());
+        List<Tag> opt2 = req.option2TagIds() == null ? List.of() : loadTags(req.option2TagIds());
+
+        // 이미지 키 검증
+        List<String> imageKeys = normalizeKeys(req.imageFileKeys());
+        imageFileKeyValidator.validateFileKeys(imageKeys);
+
+        place.update(
+                req.name(),
+                req.introduction(),
+                req.address(),
+                req.placeDefaultId(),
+                req.latitude(),
+                req.longitude(),
+                req.contactNumber(),
+                req.openingHours(),
+                req.placeType(),
+                town,
+                req.snsLinks(),
+                imageKeys,
+                mainTag,
+                opt1,
+                opt2
+        );
+
+        publishImageMoveEvent(place.getCreatedBy().getId(), place.getId(), imageKeys);
+        log.info("어드민 장소 수정 - placeId: {}", placeId);
+
+        return AdminPlaceUpsertResponse.of(place.getId());
+    }
+
+    public AdminPlaceListResponse searchPlaces(final String keyword) {
+        if (keyword == null || keyword.trim().length() < 2) {
+            throw new BusinessException(ErrorCode.INVALID_KEYWORD);
+        }
+
+        List<Place> base = placeRepository.findPlacesWithTownByKeyword(keyword);
+        if (base.isEmpty()) return AdminPlaceListResponse.of(List.of());
+
+        // tags 로딩(N+1 방지)
+        List<Long> ids = base.stream().map(Place::getId).toList();
+        placeRepository.findByIdInWithTags(ids);
+
+        List<AdminPlaceSummaryDto> result = base.stream()
+                .map(p -> AdminPlaceSummaryDto.of(
+                        p.getId(),
+                        p.getName(),
+                        p.getTown().getName(),
+                        p.getMainTag().map(Tag::getName).orElse(null)
+                ))
+                .toList();
+
+        return AdminPlaceListResponse.of(result);
+    }
+
+    public AdminPlaceListResponse getPlacesByTown(final Long townId) {
+        Town town = entityLoader.getTown(townId); // 존재 검증
+        List<Place> places = placeRepository.findAdminPlacesByTownId(town.getId());
+
+        List<AdminPlaceSummaryDto> result = places.stream()
+                .map(p -> AdminPlaceSummaryDto.of(
+                        p.getId(),
+                        p.getName(),
+                        p.getTown().getName(),
+                        p.getMainTag().map(Tag::getName).orElse(null)
+                ))
+                .toList();
+
+        return AdminPlaceListResponse.of(result);
+    }
+
+
+    private List<String> normalizeKeys(List<String> keys) {
+        return keys == null ? List.of() : keys;
+    }
+
+    private void publishImageMoveEvent(Long userId, Long placeId, List<String> imageKeys) {
+        if (imageKeys == null || imageKeys.isEmpty()) return;
+
+        ImageFileKeyUpdateEvent event = ImageFileKeyUpdateEvent.of(
+                userId,
+                placeId,
+                TargetDir.PLACE,
+                imageKeys
+        );
+        applicationEventPublisher.publishEvent(event);
+    }
+
+    private List<Tag> loadTags(List<Long> tagIds) {
+        if (tagIds == null || tagIds.isEmpty()) return List.of();
+        List<Tag> tags = new ArrayList<>(tagIds.size());
+        for (Long id : tagIds) {
+            tags.add(entityLoader.getTag(id));
+        }
+        return tags;
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/admin/place/service/PlaceImageFieldUpdater.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/place/service/PlaceImageFieldUpdater.java
@@ -1,0 +1,38 @@
+package org.sopt.solply_server.domain.admin.place.service;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.solply_server.domain.place.entity.PlaceImageInfo;
+import org.sopt.solply_server.domain.place.repository.PlaceRepository;
+import org.sopt.solply_server.global.listener.ImageFieldUpdater;
+import org.sopt.solply_server.global.util.s3.TargetDir;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+class PlaceImageFieldUpdater implements ImageFieldUpdater {
+
+    private final PlaceRepository placeRepository;
+
+    @Override
+    public TargetDir supportedDir() {
+        return TargetDir.PLACE;
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void replaceImages(final long placeId, final List<String> destKeys) {
+        var place = placeRepository.findById(placeId).orElseThrow();
+
+        place.getPlaceImageInfos().clear();
+
+        int order = 1; // ✅ Place는 1번이 썸네일이니까 1부터 추천
+        for (String key : new LinkedHashSet<>(destKeys)) {
+            if (key == null || key.isBlank()) continue;
+            place.getPlaceImageInfos().add(new PlaceImageInfo(key, order++));
+        }
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/place/entity/Place.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/entity/Place.java
@@ -103,6 +103,129 @@ public class Place extends BaseTimeEntity {
     @JoinColumn(name = "created_by", nullable = false)
     private User createdBy;
 
+    public static Place create(
+            String name,
+            String introduction,
+            String address,
+            Long placeDefaultId,
+            Double latitude,
+            Double longitude,
+            String contactNumber,
+            String openingHours,
+            String placeType,
+            Map<SnsPlatform, String> snsLinks,
+            List<String> imageFileKeys,
+            Town town,
+            User createdBy,
+            Tag mainTag,
+            List<Tag> option1Tags,
+            List<Tag> option2Tags
+    ) {
+        Place p = new Place();
+        p.name = name;
+        p.introduction = introduction;
+        p.address = address;
+        p.placeDefaultId = placeDefaultId;
+        p.latitude = latitude;
+        p.longitude = longitude;
+        p.contactNumber = contactNumber;
+        p.openingHours = openingHours;
+        p.placeType = placeType;
+        p.town = town;
+        p.createdBy = createdBy;
+
+        p.applySnsLinks(snsLinks);
+        p.replaceImagesByKeys(imageFileKeys);
+        p.replaceTags(mainTag, option1Tags, option2Tags);
+
+        return p;
+    }
+
+    public void update(
+            String name,
+            String introduction,
+            String address,
+            Long placeDefaultId,
+            Double latitude,
+            Double longitude,
+            String contactNumber,
+            String openingHours,
+            String placeType,
+            Town town,
+            Map<SnsPlatform, String> snsLinks,
+            List<String> imageFileKeys,
+            Tag mainTag,
+            List<Tag> option1Tags,
+            List<Tag> option2Tags
+    ) {
+        this.name = name;
+        this.introduction = introduction;
+        this.address = address;
+        this.placeDefaultId = placeDefaultId;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.contactNumber = contactNumber;
+        this.openingHours = openingHours;
+        this.placeType = placeType;
+        this.town = town;
+
+        applySnsLinks(snsLinks);
+        replaceImagesByKeys(imageFileKeys);
+        replaceTags(mainTag, option1Tags, option2Tags);
+    }
+    private void applySnsLinks(Map<SnsPlatform, String> links) {
+        this.snsLinks.clear();
+        if (links == null || links.isEmpty()) return;
+
+        // 값이 null/blank면 제거하고 저장
+        links.forEach((platform, url) -> {
+            if (platform == null) return;
+            if (url == null) return;
+            String trimmed = url.trim();
+            if (trimmed.isBlank()) return;
+            this.snsLinks.put(platform, trimmed);
+        });
+    }
+
+    private void replaceImagesByKeys(List<String> imageFileKeys) {
+        this.placeImageInfos.clear();
+        if (imageFileKeys == null || imageFileKeys.isEmpty()) return;
+
+        // 중복 제거(순서 유지) + displayOrder 1부터
+        int order = 1;
+        for (String key : new java.util.LinkedHashSet<>(imageFileKeys)) {
+            if (key == null) continue;
+            String k = key.trim();
+            if (k.isBlank()) continue;
+            this.placeImageInfos.add(new PlaceImageInfo(k, order++));
+        }
+    }
+
+    private void replaceTags(Tag mainTag, List<Tag> option1Tags, List<Tag> option2Tags) {
+        this.placeTags.clear();
+
+        // MAIN (필수)
+        if (mainTag != null) {
+            this.placeTags.add(PlaceTag.of(this, mainTag));
+        }
+
+        // OPTION1 (1개 이상)
+        if (option1Tags != null) {
+            for (Tag t : new java.util.LinkedHashSet<>(option1Tags)) {
+                if (t == null) continue;
+                this.placeTags.add(PlaceTag.of(this, t));
+            }
+        }
+
+        // OPTION2 (선택)
+        if (option2Tags != null) {
+            for (Tag t : new java.util.LinkedHashSet<>(option2Tags)) {
+                if (t == null) continue;
+                this.placeTags.add(PlaceTag.of(this, t));
+            }
+        }
+    }
+
     // === 편의 메서드 추가 ===
 
     /**

--- a/src/main/java/org/sopt/solply_server/domain/place/entity/PlaceImageInfo.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/entity/PlaceImageInfo.java
@@ -2,11 +2,14 @@ package org.sopt.solply_server.domain.place.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Embeddable
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PlaceImageInfo {
 
     @Column(name = "image_file_key", columnDefinition = "TEXT", nullable = false)
@@ -14,4 +17,13 @@ public class PlaceImageInfo {
 
     @Column(name = "display_order")
     private Integer displayOrder;  // 1번째 사진이 썸네일 사진
+
+    public PlaceImageInfo(String imageFileKey, Integer displayOrder) {
+        this.imageFileKey = imageFileKey;
+        this.displayOrder = displayOrder;
+    }
+
+    public static PlaceImageInfo of(String imageFileKey, Integer displayOrder) {
+        return new PlaceImageInfo(imageFileKey, displayOrder);
+    }
 }

--- a/src/main/java/org/sopt/solply_server/domain/place/entity/PlaceTag.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/entity/PlaceTag.java
@@ -46,4 +46,12 @@ public class PlaceTag {
     @JoinColumn(name = "tag_id", nullable = false)
     private Tag tag;
 
+
+    public static PlaceTag of(Place place, Tag tag) {
+        PlaceTag pt = new PlaceTag();
+        pt.place = place;
+        pt.tag = tag;
+        return pt;
+    }
+
 }

--- a/src/main/java/org/sopt/solply_server/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/repository/PlaceRepository.java
@@ -24,9 +24,6 @@ public interface PlaceRepository extends JpaRepository<Place, Long>, PlaceReposi
             "WHERE p.town.id = :townId")
     List<Place> findPlacesByTownIdWithTags(@Param("townId") Long townId);
 
-    @Query("SELECT p FROM Place p WHERE p.id IN :placeIds")
-    List<Place> findByIdIn(@Param("placeIds") List<Long> placeIds);
-
     @EntityGraph(attributePaths = {
             "placeTags",
             "placeTags.tag"
@@ -48,5 +45,17 @@ public interface PlaceRepository extends JpaRepository<Place, Long>, PlaceReposi
         where p.id in :placeIds
     """)
     List<Place> findByIdInWithTags(List<Long> placeIds);
+
+    // ✅ 어드민 리스트: town + tags(fetch)
+    @Query("""
+        select distinct p
+        from Place p
+        join fetch p.town t
+        left join fetch p.placeTags pt
+        left join fetch pt.tag tg
+        where t.id = :townId
+        order by p.createdAt desc
+    """)
+    List<Place> findAdminPlacesByTownId(@Param("townId") Long townId);
 
 }

--- a/src/main/java/org/sopt/solply_server/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/org/sopt/solply_server/global/config/swagger/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package org.sopt.solply_server.global.config;
+package org.sopt.solply_server.global.config.swagger;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;

--- a/src/main/java/org/sopt/solply_server/global/config/swagger/SwaggerGroupConfig.java
+++ b/src/main/java/org/sopt/solply_server/global/config/swagger/SwaggerGroupConfig.java
@@ -1,0 +1,26 @@
+package org.sopt.solply_server.global.config.swagger;
+
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerGroupConfig {
+
+    @Bean
+    public GroupedOpenApi publicApi() {
+        return GroupedOpenApi.builder()
+                .group("public")
+                .pathsToMatch("/api/**")
+                .pathsToExclude("/api/admin/**")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi adminApi() {
+        return GroupedOpenApi.builder()
+                .group("admin")
+                .pathsToMatch("/api/admin/**")
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/solply_server/global/util/EntityLoader.java
+++ b/src/main/java/org/sopt/solply_server/global/util/EntityLoader.java
@@ -7,6 +7,8 @@ import org.sopt.solply_server.domain.course.entity.Course;
 import org.sopt.solply_server.domain.course.repository.CourseRepository;
 import org.sopt.solply_server.domain.place.entity.Place;
 import org.sopt.solply_server.domain.place.repository.PlaceRepository;
+import org.sopt.solply_server.domain.tag.entity.Tag;
+import org.sopt.solply_server.domain.tag.repository.TagRepository;
 import org.sopt.solply_server.domain.town.entity.Town;
 import org.sopt.solply_server.domain.town.repository.TownRepository;
 import org.sopt.solply_server.domain.user.entity.User;
@@ -26,6 +28,7 @@ public class EntityLoader {
     private final PlaceRepository placeRepository;
     private final TownRepository townRepository;
     private final UserInterestTownRepository userInterestTownRepository;
+    private final TagRepository tagRepository;
 
     public User getUser(Long userId) {
         return userRepository.findById(userId)
@@ -50,6 +53,11 @@ public class EntityLoader {
     public Town getTown(Long townId) {
         return townRepository.findById(townId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_TOWN));
+    }
+
+    public Tag getTag(Long id) {
+        return tagRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_TAG));
     }
 
 //    public List<UserInterestTown> getInterestTownsWithTownsByIds(Long userId) {

--- a/src/main/java/org/sopt/solply_server/global/util/s3/TargetDir.java
+++ b/src/main/java/org/sopt/solply_server/global/util/s3/TargetDir.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum TargetDir {
+    PLACE("places"),
     PLACE_REQUEST("place-requests"),
     PLACE_REPORT("place-reports"),
     USER_PROFILE("user-profiles");


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
resolves #267 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- 장소를 관리할 때 필요한 api들을 구현했습니다.
    - 생성
    - 수정
    - 리스트 조회
    - 검색
    - 상세 조회(생각해보니 어드민용으로 따로 만드는게 나을 것 같아서 추가했습니다.)


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 기존 사진 업로드 방식이 클라에서 사진 업로드 api를 이용해 _staging 디렉토리에 생성할 장소 이미지들을 올리고, 
장소 생성이 완료되면 올바른 디렉토리로 옮겨지는 방식인데, 같은 방식으로 장소 이미지 업로드 로직을 처리했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 관리자용 장소 관리 API 추가: 장소 생성, 수정, 상세 조회, 키워드 검색, 지역별 필터링 기능 제공
  * 장소의 이미지 및 SNS 링크 관리 기능 추가
  * API 문서 그룹화 (공개/관리자 API 분리)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->