### PR TITLE
[FIX] Place에 중복으로 태그가 들어가지 않도록 방지

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/place/entity/Place.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/entity/Place.java
@@ -20,9 +20,11 @@ import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -203,25 +205,26 @@ public class Place extends BaseTimeEntity {
 
     private void replaceTags(Tag mainTag, List<Tag> option1Tags, List<Tag> option2Tags) {
         this.placeTags.clear();
+        Set<Tag> notDuplicated = new LinkedHashSet<>();
 
         // MAIN (필수)
-        if (mainTag != null) {
+        if (mainTag != null && notDuplicated.add(mainTag)) {
             this.placeTags.add(PlaceTag.of(this, mainTag));
         }
 
         // OPTION1 (1개 이상)
         if (option1Tags != null) {
-            for (Tag t : new java.util.LinkedHashSet<>(option1Tags)) {
+            for (Tag t : option1Tags) {
                 if (t == null) continue;
-                this.placeTags.add(PlaceTag.of(this, t));
+                if (notDuplicated.add(t)) this.placeTags.add(PlaceTag.of(this, t));
             }
         }
 
         // OPTION2 (선택)
         if (option2Tags != null) {
-            for (Tag t : new java.util.LinkedHashSet<>(option2Tags)) {
+            for (Tag t : option2Tags) {
                 if (t == null) continue;
-                this.placeTags.add(PlaceTag.of(this, t));
+                if (notDuplicated.add(t)) this.placeTags.add(PlaceTag.of(this, t));
             }
         }
     }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
resolves #274 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- 중복 태그 insert 방지를 위해서 수정했습니다.


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 장소 태그 중복 제거 기능을 추가하여 모든 태그 유형에서 중복 항목을 제거하고 태그 목록의 정확성 및 일관성을 강화했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->