### PR TITLE
[FIX] 코스 생성/수정 시 영속성 컨텍스트 업데이트 처리, 불필요한 쿼리 제거

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/course/repository/CourseRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/repository/CourseRepository.java
@@ -77,7 +77,7 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
 
 
 
-    @Modifying
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM CoursePlace cp WHERE cp.course.id = :courseId")
     void deleteCoursePlacesByCourseId(@Param("courseId") Long courseId);
 

--- a/src/main/java/org/sopt/solply_server/domain/course/repository/CourseRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/repository/CourseRepository.java
@@ -77,7 +77,7 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
 
 
 
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Modifying(flushAutomatically = true)
     @Query("DELETE FROM CoursePlace cp WHERE cp.course.id = :courseId")
     void deleteCoursePlacesByCourseId(@Param("courseId") Long courseId);
 

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -301,6 +301,8 @@ public class CourseService {
         course.updateIntroduction(request.courseDescription());
 
         courseRepository.deleteCoursePlacesByCourseId(course.getId());
+        course.getCoursePlaces().clear();
+
         List<PlaceInCourseInfo> placeInfos = PlaceInCourseInfo.from(request.places());
         coursePlaceService.addPlacesToTargetCourse(course, placeInfos, placesToAdd);
     }

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -301,7 +301,6 @@ public class CourseService {
         course.updateIntroduction(request.courseDescription());
 
         courseRepository.deleteCoursePlacesByCourseId(course.getId());
-        course.getCoursePlaces().clear();
 
         List<PlaceInCourseInfo> placeInfos = PlaceInCourseInfo.from(request.places());
         coursePlaceService.addPlacesToTargetCourse(course, placeInfos, placesToAdd);

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -88,7 +88,7 @@ public class CourseService {
     @Transactional
     public CourseUpdateResponse updateCourse(Long userId, Long courseId, CourseUpdateRequest request) {
         User user = entityLoader.getUser(userId);
-        Course originCourse = entityLoader.getCourseWithPlaces(courseId);
+        Course originCourse = entityLoader.getCourse(courseId);
 
         // 코스 북마크 검증
         courseBookmarkFacade.checkCourseIsBookmarked(userId, courseId);


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
resolves #284 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- delete 쿼리 수행 후, 영속성 컨텍스트와 db 정합성이 맞춰지도록 메모리를 비우고 수정(벌크 쿼리 이전에 영속성 컨텍스트의 데이터를 db에 반영 -> 벌크 쿼리 수행 후 영속성 컨텍스트를 비워서 레거시한 값들 제거)
- 쓸데 없는 1차 캐시 로드 쿼리 제거


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 기능은 그대로입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 코스 정보 업데이트 시 장소 데이터 동기화 방식 개선 — 업데이트 중 불일치 가능성 감소
  * 코스 내 장소 삭제 시 변경 내용 즉시 반영되도록 처리하여 데이터 일관성 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->