### PR TITLE
[FIX] lazy loading으로 인한 조회 문제, active 관련 로직 보완

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/admin/course/repository/AdminCourseRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/course/repository/AdminCourseRepository.java
@@ -2,6 +2,7 @@ package org.sopt.solply_server.domain.admin.course.repository;
 
 import java.util.List;
 
+import java.util.Optional;
 import org.sopt.solply_server.domain.course.entity.Course;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -16,5 +17,14 @@ public interface AdminCourseRepository extends JpaRepository<Course,Long> {
 		WHERE (:townId IS NULL OR t.id = :townId)
 	""")
 	List<Course> findAllWithTownByTownId(@Param("townId") Long townId);
+
+	@Query("""
+        SELECT DISTINCT c FROM Course c
+        LEFT JOIN FETCH c.coursePlaces cp
+        LEFT JOIN FETCH cp.place p
+        LEFT JOIN FETCH c.town t
+        WHERE c.id = :courseId
+    """)
+	Optional<Course> findByIdWithPlacesAndTown(@Param("courseId") Long courseId);
 
 }

--- a/src/main/java/org/sopt/solply_server/domain/admin/course/service/AdminCoursePlaceService.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/course/service/AdminCoursePlaceService.java
@@ -8,7 +8,7 @@ import org.sopt.solply_server.domain.admin.course.util.AdminCoursePlaceValidator
 import org.sopt.solply_server.domain.course.entity.Course;
 import org.sopt.solply_server.domain.course.entity.CoursePlace;
 import org.sopt.solply_server.domain.place.entity.Place;
-import org.sopt.solply_server.global.util.EntityLoader;
+import org.sopt.solply_server.global.util.AdminEntityLoader;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,11 +23,11 @@ public class AdminCoursePlaceService {
 	private final AdminCoursePlaceRepository adminCoursePlaceRepository;
 	private final AdminCoursePlaceValidator adminCoursePlaceValidator;
 
-	private final EntityLoader entityLoader;
+	private final AdminEntityLoader adminEntityLoader;
 
 	public void addPlacesToCourse(Course course, List<AdminCoursePlaceInfoDto> placeInfoDtoList, Long townId) {
 		for (AdminCoursePlaceInfoDto dto : placeInfoDtoList) {
-			Place place = entityLoader.getPlaceWithTown(dto.placeId());
+			Place place = adminEntityLoader.getPlaceWithTown(dto.placeId());
 			adminCoursePlaceValidator.validateCoursePlaceSameTown(place.getTown().getId(), townId);
 
 			CoursePlace coursePlace = adminCoursePlaceRepository.save(

--- a/src/main/java/org/sopt/solply_server/domain/admin/course/service/AdminCourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/course/service/AdminCourseService.java
@@ -17,6 +17,8 @@ import org.sopt.solply_server.domain.course.entity.Course;
 import org.sopt.solply_server.domain.tag.entity.Tag;
 import org.sopt.solply_server.domain.town.entity.Town;
 import org.sopt.solply_server.domain.user.entity.User;
+import org.sopt.solply_server.global.exception.BusinessException;
+import org.sopt.solply_server.global.exception.ErrorCode;
 import org.sopt.solply_server.global.util.EntityLoader;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -68,8 +70,8 @@ public class AdminCourseService {
 	}
 
 	public AdminCourseDetailResponse getCourse(Long courseId) {
-		Course course = entityLoader.getCourseWithPlacesAndTown(courseId);
-
+		Course course = adminCourseRepository.findByIdWithPlacesAndTown(courseId)
+				.orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_COURSE));
 		return AdminCourseDetailResponse.from(course);
 	}
 

--- a/src/main/java/org/sopt/solply_server/domain/admin/course/service/AdminCourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/course/service/AdminCourseService.java
@@ -18,6 +18,7 @@ import org.sopt.solply_server.domain.tag.entity.Tag;
 import org.sopt.solply_server.domain.town.entity.Town;
 import org.sopt.solply_server.domain.user.entity.User;
 import org.sopt.solply_server.global.exception.BusinessException;
+import org.sopt.solply_server.global.exception.EntityNotFoundException;
 import org.sopt.solply_server.global.exception.ErrorCode;
 import org.sopt.solply_server.global.util.EntityLoader;
 import org.springframework.stereotype.Service;
@@ -77,7 +78,8 @@ public class AdminCourseService {
 
 	@Transactional
 	public AdminCourseUpdateResponse updateCourse(Long courseId, AdminCourseUpdateRequest req) {
-		Course course = entityLoader.getCourse(courseId);
+		Course course = adminCourseRepository.findById(courseId)
+				.orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_COURSE));
 
 		course.updateName(req.name());
 
@@ -97,7 +99,8 @@ public class AdminCourseService {
 
 	@Transactional
 	public AdminCourseUpsertResponse updateCourseStatus(Long courseId, AdminCourseActivationRequest req) {
-		Course course = entityLoader.getCourse(courseId);
+		Course course = adminCourseRepository.findById(courseId)
+				.orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_COURSE));
 		course.updateActivation(req.active());
 
 		log.info("어드민 코스 상태 수정 성공 - 현재 상태: {}", course.isActive());

--- a/src/main/java/org/sopt/solply_server/domain/admin/course/service/AdminCourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/course/service/AdminCourseService.java
@@ -20,7 +20,7 @@ import org.sopt.solply_server.domain.user.entity.User;
 import org.sopt.solply_server.global.exception.BusinessException;
 import org.sopt.solply_server.global.exception.EntityNotFoundException;
 import org.sopt.solply_server.global.exception.ErrorCode;
-import org.sopt.solply_server.global.util.EntityLoader;
+import org.sopt.solply_server.global.util.AdminEntityLoader;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,16 +36,16 @@ public class AdminCourseService {
 
 	private final AdminCoursePlaceService adminCoursePlaceService;
 
-	private final EntityLoader entityLoader;
+	private final AdminEntityLoader adminEntityLoader;
 	private final AdminTagValidator adminTagValidator;
 	private final AdminTownValidator adminTownValidator;
 
 	@Transactional
 	public AdminCourseUpsertResponse createCourse(final Long adminId, final AdminCourseUpsertRequest req) {
-		User admin = entityLoader.getUser(adminId);
-		Town town = entityLoader.getTown(req.townId());
+		User admin = adminEntityLoader.getUser(adminId);
+		Town town = adminEntityLoader.getTown(req.townId());
 
-		Tag tag = entityLoader.getTag(req.tagId());
+		Tag tag = adminEntityLoader.getTag(req.tagId());
 		adminTagValidator.validateCourseTagConditions(tag);
 
 		Course course = Course.create(req.name(), req.intro(), town, admin, town.getActive(), tag);
@@ -61,7 +61,7 @@ public class AdminCourseService {
 			adminTownValidator.validateTownId(townId);
 		}
 
-		List<AdminCourseSummaryDto> dtoList = adminCourseRepository.findAllWithTownByTownId(townId)
+		List<AdminCourseSummaryDto> dtoList = adminEntityLoader.getAllWithTownByTownId(townId)
 			.stream()
 			.map(AdminCourseSummaryDto::from)
 			.toList();
@@ -71,15 +71,13 @@ public class AdminCourseService {
 	}
 
 	public AdminCourseDetailResponse getCourse(Long courseId) {
-		Course course = adminCourseRepository.findByIdWithPlacesAndTown(courseId)
-				.orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_COURSE));
+		Course course = adminEntityLoader.getCourseWithPlacesAndTown(courseId);
 		return AdminCourseDetailResponse.from(course);
 	}
 
 	@Transactional
 	public AdminCourseUpdateResponse updateCourse(Long courseId, AdminCourseUpdateRequest req) {
-		Course course = adminCourseRepository.findById(courseId)
-				.orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_COURSE));
+		Course course = adminEntityLoader.getCourse(courseId);
 
 		course.updateName(req.name());
 
@@ -88,7 +86,7 @@ public class AdminCourseService {
 		course.getCoursePlaces().clear();
 		adminCoursePlaceService.addPlacesToCourse(course, req.placeList(), course.getTown().getId());
 
-		Tag tag= entityLoader.getTag(req.tagId());
+		Tag tag= adminEntityLoader.getTag(req.tagId());
 		adminTagValidator.validateCourseTagConditions(tag);
 		course.updateCourseTag(tag);
 
@@ -99,8 +97,7 @@ public class AdminCourseService {
 
 	@Transactional
 	public AdminCourseUpsertResponse updateCourseStatus(Long courseId, AdminCourseActivationRequest req) {
-		Course course = adminCourseRepository.findById(courseId)
-				.orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_COURSE));
+		Course course = adminEntityLoader.getCourse(courseId);
 		course.updateActivation(req.active());
 
 		log.info("어드민 코스 상태 수정 성공 - 현재 상태: {}", course.isActive());

--- a/src/main/java/org/sopt/solply_server/domain/admin/place/repository/AdminPlaceRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/place/repository/AdminPlaceRepository.java
@@ -14,6 +14,15 @@ public interface AdminPlaceRepository extends JpaRepository<Place, Long>, AdminP
     @Query("""
         select distinct p
         from Place p
+        left join fetch p.town t
+        left join fetch p.checkpoints cp
+        where p.id = :placeId
+    """)
+    Optional<Place> findByIdWithTownAndCheckpoints(@Param("placeId") Long placeId);
+
+    @Query("""
+        select distinct p
+        from Place p
         join fetch p.town t
         left join fetch p.placeTags pt
         left join fetch pt.tag tg

--- a/src/main/java/org/sopt/solply_server/domain/admin/place/repository/AdminPlaceRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/place/repository/AdminPlaceRepository.java
@@ -1,6 +1,7 @@
 package org.sopt.solply_server.domain.admin.place.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.sopt.solply_server.domain.admin.place.repository.querydsl.AdminPlaceRepositoryCustom;
 import org.sopt.solply_server.domain.place.entity.Place;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -46,4 +47,12 @@ public interface AdminPlaceRepository extends JpaRepository<Place, Long>, AdminP
 		where p.town.id in :townIds
 	""")
 	boolean existsPlacesByTown_Ids(@Param("townIds") List<Long> townIds);
+
+    @Query("""
+        SELECT p
+        FROM Place p
+        JOIN FETCH p.town
+        WHERE p.id = :id
+    """)
+    Optional<Place> findByIdWithTown(@Param("id") Long placeId);
 }

--- a/src/main/java/org/sopt/solply_server/domain/admin/place/service/AdminPlaceRequestService.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/place/service/AdminPlaceRequestService.java
@@ -12,6 +12,7 @@ import org.sopt.solply_server.domain.admin.place.dto.response.AdminPlaceUpsertRe
 import org.sopt.solply_server.domain.admin.place.repository.AdminPlaceRequestRepository;
 import org.sopt.solply_server.domain.place.entity.PlaceRequestImageInfo;
 import org.sopt.solply_server.domain.tag.entity.TagType;
+import org.sopt.solply_server.global.util.AdminEntityLoader;
 import org.sopt.solply_server.global.util.s3.FileTransferMode;
 import org.sopt.solply_server.global.util.s3.ImageFileKeyUpdateEvent;
 import org.sopt.solply_server.domain.place.dto.PlaceImageInfoDto;
@@ -35,7 +36,7 @@ public class AdminPlaceRequestService {
 
     private final AdminPlaceRequestRepository adminPlaceRequestRepository;
     private final AdminPlaceService adminPlaceService;
-    private final EntityLoader entityLoader;
+    private final AdminEntityLoader adminEntityLoader;
 
     private final ImageUrlProvider imageUrlProvider;
     private final ImageFileKeyValidator imageFileKeyValidator;
@@ -100,7 +101,7 @@ public class AdminPlaceRequestService {
      */
     @Transactional
     public AdminPlaceUpsertResponse approveAndCreatePlace(final Long adminUserId, final Long requestId, final AdminPlaceUpsertRequest req) {
-        PlaceRequest pr = entityLoader.getPlaceRequest(requestId);
+        PlaceRequest pr = adminEntityLoader.getPlaceRequest(requestId);
 
         if (pr.getStatus() != PlaceRequestStatus.PENDING) {
             throw new BusinessException(ErrorCode.INVALID_REQUEST_STATE);

--- a/src/main/java/org/sopt/solply_server/domain/admin/place/service/AdminPlaceService.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/place/service/AdminPlaceService.java
@@ -11,6 +11,7 @@ import org.sopt.solply_server.domain.admin.place.dto.response.AdminPlaceListResp
 import org.sopt.solply_server.domain.admin.place.dto.response.AdminPlaceUpsertResponse;
 import org.sopt.solply_server.domain.admin.place.repository.AdminPlaceRepository;
 import org.sopt.solply_server.domain.admin.tag.util.AdminTagValidator;
+import org.sopt.solply_server.global.util.AdminEntityLoader;
 import org.sopt.solply_server.global.util.s3.FileTransferMode;
 import org.sopt.solply_server.global.util.s3.ImageFileKeyUpdateEvent;
 import org.sopt.solply_server.domain.place.dto.PlaceImageInfoDto;
@@ -37,22 +38,22 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminPlaceService {
 
     private final AdminPlaceRepository adminPlaceRepository;
-    private final EntityLoader entityLoader;
 
     private final ImageFileKeyValidator imageFileKeyValidator;
     private final ApplicationEventPublisher applicationEventPublisher;
     private final ImageUrlProvider imageUrlProvider;
     private final AdminTagValidator adminTagValidator;
+    private final AdminEntityLoader adminEntityLoader;
 
     @Transactional
     public AdminPlaceUpsertResponse createPlace(final Long adminUserId, final AdminPlaceUpsertRequest req) {
-        User admin = entityLoader.getUser(adminUserId);
-        Town town = entityLoader.getTown(req.townId());
+        User admin = adminEntityLoader.getUser(adminUserId);
+        Town town = adminEntityLoader.getTown(req.townId());
 
         // 태그 검증(타입 + 관계)
         adminTagValidator.validatePlaceTagConditions(req.mainTagId(), req.option1TagIds(), req.option2TagIds());
 
-        Tag mainTag = entityLoader.getTag(req.mainTagId());
+        Tag mainTag = adminEntityLoader.getTag(req.mainTagId());
         List<Tag> opt1 = loadTags(req.option1TagIds());
         List<Tag> opt2 = req.option2TagIds() == null ? List.of() : loadTags(req.option2TagIds());
 
@@ -89,13 +90,13 @@ public class AdminPlaceService {
 
     @Transactional
     public AdminPlaceUpsertResponse updatePlace(final Long placeId, final AdminPlaceUpsertRequest req) {
-        Place place = entityLoader.getPlaceWithTown(placeId);
-        Town updatedTown = entityLoader.getTown(req.townId());
+        Place place = adminEntityLoader.getPlaceWithTown(placeId);
+        Town updatedTown = adminEntityLoader.getTown(req.townId());
 
         // 태그 검증(타입 + 관계)
         adminTagValidator.validatePlaceTagConditions(req.mainTagId(), req.option1TagIds(), req.option2TagIds());
 
-        Tag mainTag = entityLoader.getTag(req.mainTagId());
+        Tag mainTag = adminEntityLoader.getTag(req.mainTagId());
         List<Tag> opt1 = loadTags(req.option1TagIds());
         List<Tag> opt2 = req.option2TagIds() == null ? List.of() : loadTags(req.option2TagIds());
 
@@ -127,7 +128,7 @@ public class AdminPlaceService {
     }
 
     public AdminPlaceDetailsGetResponse getPlaceDetails(final Long placeId) {
-        Place place = entityLoader.getPlaceWithTownAndCheckpoints(placeId);
+        Place place = adminEntityLoader.getPlaceWithTownAndCheckpoints(placeId);
 
         Town town = place.getTown();
 
@@ -199,7 +200,7 @@ public class AdminPlaceService {
     }
 
     public AdminPlaceListResponse getPlacesByTown(final Long townId) {
-        Town town = entityLoader.getTown(townId); // 존재 검증
+        Town town = adminEntityLoader.getTown(townId); // 존재 검증
         List<Place> places = adminPlaceRepository.findAdminPlacesWithTagsByTownId(town.getId());
 
         List<AdminPlaceSummaryDto> result = places.stream()
@@ -241,7 +242,7 @@ public class AdminPlaceService {
         if (tagIds == null || tagIds.isEmpty()) return List.of();
         List<Tag> tags = new ArrayList<>(tagIds.size());
         for (Long id : tagIds) {
-            tags.add(entityLoader.getTag(id));
+            tags.add(adminEntityLoader.getTag(id));
         }
         return tags;
     }

--- a/src/main/java/org/sopt/solply_server/domain/admin/place/service/AdminPlaceService.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/place/service/AdminPlaceService.java
@@ -90,6 +90,7 @@ public class AdminPlaceService {
     @Transactional
     public AdminPlaceUpsertResponse updatePlace(final Long placeId, final AdminPlaceUpsertRequest req) {
         Place place = entityLoader.getPlaceWithTown(placeId);
+        Town updatedTown = entityLoader.getTown(req.townId());
 
         // 태그 검증(타입 + 관계)
         adminTagValidator.validatePlaceTagConditions(req.mainTagId(), req.option1TagIds(), req.option2TagIds());
@@ -110,7 +111,7 @@ public class AdminPlaceService {
                 req.longitude(),
                 req.contactNumber(),
                 req.openingHours(),
-                place.getTown(),
+                updatedTown,
                 req.snsLinks(),
                 imageKeys,
                 req.placeCheckpoints(),

--- a/src/main/java/org/sopt/solply_server/domain/admin/place/service/AdminPlaceService.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/place/service/AdminPlaceService.java
@@ -139,7 +139,7 @@ public class AdminPlaceService {
                 .toList();
 
         // 태그 id 추출
-        Long mainTagId = place.getActiveMainTag().map(Tag::getId).orElse(null);
+        Long mainTagId = place.getMainTag().map(Tag::getId).orElse(null);
 
         List<Long> option1TagIds = place.getPlaceTags().stream()
                 .map(PlaceTag::getTag)
@@ -190,7 +190,7 @@ public class AdminPlaceService {
                         p.getId(),
                         p.getName(),
                         p.getTown().getName(),
-                        p.getActiveMainTag().map(Tag::getName).orElse(null)
+                        p.getMainTag().map(Tag::getName).orElse(null)
                 ))
                 .toList();
 
@@ -206,7 +206,7 @@ public class AdminPlaceService {
                         p.getId(),
                         p.getName(),
                         p.getTown().getName(),
-                        p.getActiveMainTag().map(Tag::getName).orElse(null)
+                        p.getMainTag().map(Tag::getName).orElse(null)
                 ))
                 .toList();
 

--- a/src/main/java/org/sopt/solply_server/domain/admin/place/service/AdminPlaceService.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/place/service/AdminPlaceService.java
@@ -89,8 +89,7 @@ public class AdminPlaceService {
 
     @Transactional
     public AdminPlaceUpsertResponse updatePlace(final Long placeId, final AdminPlaceUpsertRequest req) {
-        Place place = entityLoader.getPlace(placeId);
-        Town town = entityLoader.getTown(req.townId());
+        Place place = entityLoader.getPlaceWithTown(placeId);
 
         // 태그 검증(타입 + 관계)
         adminTagValidator.validatePlaceTagConditions(req.mainTagId(), req.option1TagIds(), req.option2TagIds());
@@ -111,7 +110,7 @@ public class AdminPlaceService {
                 req.longitude(),
                 req.contactNumber(),
                 req.openingHours(),
-                town,
+                place.getTown(),
                 req.snsLinks(),
                 imageKeys,
                 req.placeCheckpoints(),
@@ -127,7 +126,7 @@ public class AdminPlaceService {
     }
 
     public AdminPlaceDetailsGetResponse getPlaceDetails(final Long placeId) {
-        Place place = entityLoader.getPlace(placeId);
+        Place place = entityLoader.getPlaceWithTownAndCheckpoints(placeId);
 
         Town town = place.getTown();
 

--- a/src/main/java/org/sopt/solply_server/domain/admin/tag/service/AdminTagService.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/tag/service/AdminTagService.java
@@ -12,10 +12,9 @@ import org.sopt.solply_server.domain.admin.tag.dto.response.AdminTagListResponse
 import org.sopt.solply_server.domain.admin.tag.repository.AdminTagRepository;
 import org.sopt.solply_server.domain.admin.tag.util.AdminTagValidator;
 import org.sopt.solply_server.domain.tag.entity.Tag;
-import org.sopt.solply_server.domain.tag.entity.TagPersonaMapping;
 import org.sopt.solply_server.global.exception.BusinessException;
 import org.sopt.solply_server.global.exception.ErrorCode;
-import org.sopt.solply_server.global.util.EntityLoader;
+import org.sopt.solply_server.global.util.AdminEntityLoader;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,7 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminTagService {
 
     private final AdminTagRepository adminTagRepository;
-    private final EntityLoader entityLoader;
+    private final AdminEntityLoader adminEntityLoader;
 
     private final AdminTagValidator adminTagValidator;
 
@@ -35,7 +34,7 @@ public class AdminTagService {
 
         Tag parent = null;
         if (req.parentId() != null) {
-            parent = entityLoader.getTag(req.parentId()); // admin은 active 무시
+            parent = adminEntityLoader.getTag(req.parentId()); // admin은 active 무시
         }
 
         adminTagValidator.validateParentForAdmin(
@@ -78,11 +77,11 @@ public class AdminTagService {
 
     @Transactional
     public Long updateTag(Long id, AdminTagUpsertRequest req) {
-        Tag tag = entityLoader.getTag(id);
+        Tag tag = adminEntityLoader.getTag(id);
 
         Tag parent = null;
         if (req.parentId() != null) {
-            parent = entityLoader.getTag(req.parentId());
+            parent = adminEntityLoader.getTag(req.parentId());
         }
 
         adminTagValidator.validateParentForAdmin(
@@ -106,7 +105,7 @@ public class AdminTagService {
 
     @Transactional
     public AdminTagActivationResponse toggleActive(Long id, AdminTagActivationRequest req) {
-        Tag tag = entityLoader.getTag(id);
+        Tag tag = adminEntityLoader.getTag(id);
 
         // 활성화 요청인데 parent가 비활성이면 에러
         if (req.active() && tag.getParent() != null && !tag.getParent().isActive()) {

--- a/src/main/java/org/sopt/solply_server/domain/admin/town/service/AdminTownService.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/town/service/AdminTownService.java
@@ -12,7 +12,7 @@ import org.sopt.solply_server.domain.admin.town.dto.response.AdminTownUpsertResp
 import org.sopt.solply_server.domain.admin.town.repository.AdminTownRepository;
 import org.sopt.solply_server.domain.admin.town.util.AdminTownValidator;
 import org.sopt.solply_server.domain.town.entity.Town;
-import org.sopt.solply_server.global.util.EntityLoader;
+import org.sopt.solply_server.global.util.AdminEntityLoader;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,7 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 public class AdminTownService {
 
 	private final AdminTownRepository adminTownRepository;
-	private final EntityLoader entityLoader;
+	private final AdminEntityLoader adminEntityLoader;
 
 	private final AdminTownValidator adminTownValidator;
 	private final AdminPlaceService adminPlaceService;
@@ -36,7 +36,7 @@ public class AdminTownService {
 		Town parent = null;
 		if (req.parentId() != null) {
 			adminTownValidator.validateTownId(req.parentId());
-			parent = entityLoader.getTown(req.parentId());
+			parent = adminEntityLoader.getTown(req.parentId());
 		}
 
 		Town town = Town.create(
@@ -52,7 +52,7 @@ public class AdminTownService {
 
 	@Transactional
 	public AdminTownUpsertResponse updateTown(final Long townId, final AdminTownUpsertRequest req) {
-		Town town = entityLoader.getTown(townId);
+		Town town = adminEntityLoader.getTown(townId);
 
 		// 부모 town, 자식 town 구분
 		Town parent;
@@ -62,7 +62,7 @@ public class AdminTownService {
 		} else {
 			adminTownValidator.validateChildTown(townId);
 			adminTownValidator.validateParentTown(req.parentId());
-			parent = entityLoader.getTown(req.parentId());
+			parent = adminEntityLoader.getTown(req.parentId());
 		}
 
 		town.update(
@@ -91,7 +91,7 @@ public class AdminTownService {
 
 	@Transactional
 	public void deleteTown(final Long townId) {
-		Town town = entityLoader.getTown(townId);
+		Town town = adminEntityLoader.getTown(townId);
 		adminTownValidator.validateDeletableTown(townId);
 		adminTownRepository.delete(town);
 
@@ -128,7 +128,7 @@ public class AdminTownService {
 	}
 
 	private void activateTown(Long townId) {
-		Town town = entityLoader.getTown(townId);
+		Town town = adminEntityLoader.getTown(townId);
 		List<Long> townIds = new ArrayList<>();
 
 		if (town.getParent() == null) {
@@ -143,7 +143,7 @@ public class AdminTownService {
 	}
 
 	private void deactivateTown(Long townId) {
-		Town town = entityLoader.getTown(townId);
+		Town town = adminEntityLoader.getTown(townId);
 
 		if (town.getParent() == null) {
 			adminTownValidator.validateDeactivatableParentTown(townId);

--- a/src/main/java/org/sopt/solply_server/domain/admin/user/repository/AdminUserRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/user/repository/AdminUserRepository.java
@@ -1,0 +1,8 @@
+package org.sopt.solply_server.domain.admin.user.repository;
+
+import org.sopt.solply_server.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminUserRepository extends JpaRepository<User, Long> {
+
+}

--- a/src/main/java/org/sopt/solply_server/domain/course/repository/CourseRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/repository/CourseRepository.java
@@ -12,20 +12,15 @@ import org.springframework.data.repository.query.Param;
 
 public interface CourseRepository extends JpaRepository<Course, Long> {
 
-    /**
-     * 코스 상세 조회 - 코스와 관련된 장소 목록 조회 (단계별 조회로 MultipleBagFetchException 해결)
-     * Course, CoursePlace, Place 모두 한 번에 로딩
-     */
-    @Query("SELECT DISTINCT c FROM Course c " +
-            "LEFT JOIN FETCH c.coursePlaces cp " +
-            "LEFT JOIN FETCH cp.place p " +
-            "WHERE c.id = :courseId")
-    Optional<Course> findByIdWithPlaces(@Param("courseId") Long courseId);
+    @Query("""
+        SELECT DISTINCT c FROM Course c
+        LEFT JOIN FETCH c.coursePlaces cp
+        LEFT JOIN FETCH cp.place p
+        WHERE c.id = :courseId
+          AND c.active = true
+    """)
+    Optional<Course> findActiveByIdWithPlaces(@Param("courseId") Long courseId);
 
-    /**
-     * 특정 동네의 공유된 코스 목록 조회 (단계별 조회로 MultipleBagFetchException 해결)
-     * 코스와 코스 내 장소들 조회
-     */
     @Query("""
         SELECT DISTINCT c FROM Course c
         LEFT JOIN FETCH c.tag t
@@ -33,15 +28,11 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
         LEFT JOIN FETCH cp.place p
         WHERE c.town.id = :townId
           AND c.isShared = true
+          AND c.active = true
         ORDER BY c.createdAt DESC
     """)
-    List<Course> findSharedCoursesByTownIdWithPlaces(@Param("townId") Long townId);
+    List<Course> findActiveSharedCoursesByTownIdWithPlaces(@Param("townId") Long townId);
 
-
-    /**
-     * 특정 동네의 북마크된 코스 목록 조회
-     * 코스와 코스 내 장소들을 함께 조회
-     */
     @Query("""
         SELECT DISTINCT c FROM Course c
         JOIN FETCH c.town t
@@ -50,32 +41,18 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
         LEFT JOIN FETCH cp.place p
         WHERE t.id = :townId
           AND c.id IN :courseIds
+          AND c.active = true
     """)
-    List<Course> findCoursesFilteredByTownId(@Param("courseIds") List<Long> courseIds,
+    List<Course> findActiveCoursesFilteredByTownId(@Param("courseIds") List<Long> courseIds,
             @Param("townId") Long townId);
-
-
-
-    @Modifying(flushAutomatically = true)
-    @Query("DELETE FROM CoursePlace cp WHERE cp.course.id = :courseId")
-    void deleteCoursePlacesByCourseId(@Param("courseId") Long courseId);
-
-    /**
-     * 특정 사용자가 북마크한 코스명들 조회 (패턴 매칭)
-     */
-    @Query("SELECT c.name FROM Course c " +
-            "WHERE c.id in :courseIds " +
-            "AND c.name LIKE :namePattern")
-    List<String> findCourseNamesByBookmarkedCourses(
-            @Param("courseIds") Set<Long> courseIds, @Param("namePattern") String namePattern);
-
 
     @Query("""
         select c.id, c.town.id
         from Course c
         where c.id in :courseIds
+          and c.active = true
     """)
-    List<Object[]> findCourseIdAndTownIdByCourseIds(@Param("courseIds") List<Long> courseIds);
+    List<Object[]> findActiveCourseIdAndTownIdByCourseIds(@Param("courseIds") List<Long> courseIds);
 
     @Query("""
         select distinct c
@@ -85,13 +62,33 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
         left join fetch c.coursePlaces cp
         left join fetch cp.place p
         where c.id in :courseIds
+          and c.active = true
     """)
-    List<Course> findFolderPreviewCourses(@Param("courseIds") List<Long> courseIds);
+    List<Course> findActiveFolderPreviewCourses(@Param("courseIds") List<Long> courseIds);
 
-    @Query("SELECT DISTINCT c FROM Course c " +
-        "LEFT JOIN FETCH c.coursePlaces cp " +
-        "LEFT JOIN FETCH cp.place p " +
-        "LEFT JOIN FETCH c.town t " +
-        "WHERE c.id = :courseId")
-    Optional<Course> findByIdWithPlacesAndTown(@Param("courseId") Long courseId);
+    @Query("""
+        SELECT DISTINCT c FROM Course c
+        LEFT JOIN FETCH c.coursePlaces cp
+        LEFT JOIN FETCH cp.place p
+        LEFT JOIN FETCH c.town t
+        WHERE c.id = :courseId
+          AND c.active = true
+    """)
+    Optional<Course> findActiveByIdWithPlacesAndTown(@Param("courseId") Long courseId);
+
+    @Modifying(flushAutomatically = true)
+    @Query("DELETE FROM CoursePlace cp WHERE cp.course.id = :courseId")
+    void deleteCoursePlacesByCourseId(@Param("courseId") Long courseId);
+
+    @Query("""
+        SELECT c.name
+        FROM Course c
+        WHERE c.id in :courseIds
+          AND c.name LIKE :namePattern
+          AND c.active = true
+    """)
+    List<String> findCourseNamesByBookmarkedCourses(@Param("courseIds") Set<Long> courseIds,
+            @Param("namePattern") String namePattern);
+
+    Optional<Course> findByIdAndActiveTrue(Long id);
 }

--- a/src/main/java/org/sopt/solply_server/domain/course/repository/CourseRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/repository/CourseRepository.java
@@ -66,16 +66,6 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
     """)
     List<Course> findActiveFolderPreviewCourses(@Param("courseIds") List<Long> courseIds);
 
-    @Query("""
-        SELECT DISTINCT c FROM Course c
-        LEFT JOIN FETCH c.coursePlaces cp
-        LEFT JOIN FETCH cp.place p
-        LEFT JOIN FETCH c.town t
-        WHERE c.id = :courseId
-          AND c.active = true
-    """)
-    Optional<Course> findActiveByIdWithPlacesAndTown(@Param("courseId") Long courseId);
-
     @Modifying(flushAutomatically = true)
     @Query("DELETE FROM CoursePlace cp WHERE cp.course.id = :courseId")
     void deleteCoursePlacesByCourseId(@Param("courseId") Long courseId);

--- a/src/main/java/org/sopt/solply_server/domain/course/repository/CourseRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/repository/CourseRepository.java
@@ -14,12 +14,13 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
 
     @Query("""
         SELECT DISTINCT c FROM Course c
+        LEFT JOIN FETCH c.tag t
         LEFT JOIN FETCH c.coursePlaces cp
         LEFT JOIN FETCH cp.place p
         WHERE c.id = :courseId
           AND c.active = true
     """)
-    Optional<Course> findActiveByIdWithPlaces(@Param("courseId") Long courseId);
+    Optional<Course> findActiveByIdWithTagsAndPlaces(@Param("courseId") Long courseId);
 
     @Query("""
         SELECT DISTINCT c FROM Course c

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -29,6 +29,7 @@ import org.sopt.solply_server.global.exception.BusinessException;
 import org.sopt.solply_server.global.exception.EntityNotFoundException;
 import org.sopt.solply_server.global.exception.ErrorCode;
 import org.sopt.solply_server.global.util.EntityLoader;
+import org.sopt.solply_server.global.util.TagViewUtils;
 import org.sopt.solply_server.global.util.s3.ImageUrlProvider;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -203,7 +204,7 @@ public class CourseService {
 
 
         if (course.getCoursePlaces().isEmpty()) {
-            return CourseDetailGetResponse.of(course, courseTag.getName(), isCourseBookmarked, List.of());
+            return CourseDetailGetResponse.of(course, TagViewUtils.getActiveNameOrNull(courseTag), isCourseBookmarked, List.of());
         }
 
         List<Long> placeIds = course.getCoursePlaces().stream()
@@ -218,9 +219,8 @@ public class CourseService {
                     String thumbnailUrl = place.getThumbnailFileKey() != null
                             ? imageUrlProvider.getImageUrl(place.getThumbnailFileKey())
                             : null;
-                    String mainTagName = place.getActiveMainTag()
-                            .map(Tag::getName)
-                            .orElse(null);
+                    Tag placeTag = place.getMainTag().orElse(null);
+                    String mainTagName = TagViewUtils.getActiveNameOrNull(placeTag);
 
                     return CoursePlaceDetailsDto.of(
                             place,
@@ -234,7 +234,7 @@ public class CourseService {
 
         return CourseDetailGetResponse.of(
                 course,
-                courseTag.isActive() ? courseTag.getName() : null,
+                TagViewUtils.getActiveNameOrNull(courseTag),
                 isCourseBookmarked,
                 coursePlaces
         );
@@ -470,11 +470,7 @@ public class CourseService {
                 .map(course -> {
                     String thumbnailUrl = courseUtils.getCourseThumbnailUrl(course);
                     Tag courseTag = course.getTag();
-                    String courseTagName = null;
-                    if (courseTag != null) {
-                        courseTagName = courseTag.isActive() ? courseTag.getName() : null;
-                    }
-                    return CourseFolderDto.of(course, courseTagName, thumbnailUrl);
+                    return CourseFolderDto.of(course, TagViewUtils.getActiveNameOrNull(courseTag), thumbnailUrl);
                 })
                 .toList();
     }
@@ -492,7 +488,7 @@ public class CourseService {
         return filteredCourses.stream()
                 .map(course -> {
                     Tag courseTag = course.getTag();
-                    String courseTagName = (courseTag != null && courseTag.isActive()) ? courseTag.getName() : null;
+                    String courseTagName = TagViewUtils.getActiveNameOrNull(courseTag);
 
                     String thumbnailUrl = courseUtils.getCourseThumbnailUrl(course);
 
@@ -507,5 +503,6 @@ public class CourseService {
                         .compareTo(courseIdCreatedAtMap.getOrDefault(a.courseId(), LocalDateTime.MIN)))
                 .toList();
     }
+
 
 }

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -148,7 +148,7 @@ public class CourseService {
     public CourseAddPlaceResponse addPlaceToCourse(final Long userId, final Long placeId, final Long courseId) {
         User user = entityLoader.getUser(userId);
         Place place = entityLoader.getPlace(placeId);
-        Course originCourse = entityLoader.getActiveCourseWithPlaces(courseId);
+        Course originCourse = entityLoader.getActiveCourseWithTagsAndPlaces(courseId);
 
         // 코스 북마크 검증
         courseBookmarkFacade.checkCourseIsBookmarked(userId, courseId);
@@ -195,7 +195,7 @@ public class CourseService {
      * 코스 상세 정보 조회
      */
     public CourseDetailGetResponse getCourseDetailsById(final Long userId, final Long courseId) {
-        Course course = entityLoader.getActiveCourseWithPlaces(courseId);
+        Course course = entityLoader.getActiveCourseWithTagsAndPlaces(courseId);
 
         Tag courseTag = course.getTag();
         tagValidator.validateCourseTag(courseTag);

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -69,7 +69,7 @@ public class CourseService {
         List<PlaceInCourseInfo> placeInfosForOrder = PlaceInCourseInfo.from(request.places());
 
         // 코스 태그 검증
-        Tag courseTag = entityLoader.getTag(request.courseTagId());
+        Tag courseTag = entityLoader.getActiveTag(request.courseTagId());
         tagValidator.validateCourseTag(courseTag);
 
         // 코스에 등록할 장소들
@@ -93,7 +93,7 @@ public class CourseService {
     @Transactional
     public CourseUpdateResponse updateCourse(Long userId, Long courseId, CourseUpdateRequest request) {
         User user = entityLoader.getUser(userId);
-        Course originCourse = entityLoader.getCourse(courseId);
+        Course originCourse = entityLoader.getActiveCourse(courseId);
 
         // 코스 북마크 검증
         courseBookmarkFacade.checkCourseIsBookmarked(userId, courseId);
@@ -107,7 +107,7 @@ public class CourseService {
         coursePlaceValidator.validatePlacesForCourse(placeInfosInCourseForOrder, placesToAdd);
 
         // 코스 태그 검증
-        Tag updatedCourseTag = entityLoader.getTag(request.courseTagId());
+        Tag updatedCourseTag = entityLoader.getActiveTag(request.courseTagId());
         tagValidator.validateCourseTag(updatedCourseTag);
 
         if (originCourse.isCreatedBy(userId)) { // 사용자가 소유한 코스인 경우
@@ -147,7 +147,7 @@ public class CourseService {
     public CourseAddPlaceResponse addPlaceToCourse(final Long userId, final Long placeId, final Long courseId) {
         User user = entityLoader.getUser(userId);
         Place place = entityLoader.getPlace(placeId);
-        Course originCourse = entityLoader.getCourseWithPlaces(courseId);
+        Course originCourse = entityLoader.getActiveCourseWithPlaces(courseId);
 
         // 코스 북마크 검증
         courseBookmarkFacade.checkCourseIsBookmarked(userId, courseId);
@@ -194,7 +194,7 @@ public class CourseService {
      * 코스 상세 정보 조회
      */
     public CourseDetailGetResponse getCourseDetailsById(final Long userId, final Long courseId) {
-        Course course = entityLoader.getCourseWithPlaces(courseId);
+        Course course = entityLoader.getActiveCourseWithPlaces(courseId);
 
         Tag courseTag = course.getTag();
         tagValidator.validateCourseTag(courseTag);
@@ -274,7 +274,7 @@ public class CourseService {
 
         // 북마크된 코스 아이디 추출
         List<Long> courseIds = new ArrayList<>(courseIdCreatedAtMap.keySet());
-        List<Course> filteredCourses = courseRepository.findCoursesFilteredByTownId(courseIds, targetTownId);
+        List<Course> filteredCourses = courseRepository.findActiveCoursesFilteredByTownId(courseIds, targetTownId);
 
         if (filteredCourses.isEmpty()) {
             log.info("동네 {}에 북마크된 코스가 없습니다.", targetTownId);
@@ -313,7 +313,7 @@ public class CourseService {
 
         List<Long> sortedCourseIds = sortIdsByCreatedAtDesc(latestCourseIdsByTown, createdAtMap);
 
-        List<Course> courses = courseRepository.findFolderPreviewCourses(latestCourseIdsByTown);
+        List<Course> courses = courseRepository.findActiveFolderPreviewCourses(latestCourseIdsByTown);
         if (courses.isEmpty()) {
             return CourseFolderPreviewListGetResponse.from(List.of());
         }
@@ -376,7 +376,7 @@ public class CourseService {
 
     private List<Place> getPlacesWithTownByPlaceIds(final List<Long> placeIds) {
         // Town 정보까지 함께 조회 (N+1 문제 방지)
-        List<Place> places = entityLoader.findPlacesWithTown(placeIds);
+        List<Place> places = entityLoader.getPlacesWithTown(placeIds);
 
         if (places.size() != placeIds.size()) {
             Set<Long> foundIds = places.stream()
@@ -440,7 +440,7 @@ public class CourseService {
     }
 
     private Map<Long, Long> loadCourseToTownMap(List<Long> courseIds) {
-        return courseRepository.findCourseIdAndTownIdByCourseIds(courseIds).stream()
+        return courseRepository.findActiveCourseIdAndTownIdByCourseIds(courseIds).stream()
                 .collect(Collectors.toMap(
                         row -> (Long) row[0],   // courseId
                         row -> (Long) row[1]    // townId

--- a/src/main/java/org/sopt/solply_server/domain/place/entity/Place.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/entity/Place.java
@@ -244,10 +244,9 @@ public class Place extends BaseTimeEntity {
     }
 
     /** active MAIN만 */
-    public Optional<Tag> getActiveMainTag() {
+    public Optional<Tag> getMainTag() {
         return placeTags.stream()
                 .map(PlaceTag::getTag)
-                .filter(Tag::isActive)
                 .filter(tag -> tag.getType() == TagType.MAIN)
                 .findFirst();
     }

--- a/src/main/java/org/sopt/solply_server/domain/place/entity/Place.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/entity/Place.java
@@ -235,15 +235,12 @@ public class Place extends BaseTimeEntity {
 
     // === 편의 메서드 추가 ===
 
-    /** active tag만 */
-    public List<Tag> getActiveTags() {
+    public List<Tag> getTags() {
         return placeTags.stream()
                 .map(PlaceTag::getTag)
-                .filter(Tag::isActive)
                 .toList();
     }
 
-    /** active MAIN만 */
     public Optional<Tag> getMainTag() {
         return placeTags.stream()
                 .map(PlaceTag::getTag)

--- a/src/main/java/org/sopt/solply_server/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/repository/PlaceRepository.java
@@ -57,10 +57,11 @@ public interface PlaceRepository extends JpaRepository<Place, Long>, PlaceReposi
     List<Place> findByIdInWithTags(@Param("placeIds") List<Long> placeIds);
 
     @Query("""
-        SELECT p
-        FROM Place p
-        JOIN FETCH p.town
-        WHERE p.id = :id
+        select distinct p
+        from Place p
+        left join fetch p.town t
+        left join fetch p.checkpoints cp
+        where p.id = :placeId
     """)
-    Optional<Place> findByIdWithTown(@Param("id") Long placeId);
+    Optional<Place> findByIdWithTownAndCheckpoints(@Param("placeId") Long placeId);
 }

--- a/src/main/java/org/sopt/solply_server/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/repository/PlaceRepository.java
@@ -20,7 +20,7 @@ public interface PlaceRepository extends JpaRepository<Place, Long>, PlaceReposi
         WHERE p.id IN :placeIds
           AND p.active = true
     """)
-    List<Place> findAllByIdsWithTown(@Param("placeIds") List<Long> placeIds);
+    List<Place> findActiveAllByIdsWithTown(@Param("placeIds") List<Long> placeIds);
 
     @Query("""
         SELECT DISTINCT p
@@ -30,7 +30,7 @@ public interface PlaceRepository extends JpaRepository<Place, Long>, PlaceReposi
         WHERE p.town.id = :townId
           AND p.active = true
     """)
-    List<Place> findPlacesByTownIdWithTags(@Param("townId") Long townId);
+    List<Place> findActivePlacesByTownIdWithTags(@Param("townId") Long townId);
 
     @EntityGraph(attributePaths = {
             "placeTags",
@@ -64,5 +64,5 @@ public interface PlaceRepository extends JpaRepository<Place, Long>, PlaceReposi
         where p.id = :placeId
             and p.active = true
     """)
-    Optional<Place> findByIdWithTownAndCheckpoints(@Param("placeId") Long placeId);
+    Optional<Place> findActiveByIdWithTownAndCheckpoints(@Param("placeId") Long placeId);
 }

--- a/src/main/java/org/sopt/solply_server/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/repository/PlaceRepository.java
@@ -62,6 +62,7 @@ public interface PlaceRepository extends JpaRepository<Place, Long>, PlaceReposi
         left join fetch p.town t
         left join fetch p.checkpoints cp
         where p.id = :placeId
+            and p.active = true
     """)
     Optional<Place> findByIdWithTownAndCheckpoints(@Param("placeId") Long placeId);
 }

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
@@ -54,7 +54,7 @@ public class PlaceService {
      * 장소 상세 정보 조회
      */
     public PlaceDetailsGetResponse getPlaceDetailsById(final Long userId, final Long placeId) {
-        Place place = entityLoader.getPlace(placeId);
+        Place place = entityLoader.getPlaceWithTownAndCheckpoints(placeId);
 
         List<PlaceImageInfoDto> imageInfos = place.getPlaceImageInfos().stream()
                 .map(info -> PlaceImageInfoDto.of(
@@ -127,7 +127,7 @@ public class PlaceService {
 
         List<Long> sortedPlaceIds = sortIdsByCreatedAtDesc(latestPlaceIds, createdAtMap);
 
-        List<Place> places = placeRepository.findAllByIdsWithTown(sortedPlaceIds);
+        List<Place> places = entityLoader.getPlacesWithTown(sortedPlaceIds);
         if (places.isEmpty()) {
             return PlaceFolderPreviewListGetResponse.from(List.of());
         }

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -28,11 +27,11 @@ import org.sopt.solply_server.domain.tag.util.TagValidator;
 import org.sopt.solply_server.domain.town.entity.Town;
 import org.sopt.solply_server.domain.town.util.TownValidator;
 import org.sopt.solply_server.global.exception.BusinessException;
-import org.sopt.solply_server.global.exception.EntityNotFoundException;
 import org.sopt.solply_server.global.exception.ErrorCode;
 import org.sopt.solply_server.global.exception.JwtTokenException;
 import org.sopt.solply_server.global.util.EntityLoader;
 import org.sopt.solply_server.global.util.InputValidator;
+import org.sopt.solply_server.global.util.TagViewUtils;
 import org.sopt.solply_server.global.util.s3.ImageUrlProvider;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -69,7 +68,7 @@ public class PlaceService {
 
         return PlaceDetailsGetResponse.of(
                 place,
-                place.getActiveMainTag().map(Tag::getName).orElse(null),
+                TagViewUtils.getActiveNameOrNull(place.getMainTag().orElse(null)),
                 imageInfos,
                 isBookmarked,
                 town
@@ -99,7 +98,7 @@ public class PlaceService {
                         place.getId(),
                         place.getName(),
                         imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
-                        place.getActiveMainTag().map(Tag::getName).orElse(null),
+                        TagViewUtils.getActiveNameOrNull(place.getMainTag().orElse(null)),
                         placeBookmarkFacade.isBookmarked(userId, place.getId()),
                         townId
                 ))
@@ -147,7 +146,7 @@ public class PlaceService {
                             place.getId(),
                             place.getName(),
                             imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
-                                place.getActiveMainTag().map(Tag::getName).orElse(null),
+                                TagViewUtils.getActiveNameOrNull(place.getMainTag().orElse(null)),
                             place.getAddress(),
                             false, // 검색 결과에서는 북마크 여부를 제공 X,
                             town.getId()

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
@@ -22,7 +22,6 @@ import org.sopt.solply_server.domain.place.dto.response.PlaceSearchResponse;
 import org.sopt.solply_server.domain.place.entity.Place;
 import org.sopt.solply_server.domain.place.repository.PlaceRepository;
 import org.sopt.solply_server.domain.place.service.facade.PlaceBookmarkFacade;
-import org.sopt.solply_server.domain.tag.entity.Tag;
 import org.sopt.solply_server.domain.tag.util.TagValidator;
 import org.sopt.solply_server.domain.town.entity.Town;
 import org.sopt.solply_server.domain.town.util.TownValidator;
@@ -53,7 +52,7 @@ public class PlaceService {
      * 장소 상세 정보 조회
      */
     public PlaceDetailsGetResponse getPlaceDetailsById(final Long userId, final Long placeId) {
-        Place place = entityLoader.getPlaceWithTownAndCheckpoints(placeId);
+        Place place = entityLoader.getActivePlaceWithTownAndCheckpoints(placeId);
 
         List<PlaceImageInfoDto> imageInfos = place.getPlaceImageInfos().stream()
                 .map(info -> PlaceImageInfoDto.of(

--- a/src/main/java/org/sopt/solply_server/domain/recommend/service/RecommendService.java
+++ b/src/main/java/org/sopt/solply_server/domain/recommend/service/RecommendService.java
@@ -120,7 +120,7 @@ public class RecommendService {
                                 ));
 
         // 5) 동네 장소 조회(+tags)
-        List<Place> townPlaces = placeRepository.findPlacesByTownIdWithTags(townId);
+        List<Place> townPlaces = placeRepository.findActivePlacesByTownIdWithTags(townId);
         if (townPlaces == null || townPlaces.isEmpty()) {
             return new PlaceRecommendationGetResponse(List.of());
         }

--- a/src/main/java/org/sopt/solply_server/domain/recommend/service/RecommendService.java
+++ b/src/main/java/org/sopt/solply_server/domain/recommend/service/RecommendService.java
@@ -110,7 +110,8 @@ public class RecommendService {
                 (recentBookmarkedPlaceIds == null || recentBookmarkedPlaceIds.isEmpty())
                         ? Map.of()
                         : placeRepository.findByIdInWithTags(recentBookmarkedPlaceIds).stream()
-                                .flatMap(p -> p.getActiveTags().stream())
+                                .flatMap(p -> p.getTags().stream())
+                                .filter(Tag::isActive)
                                 .map(Tag::getId)
                                 .collect(Collectors.toMap(
                                         tagId -> tagId,

--- a/src/main/java/org/sopt/solply_server/domain/recommend/service/RecommendService.java
+++ b/src/main/java/org/sopt/solply_server/domain/recommend/service/RecommendService.java
@@ -34,6 +34,7 @@ import org.sopt.solply_server.domain.user.entity.UserPersona;
 import org.sopt.solply_server.global.exception.BusinessException;
 import org.sopt.solply_server.global.exception.ErrorCode;
 import org.sopt.solply_server.global.util.EntityLoader;
+import org.sopt.solply_server.global.util.TagViewUtils;
 import org.sopt.solply_server.global.util.s3.ImageUrlProvider;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -256,7 +257,7 @@ public class RecommendService {
                 place.getId(),
                 place.getName(),
                 imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
-                place.getActiveMainTag().map(Tag::getName).orElse(null),
+                TagViewUtils.getActiveNameOrNull(place.getMainTag().orElse(null)),
                 place.getIntroduction()
         );
     }

--- a/src/main/java/org/sopt/solply_server/domain/recommend/service/RecommendService.java
+++ b/src/main/java/org/sopt/solply_server/domain/recommend/service/RecommendService.java
@@ -174,7 +174,7 @@ public class RecommendService {
     public CourseRecommendGetResponse getRecommendCourses(Long userId, Long townId) {
         townValidator.validateTownId(townId);
 
-        List<Course> sharedCourses = courseRepository.findSharedCoursesByTownIdWithPlaces(townId);
+        List<Course> sharedCourses = courseRepository.findActiveSharedCoursesByTownIdWithPlaces(townId);
 
         if (sharedCourses.isEmpty()) {
             log.info("동네 ID {}에 공유된 코스가 없습니다.", townId);

--- a/src/main/java/org/sopt/solply_server/domain/tag/repository/TagRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/tag/repository/TagRepository.java
@@ -37,4 +37,5 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
     """)
     Optional<Tag> findByIdWithParentAndActiveTrue(@Param("id") Long id);
 
+    Optional<Tag> findByIdAndActiveTrue(Long id);
 }

--- a/src/main/java/org/sopt/solply_server/domain/town/repository/TownRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/town/repository/TownRepository.java
@@ -2,6 +2,7 @@ package org.sopt.solply_server.domain.town.repository;
 
 import java.util.List;
 
+import java.util.Optional;
 import org.sopt.solply_server.domain.town.entity.Town;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,6 @@ public interface TownRepository extends JpaRepository<Town, Long> {
 	List<Town> findByParentIsNull();
 
 	List<Town> findByParent(Town parent);
+
+    Optional<Town> findTownByIdAndActiveTrue(Long townId);
 }

--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.RequiredArgsConstructor;
 import org.sopt.solply_server.domain.place.dto.PlacePreviewDto;
 import org.sopt.solply_server.domain.town.entity.Town;
+import org.sopt.solply_server.domain.town.repository.TownRepository;
 import org.sopt.solply_server.domain.user.dto.UserPersonaDto;
 import org.sopt.solply_server.domain.user.dto.UserPlacePreviewDto;
 import org.sopt.solply_server.domain.user.dto.UserTownInfoDto;
@@ -53,7 +54,8 @@ public class UserService {
     private final S3FileService s3FileService;
     private final UserPolicyService userPolicyService;
 
-    private final int INITIAL_TOWN_ID = 2;
+    private static final long INITIAL_TOWN_ID = 2;
+    private final TownRepository townRepository;
 
     public NicknameCheckResponse checkNickname(Long userId, String nickname) {
         User user = entityLoader.getUser(userId);
@@ -72,7 +74,10 @@ public class UserService {
         if (user.getSelectedTownId() == null) {
             throw new BusinessException(ErrorCode.NOT_FOUND_USER_SELECTED_TOWN);
         }
-        Town selectedTown = entityLoader.getActiveTown(user.getSelectedTownId());
+        Town selectedTown = townRepository.findById(user.getSelectedTownId()).orElse(null);
+        if (selectedTown == null || selectedTown.getActive() == false) {
+            selectedTown = townRepository.findById(INITIAL_TOWN_ID).orElse(null);
+        }
 
         List<UserPlacePreviewDto> myPlacePreviews = myPageFacade.getMyPlacePreviewsTop3(user);
 
@@ -87,20 +92,18 @@ public class UserService {
         User user = entityLoader.getUser(userId);
 
         // 선택한 동네가 없는 경우 null 처리
-        UserTownInfoDto selectedTown = Optional.ofNullable(user.getSelectedTownId())
-                .map(entityLoader::getActiveTown)
-                .map(town -> UserTownInfoDto.of(town.getId(), town.getName()))
-                .orElse(null);
+        Long selectedTownId = user.getSelectedTownId();
+        if (selectedTownId == null) {
+            return UserTownGetResponse.of(null);
+        }
 
-        // 관심 동네들
-//        List<UserTownInfoDto> interestTowns = entityLoader.getInterestTownsWithTownsByIds(userId)
-//                .stream()
-//                .map(interestTown -> UserTownInfoDto.of(
-//                        interestTown.getTown().getId(),
-//                        interestTown.getTown().getName()))
-//                .toList();
+        Town selectedTown = townRepository.findById(selectedTownId).orElse(null);
+        if (selectedTown == null || selectedTown.getActive() == false) {
+            selectedTown = townRepository.findById(INITIAL_TOWN_ID).orElse(null);
+        }
+        UserTownInfoDto townInfoDto = UserTownInfoDto.of(selectedTown.getId(), selectedTown.getName());
 
-        return UserTownGetResponse.of(selectedTown);
+        return UserTownGetResponse.of(townInfoDto);
     }
 
     public UserRequestedPlaceAllGetResponse getPlacesCreatedBy(final Long userId, final int page, final int size) {
@@ -129,12 +132,12 @@ public class UserService {
     public UserInOnboardingUpdateResponse updateUserInfoInOnboarding(
             final Long userId, UserInOnboardingUpdateRequest request) {
         User user = entityLoader.getUser(userId);
-        Town selectedTown = entityLoader.getActiveTown((long)INITIAL_TOWN_ID);
+        Town selectedTown = entityLoader.getActiveTown(INITIAL_TOWN_ID);
 
         userValidator.validateOnboardingAvailable(user);
         userValidator.validateNickname(user.getNickname(), request.nickname());
 
-        user.updateOnboardingInfo(request.persona(), request.nickname(), (long)INITIAL_TOWN_ID);
+        user.updateOnboardingInfo(request.persona(), request.nickname(), INITIAL_TOWN_ID);
 
         // 약관 동의 여부 저장
         for (var policyInfo : request.policyAgreementInfos()) {
@@ -198,10 +201,7 @@ public class UserService {
     @Transactional
     public UserTownsUpdateResponse updateUserTowns(final Long userId, UserTownsUpdateRequest request) {
         User user = entityLoader.getUser(userId);
-//        List<Town> towns = request.favoriteTownIdList().stream()
-//                .map(entityLoader::getTown)
-//                .toList();
-//        userInterestTownService.updateUserInterestTowns(user, towns);
+
         Town selectedTown = entityLoader.getActiveTown(request.selectedTownId());
         user.updateSelectedTown(request.selectedTownId());
 

--- a/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/UserService.java
@@ -72,7 +72,7 @@ public class UserService {
         if (user.getSelectedTownId() == null) {
             throw new BusinessException(ErrorCode.NOT_FOUND_USER_SELECTED_TOWN);
         }
-        Town selectedTown = entityLoader.getTown(user.getSelectedTownId());
+        Town selectedTown = entityLoader.getActiveTown(user.getSelectedTownId());
 
         List<UserPlacePreviewDto> myPlacePreviews = myPageFacade.getMyPlacePreviewsTop3(user);
 
@@ -88,7 +88,7 @@ public class UserService {
 
         // 선택한 동네가 없는 경우 null 처리
         UserTownInfoDto selectedTown = Optional.ofNullable(user.getSelectedTownId())
-                .map(entityLoader::getTown)
+                .map(entityLoader::getActiveTown)
                 .map(town -> UserTownInfoDto.of(town.getId(), town.getName()))
                 .orElse(null);
 
@@ -129,7 +129,7 @@ public class UserService {
     public UserInOnboardingUpdateResponse updateUserInfoInOnboarding(
             final Long userId, UserInOnboardingUpdateRequest request) {
         User user = entityLoader.getUser(userId);
-        Town selectedTown = entityLoader.getTown((long)INITIAL_TOWN_ID);
+        Town selectedTown = entityLoader.getActiveTown((long)INITIAL_TOWN_ID);
 
         userValidator.validateOnboardingAvailable(user);
         userValidator.validateNickname(user.getNickname(), request.nickname());
@@ -202,7 +202,7 @@ public class UserService {
 //                .map(entityLoader::getTown)
 //                .toList();
 //        userInterestTownService.updateUserInterestTowns(user, towns);
-        Town selectedTown = entityLoader.getTown(request.selectedTownId());
+        Town selectedTown = entityLoader.getActiveTown(request.selectedTownId());
         user.updateSelectedTown(request.selectedTownId());
 
         return UserTownsUpdateResponse.of(

--- a/src/main/java/org/sopt/solply_server/domain/user/service/mypage/MyPageFacade.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/mypage/MyPageFacade.java
@@ -9,6 +9,7 @@ import org.sopt.solply_server.domain.place.repository.PlaceRepository;
 import org.sopt.solply_server.domain.tag.entity.Tag;
 import org.sopt.solply_server.domain.user.dto.UserPlacePreviewDto;
 import org.sopt.solply_server.domain.user.entity.User;
+import org.sopt.solply_server.global.util.TagViewUtils;
 import org.sopt.solply_server.global.util.s3.ImageUrlProvider;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -36,7 +37,7 @@ public class MyPageFacade {
                         place.getId(),
                         place.getName(),
                         imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
-                        place.getActiveMainTag().map(Tag::getName).orElse(null),
+                        TagViewUtils.getActiveNameOrNull(place.getMainTag().orElse(null)),
                         bookmarkMap.getOrDefault(place.getId(), false)
                 ))
                 .toList();
@@ -53,7 +54,7 @@ public class MyPageFacade {
                 place.getId(),
                 place.getName(),
                 imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
-                place.getActiveMainTag().map(Tag::getName).orElse(null),
+                TagViewUtils.getActiveNameOrNull(place.getMainTag().orElse(null)),
                 bookmarkMap.getOrDefault(place.getId(), false),
                 place.getTown().getId()
         ));

--- a/src/main/java/org/sopt/solply_server/global/util/AdminEntityLoader.java
+++ b/src/main/java/org/sopt/solply_server/global/util/AdminEntityLoader.java
@@ -1,0 +1,76 @@
+package org.sopt.solply_server.global.util;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.solply_server.domain.admin.course.repository.AdminCourseRepository;
+import org.sopt.solply_server.domain.admin.place.repository.AdminPlaceRepository;
+import org.sopt.solply_server.domain.admin.place.repository.AdminPlaceRequestRepository;
+import org.sopt.solply_server.domain.admin.tag.repository.AdminTagRepository;
+import org.sopt.solply_server.domain.admin.town.repository.AdminTownRepository;
+import org.sopt.solply_server.domain.admin.user.repository.AdminUserRepository;
+import org.sopt.solply_server.domain.course.entity.Course;
+import org.sopt.solply_server.domain.place.entity.Place;
+import org.sopt.solply_server.domain.place.entity.PlaceRequest;
+import org.sopt.solply_server.domain.tag.entity.Tag;
+import org.sopt.solply_server.domain.town.entity.Town;
+import org.sopt.solply_server.domain.user.entity.User;
+import org.sopt.solply_server.global.exception.BusinessException;
+import org.sopt.solply_server.global.exception.EntityNotFoundException;
+import org.sopt.solply_server.global.exception.ErrorCode;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AdminEntityLoader {
+
+    private final AdminTagRepository adminTagRepository;
+    private final AdminTownRepository adminTownRepository;
+    private final AdminPlaceRepository adminPlaceRepository;
+    private final AdminCourseRepository adminCourseRepository;
+    private final AdminUserRepository adminUserRepository;
+    private final AdminPlaceRequestRepository adminPlaceRequestRepository;
+
+    public Course getCourse(Long courseId) {
+        return adminCourseRepository.findById(courseId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_COURSE));
+    }
+
+    public Course getCourseWithPlacesAndTown(Long courseId) {
+        return adminCourseRepository.findByIdWithPlacesAndTown(courseId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_COURSE));
+    }
+
+    public User getUser(Long userId) {
+        return adminUserRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_USER));
+    }
+
+    public Town getTown(Long townId) {
+        return adminTownRepository.findById(townId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_TOWN));
+    }
+
+    public Tag getTag(Long id) {
+        return adminTagRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_TAG));
+    }
+
+    public Place getPlaceWithTown(Long placeId) {
+        return adminPlaceRepository.findByIdWithTown(placeId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_PLACE));
+    }
+
+    public PlaceRequest getPlaceRequest(Long requestId) {
+        return adminPlaceRequestRepository.findById(requestId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_PLACE_REQUEST));
+    }
+
+    public Place getPlaceWithTownAndCheckpoints(Long placeId) {
+        return adminPlaceRepository.findByIdWithTownAndCheckpoints(placeId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_PLACE));
+    }
+
+    public List<Course> getAllWithTownByTownId(Long townId) {
+        return adminCourseRepository.findAllWithTownByTownId(townId);
+    }
+}

--- a/src/main/java/org/sopt/solply_server/global/util/EntityLoader.java
+++ b/src/main/java/org/sopt/solply_server/global/util/EntityLoader.java
@@ -37,11 +37,6 @@ public class EntityLoader {
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_USER));
     }
 
-    public Course getCourse(Long courseId) {
-        return courseRepository.findById(courseId)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_COURSE));
-    }
-
     public Course getActiveCourse(Long courseId) {
         return courseRepository.findByIdAndActiveTrue(courseId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_COURSE));

--- a/src/main/java/org/sopt/solply_server/global/util/EntityLoader.java
+++ b/src/main/java/org/sopt/solply_server/global/util/EntityLoader.java
@@ -1,6 +1,9 @@
 package org.sopt.solply_server.global.util;
 
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
+import java.util.Optional;
+import org.sopt.solply_server.domain.admin.place.repository.AdminPlaceRepository;
 import org.sopt.solply_server.domain.course.entity.Course;
 import org.sopt.solply_server.domain.course.repository.CourseRepository;
 import org.sopt.solply_server.domain.place.entity.Place;
@@ -29,6 +32,7 @@ public class EntityLoader {
     private final TownRepository townRepository;
     private final TagRepository tagRepository;
     private final PlaceRequestRepository placeRequestRepository;
+    private final AdminPlaceRepository adminPlaceRepository;
 
     public User getUser(Long userId) {
         return userRepository.findById(userId)
@@ -40,13 +44,18 @@ public class EntityLoader {
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_COURSE));
     }
 
-    public Course getCourseWithPlaces(Long courseId) {
-        return courseRepository.findByIdWithPlaces(courseId)
+    public Course getActiveCourse(Long courseId) {
+        return courseRepository.findByIdAndActiveTrue(courseId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_COURSE));
+    }
+
+    public Course getActiveCourseWithPlaces(Long courseId) {
+        return courseRepository.findActiveByIdWithPlaces(courseId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_COURSE));
     }
 
     public Course getCourseWithPlacesAndTown(Long courseId) {
-        return courseRepository.findByIdWithPlacesAndTown(courseId)
+        return courseRepository.findActiveByIdWithPlacesAndTown(courseId)
             .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_COURSE));
     }
 
@@ -55,18 +64,39 @@ public class EntityLoader {
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_PLACE));
     }
 
-    public Place getPlaceWithTown(Long placeId) {
-        return placeRepository.findByIdWithTown(placeId)
+    public Place getPlaceWithTownAndCheckpoints(Long placeId) {
+        return placeRepository.findByIdWithTownAndCheckpoints(placeId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_PLACE));
     }
+
+    public Place getPlaceWithTown(Long placeId) {
+        return adminPlaceRepository.findByIdWithTown(placeId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_PLACE));
+    }
+
+    public List<Place> getPlacesWithTown(List<Long> placeIds) {
+        return placeRepository.findAllByIdsWithTown(placeIds);
+    }
+
 
     public Town getTown(Long townId) {
         return townRepository.findById(townId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_TOWN));
     }
 
+    public Town getActiveTown(Long townId) {
+        return townRepository.findTownByIdAndActiveTrue(townId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_TOWN));
+    }
+
+
     public Tag getTag(Long id) {
         return tagRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_TAG));
+    }
+
+    public Tag getActiveTag(Long id) {
+        return tagRepository.findByIdAndActiveTrue(id)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_TAG));
     }
 
@@ -75,11 +105,4 @@ public class EntityLoader {
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_PLACE_REQUEST));
     }
 
-    public List<Place> findPlacesWithTown(List<Long> placeIds) {
-        return placeRepository.findAllByIdsWithTown(placeIds);
-    }
-
-//    public List<UserInterestTown> getInterestTownsWithTownsByIds(Long userId) {
-//        return userInterestTownRepository.findAllByUserWithTown(userId);
-//    }
 }

--- a/src/main/java/org/sopt/solply_server/global/util/EntityLoader.java
+++ b/src/main/java/org/sopt/solply_server/global/util/EntityLoader.java
@@ -63,7 +63,6 @@ public class EntityLoader {
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_TOWN));
     }
 
-
     public Tag getActiveTag(Long id) {
         return tagRepository.findByIdAndActiveTrue(id)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_TAG));

--- a/src/main/java/org/sopt/solply_server/global/util/EntityLoader.java
+++ b/src/main/java/org/sopt/solply_server/global/util/EntityLoader.java
@@ -1,8 +1,6 @@
 package org.sopt.solply_server.global.util;
 
-import jakarta.validation.constraints.NotNull;
 import java.util.List;
-import java.util.Optional;
 import org.sopt.solply_server.domain.admin.place.repository.AdminPlaceRepository;
 import org.sopt.solply_server.domain.course.entity.Course;
 import org.sopt.solply_server.domain.course.repository.CourseRepository;
@@ -52,11 +50,6 @@ public class EntityLoader {
     public Course getActiveCourseWithPlaces(Long courseId) {
         return courseRepository.findActiveByIdWithPlaces(courseId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_COURSE));
-    }
-
-    public Course getCourseWithPlacesAndTown(Long courseId) {
-        return courseRepository.findActiveByIdWithPlacesAndTown(courseId)
-            .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_COURSE));
     }
 
     public Place getPlace(Long placeId) {

--- a/src/main/java/org/sopt/solply_server/global/util/EntityLoader.java
+++ b/src/main/java/org/sopt/solply_server/global/util/EntityLoader.java
@@ -1,13 +1,10 @@
 package org.sopt.solply_server.global.util;
 
 import java.util.List;
-import org.sopt.solply_server.domain.admin.place.repository.AdminPlaceRepository;
 import org.sopt.solply_server.domain.course.entity.Course;
 import org.sopt.solply_server.domain.course.repository.CourseRepository;
 import org.sopt.solply_server.domain.place.entity.Place;
-import org.sopt.solply_server.domain.place.entity.PlaceRequest;
 import org.sopt.solply_server.domain.place.repository.PlaceRepository;
-import org.sopt.solply_server.domain.place.repository.PlaceRequestRepository;
 import org.sopt.solply_server.domain.tag.entity.Tag;
 import org.sopt.solply_server.domain.tag.repository.TagRepository;
 import org.sopt.solply_server.domain.town.entity.Town;
@@ -29,8 +26,7 @@ public class EntityLoader {
     private final PlaceRepository placeRepository;
     private final TownRepository townRepository;
     private final TagRepository tagRepository;
-    private final PlaceRequestRepository placeRequestRepository;
-    private final AdminPlaceRepository adminPlaceRepository;
+
 
     public User getUser(Long userId) {
         return userRepository.findById(userId)
@@ -52,25 +48,15 @@ public class EntityLoader {
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_PLACE));
     }
 
-    public Place getPlaceWithTownAndCheckpoints(Long placeId) {
-        return placeRepository.findByIdWithTownAndCheckpoints(placeId)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_PLACE));
-    }
-
-    public Place getPlaceWithTown(Long placeId) {
-        return adminPlaceRepository.findByIdWithTown(placeId)
+    public Place getActivePlaceWithTownAndCheckpoints(Long placeId) {
+        return placeRepository.findActiveByIdWithTownAndCheckpoints(placeId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_PLACE));
     }
 
     public List<Place> getPlacesWithTown(List<Long> placeIds) {
-        return placeRepository.findAllByIdsWithTown(placeIds);
+        return placeRepository.findActiveAllByIdsWithTown(placeIds);
     }
 
-
-    public Town getTown(Long townId) {
-        return townRepository.findById(townId)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_TOWN));
-    }
 
     public Town getActiveTown(Long townId) {
         return townRepository.findTownByIdAndActiveTrue(townId)
@@ -78,19 +64,11 @@ public class EntityLoader {
     }
 
 
-    public Tag getTag(Long id) {
-        return tagRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_TAG));
-    }
-
     public Tag getActiveTag(Long id) {
         return tagRepository.findByIdAndActiveTrue(id)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_TAG));
     }
 
-    public PlaceRequest getPlaceRequest(Long requestId) {
-        return placeRequestRepository.findById(requestId)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_PLACE_REQUEST));
-    }
+
 
 }

--- a/src/main/java/org/sopt/solply_server/global/util/EntityLoader.java
+++ b/src/main/java/org/sopt/solply_server/global/util/EntityLoader.java
@@ -42,8 +42,8 @@ public class EntityLoader {
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_COURSE));
     }
 
-    public Course getActiveCourseWithPlaces(Long courseId) {
-        return courseRepository.findActiveByIdWithPlaces(courseId)
+    public Course getActiveCourseWithTagsAndPlaces(Long courseId) {
+        return courseRepository.findActiveByIdWithTagsAndPlaces(courseId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_COURSE));
     }
 

--- a/src/main/java/org/sopt/solply_server/global/util/TagViewUtils.java
+++ b/src/main/java/org/sopt/solply_server/global/util/TagViewUtils.java
@@ -1,0 +1,12 @@
+package org.sopt.solply_server.global.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.sopt.solply_server.domain.tag.entity.Tag;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class TagViewUtils {
+    public static String getActiveNameOrNull(Tag tag) {
+        return (tag != null && tag.isActive()) ? tag.getName() : null;
+    }
+}


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
resolves #306 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- place 상세조회 과정에서 checkpoints가 트랜잭션 밖으로 튀어서 로딩이 안된 문제를 수정했습니다.
- place에서 tag를 active한 것만 필터링 하는 부분을 utill로 분리했습니다.
- course 관련 서비스에서 tag를 active한 것 외에도 조회해오는 문제가 있어 수정했습니다.
- course를 조회할 때 active하지 않은 course도 조회해오는 문제를 수정했습니다.


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 비활성 코스·장소가 화면에 노출되던 문제를 해결했습니다.
  * 장소 상세에서 주요 태그가 잘못 표시되던 문제를 수정했습니다.
  * 장소 상세 조회 시 연관 체크포인트 누락 문제를 해결했습니다.

* **개선사항**
  * 활성 상태 필터가 서비스 전반에 일관되게 적용되어 콘텐츠 신뢰도가 향상되었습니다.
  * 태그 이름 처리 로직을 유틸화해 표시 일관성과 널 안전성이 개선되었습니다.
  * 장소·코스 조회 경로를 정비해 로딩 안정성과 성능을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->