### PR TITLE
[FEAT] 신규 유저 가입시 디코 알람 기능 구현(+ 공유된 코스만 조회)

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -197,6 +197,8 @@ public class CourseService {
     public CourseDetailGetResponse getCourseDetailsById(final Long userId, final Long courseId) {
         Course course = entityLoader.getActiveCourseWithTagsAndPlaces(courseId);
 
+        if (isNotSharedCourse(course, userId)) throw new BusinessException(ErrorCode.NOT_SHARED_COURSE);
+
         Tag courseTag = course.getTag();
         tagValidator.validateCourseTag(courseTag);
 
@@ -283,6 +285,7 @@ public class CourseService {
 
         final List<CourseInfoDto> courseInfoDtos = createSortedCourseInfoDtoList(
                 filteredCourses,
+                userId,
                 courseIdCreatedAtMap,
                 candidatePlace,
                 candidatePlaceId != null
@@ -477,6 +480,7 @@ public class CourseService {
 
     private List<CourseInfoDto> createSortedCourseInfoDtoList(
             final List<Course> filteredCourses,
+            final Long userId,
             final Map<Long, LocalDateTime> courseIdCreatedAtMap,
             final Place candidatePlace,
             final boolean hasCandidatePlace
@@ -486,6 +490,7 @@ public class CourseService {
                 prepareValidationResults(filteredCourses, candidatePlace, hasCandidatePlace);
 
         return filteredCourses.stream()
+                .filter(course -> isNotSharedCourse(course, userId))
                 .map(course -> {
                     Tag courseTag = course.getTag();
                     String courseTagName = TagViewUtils.getActiveNameOrNull(courseTag);
@@ -502,6 +507,10 @@ public class CourseService {
                         .getOrDefault(b.courseId(), LocalDateTime.MIN)
                         .compareTo(courseIdCreatedAtMap.getOrDefault(a.courseId(), LocalDateTime.MIN)))
                 .toList();
+    }
+
+    private boolean isNotSharedCourse(Course course, Long userId) {
+        return !course.isShared() && !course.isCreatedBy(userId);
     }
 
 

--- a/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
+++ b/src/main/java/org/sopt/solply_server/domain/course/service/CourseService.java
@@ -197,7 +197,7 @@ public class CourseService {
     public CourseDetailGetResponse getCourseDetailsById(final Long userId, final Long courseId) {
         Course course = entityLoader.getActiveCourseWithTagsAndPlaces(courseId);
 
-        if (isNotSharedCourse(course, userId)) throw new BusinessException(ErrorCode.NOT_SHARED_COURSE);
+        if (!isSharedCourse(course, userId)) throw new BusinessException(ErrorCode.NOT_SHARED_COURSE);
 
         Tag courseTag = course.getTag();
         tagValidator.validateCourseTag(courseTag);
@@ -490,7 +490,7 @@ public class CourseService {
                 prepareValidationResults(filteredCourses, candidatePlace, hasCandidatePlace);
 
         return filteredCourses.stream()
-                .filter(course -> isNotSharedCourse(course, userId))
+                .filter(course -> isSharedCourse(course, userId))
                 .map(course -> {
                     Tag courseTag = course.getTag();
                     String courseTagName = TagViewUtils.getActiveNameOrNull(courseTag);
@@ -509,8 +509,8 @@ public class CourseService {
                 .toList();
     }
 
-    private boolean isNotSharedCourse(Course course, Long userId) {
-        return !course.isShared() && !course.isCreatedBy(userId);
+    private boolean isSharedCourse(Course course, Long userId) {
+        return course.isShared() || course.isCreatedBy(userId);
     }
 
 

--- a/src/main/java/org/sopt/solply_server/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/repository/UserRepository.java
@@ -28,4 +28,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query(value = "SELECT * FROM users WHERE email = :email LIMIT 1", nativeQuery = true)
     Optional<User> findAnyByEmail(@Param("email") String email);
 
+    @Query("SELECT COUNT(u) FROM User u WHERE u.isDeleted = false ")
+    long countByActiveTrue();
 }

--- a/src/main/java/org/sopt/solply_server/domain/user/service/SocialUserService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/SocialUserService.java
@@ -9,6 +9,7 @@ import org.sopt.solply_server.domain.user.repository.SocialUserInfoRepository;
 import org.sopt.solply_server.domain.user.repository.UserRepository;
 import org.sopt.solply_server.global.exception.BusinessException;
 import org.sopt.solply_server.global.exception.ErrorCode;
+import org.sopt.solply_server.global.external.discord.DiscordNotificationService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +20,7 @@ public class SocialUserService {
 
     private final SocialUserInfoRepository socialUserInfoRepository;
     private final UserRepository userRepository;
+    private final DiscordNotificationService discordNotificationService;
 
     @Transactional
     public User createOrLoginSocialUser(
@@ -46,6 +48,7 @@ public class SocialUserService {
 
         // 2) 해당 소셜 링크가 없으면, email로 기존 유저 연동 시도
         User user = null;
+        boolean isNewUser = false; // 신규 유저 여부 체크 플래그
 
         if (email != null) {
             user = userRepository.findAnyByEmail(email)
@@ -56,11 +59,17 @@ public class SocialUserService {
         // 3) 없으면 신규 생성
         if (user == null) {
             user = userRepository.save(User.create(email)); // email은 null 가능하게
+            isNewUser = true;
         }
 
         // 4) 소셜 링크 생성
         // socialCode는 유니크라서 여기서 동시성 안전하게 처리하는 게 좋음(아래 참고)
         linkSocialAccount(user, platform, socialId);
+
+        if (isNewUser) {
+            discordNotificationService.sendRegistrationMessage(user, platform);
+        }
+
 
         return user;
     }

--- a/src/main/java/org/sopt/solply_server/domain/user/service/SocialUserService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/SocialUserService.java
@@ -7,9 +7,11 @@ import org.sopt.solply_server.domain.user.entity.SocialUserInfo;
 import org.sopt.solply_server.domain.user.entity.User;
 import org.sopt.solply_server.domain.user.repository.SocialUserInfoRepository;
 import org.sopt.solply_server.domain.user.repository.UserRepository;
+import org.sopt.solply_server.domain.user.service.event.UserRegistrationEvent;
 import org.sopt.solply_server.global.exception.BusinessException;
 import org.sopt.solply_server.global.exception.ErrorCode;
 import org.sopt.solply_server.global.external.discord.DiscordNotificationService;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +23,7 @@ public class SocialUserService {
     private final SocialUserInfoRepository socialUserInfoRepository;
     private final UserRepository userRepository;
     private final DiscordNotificationService discordNotificationService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public User createOrLoginSocialUser(
@@ -67,7 +70,7 @@ public class SocialUserService {
         linkSocialAccount(user, platform, socialId);
 
         if (isNewUser) {
-            discordNotificationService.sendRegistrationMessage(user, platform);
+            eventPublisher.publishEvent(new UserRegistrationEvent(user, platform));
         }
 
 

--- a/src/main/java/org/sopt/solply_server/domain/user/service/SocialUserService.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/SocialUserService.java
@@ -10,7 +10,6 @@ import org.sopt.solply_server.domain.user.repository.UserRepository;
 import org.sopt.solply_server.domain.user.service.event.UserRegistrationEvent;
 import org.sopt.solply_server.global.exception.BusinessException;
 import org.sopt.solply_server.global.exception.ErrorCode;
-import org.sopt.solply_server.global.external.discord.DiscordNotificationService;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,7 +21,6 @@ public class SocialUserService {
 
     private final SocialUserInfoRepository socialUserInfoRepository;
     private final UserRepository userRepository;
-    private final DiscordNotificationService discordNotificationService;
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional

--- a/src/main/java/org/sopt/solply_server/domain/user/service/event/UserRegistrationEvent.java
+++ b/src/main/java/org/sopt/solply_server/domain/user/service/event/UserRegistrationEvent.java
@@ -1,0 +1,10 @@
+package org.sopt.solply_server.domain.user.service.event;
+
+import org.sopt.solply_server.domain.auth.entity.SocialPlatform;
+import org.sopt.solply_server.domain.user.entity.User;
+
+public record UserRegistrationEvent(
+        User user,
+        SocialPlatform platform
+) {
+}

--- a/src/main/java/org/sopt/solply_server/global/exception/ErrorCode.java
+++ b/src/main/java/org/sopt/solply_server/global/exception/ErrorCode.java
@@ -75,7 +75,7 @@ public enum ErrorCode {
     NOT_SUFFICIENT_PLACE_COUNT(HttpStatus.BAD_REQUEST, "COURSE-006", "코스에 최소 1개 이상의 장소가 필요합니다."),
     INVALID_PLACES_ORDER(HttpStatus.BAD_REQUEST, "COURSE-007", "장소 순서가 올바르지 않습니다."),
     DUPLICATE_COURSE_NAME(HttpStatus.BAD_REQUEST,"COURSE-008","코스 이름이 중복됩니다."),
-    NOT_SHARED_COURSE(HttpStatus.BAD_REQUEST,"COURSE-009" ,"공유되지 않은 코스입니다." ),
+    NOT_SHARED_COURSE(HttpStatus.FORBIDDEN,"COURSE-009" ,"공유되지 않은 코스입니다." ),
 
     // 동네 관련 (TOWN-xxx)
     NOT_FOUND_TOWN(HttpStatus.NOT_FOUND, "TOWN-001" , "존재하지 않는 동네입니다."),

--- a/src/main/java/org/sopt/solply_server/global/exception/ErrorCode.java
+++ b/src/main/java/org/sopt/solply_server/global/exception/ErrorCode.java
@@ -75,6 +75,7 @@ public enum ErrorCode {
     NOT_SUFFICIENT_PLACE_COUNT(HttpStatus.BAD_REQUEST, "COURSE-006", "코스에 최소 1개 이상의 장소가 필요합니다."),
     INVALID_PLACES_ORDER(HttpStatus.BAD_REQUEST, "COURSE-007", "장소 순서가 올바르지 않습니다."),
     DUPLICATE_COURSE_NAME(HttpStatus.BAD_REQUEST,"COURSE-008","코스 이름이 중복됩니다."),
+    NOT_SHARED_COURSE(HttpStatus.BAD_REQUEST,"COURSE-009" ,"공유되지 않은 코스입니다." ),
 
     // 동네 관련 (TOWN-xxx)
     NOT_FOUND_TOWN(HttpStatus.NOT_FOUND, "TOWN-001" , "존재하지 않는 동네입니다."),

--- a/src/main/java/org/sopt/solply_server/global/external/discord/DiscordNotificationService.java
+++ b/src/main/java/org/sopt/solply_server/global/external/discord/DiscordNotificationService.java
@@ -1,0 +1,54 @@
+package org.sopt.solply_server.global.external.discord;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.solply_server.domain.auth.entity.SocialPlatform;
+import org.sopt.solply_server.domain.user.entity.User;
+import org.sopt.solply_server.domain.user.repository.UserRepository;
+import org.sopt.solply_server.global.external.discord.dto.DiscordMessageDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DiscordNotificationService {
+
+    @Value("${discord.webhook.url}") // application.yml에 등록된 url
+    private String webhookUrl;
+
+    @Value("${discord.enabled:false}") // 기본값은 false
+    private boolean isDiscordEnabled;
+
+    private final UserRepository userRepository;
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Async // 회원가입 로직이 멈추지 않게 비동기로 실행
+    public void sendRegistrationMessage(User user, SocialPlatform platform) {
+        if (!isDiscordEnabled) return;
+
+        try {
+            // 1. 가입 시간
+            String joinTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+
+            // 2. 총 가입자 수 조회 (탈퇴하지 않은 유저만 카운트)
+            long totalCount = userRepository.countByActiveTrue();
+
+            DiscordMessageDto message = DiscordMessageDto.newUser(
+                    "솔플러_" + user.getId(),
+                    user.getEmail(),
+                    platform.name(),
+                    joinTime,
+                    totalCount
+            );
+
+            restTemplate.postForEntity(webhookUrl, message, String.class);
+        } catch (Exception e) {
+            log.error("디스코드 알림 전송 실패: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/org/sopt/solply_server/global/external/discord/dto/DiscordMessageDto.java
+++ b/src/main/java/org/sopt/solply_server/global/external/discord/dto/DiscordMessageDto.java
@@ -7,7 +7,7 @@ public record DiscordMessageDto(
         List<Embed> embeds
 ) {
     public static DiscordMessageDto newUser(
-            String nickname, String email, String platform, String joinTime, long totalCount
+            String nickname, String joinTime, long totalCount
     ) {
         return new DiscordMessageDto(
                 "🎉 **새로운 솔플러가 합류했습니다!**",
@@ -16,8 +16,6 @@ public record DiscordMessageDto(
                         0x3498DB, // 파란색 코드
                         List.of(
                                 new Field("닉네임", nickname, true),
-                                new Field("플랫폼", platform, true),
-                                new Field("이메일", email != null ? email : "비공개", false),
                                 new Field("가입시간", joinTime, true),
                                 new Field("총 가입자", totalCount + "명", true)
                         )

--- a/src/main/java/org/sopt/solply_server/global/external/discord/dto/DiscordMessageDto.java
+++ b/src/main/java/org/sopt/solply_server/global/external/discord/dto/DiscordMessageDto.java
@@ -1,0 +1,30 @@
+package org.sopt.solply_server.global.external.discord.dto;
+
+import java.util.List;
+
+public record DiscordMessageDto(
+        String content,
+        List<Embed> embeds
+) {
+    public static DiscordMessageDto newUser(
+            String nickname, String email, String platform, String joinTime, long totalCount
+    ) {
+        return new DiscordMessageDto(
+                "🎉 **새로운 솔플러가 합류했습니다!**",
+                List.of(new Embed(
+                        "신규 유저 가입 알림",
+                        0x3498DB, // 파란색 코드
+                        List.of(
+                                new Field("닉네임", nickname, true),
+                                new Field("플랫폼", platform, true),
+                                new Field("이메일", email != null ? email : "비공개", false),
+                                new Field("가입시간", joinTime, true),
+                                new Field("총 가입자", totalCount + "명", true)
+                        )
+                ))
+        );
+    }
+
+    public record Embed(String title, int color, List<Field> fields) {}
+    public record Field(String name, String value, boolean inline) {}
+}

--- a/src/main/java/org/sopt/solply_server/global/listener/UserRegistrationEventListener.java
+++ b/src/main/java/org/sopt/solply_server/global/listener/UserRegistrationEventListener.java
@@ -1,54 +1,53 @@
-package org.sopt.solply_server.global.external.discord;
+package org.sopt.solply_server.global.listener;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.sopt.solply_server.domain.auth.entity.SocialPlatform;
-import org.sopt.solply_server.domain.user.entity.User;
+import org.sopt.solply_server.domain.user.service.event.UserRegistrationEvent;
 import org.sopt.solply_server.domain.user.repository.UserRepository;
 import org.sopt.solply_server.global.external.discord.dto.DiscordMessageDto;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.web.client.RestTemplate;
 
 @Slf4j
-@Service
+@Component
 @RequiredArgsConstructor
-public class DiscordNotificationService {
+public class UserRegistrationEventListener {
 
-    @Value("${discord.webhook.url}") // application.yml에 등록된 url
+    @Value("${discord.webhook.url}")
     private String webhookUrl;
 
-    @Value("${discord.enabled:false}") // 기본값은 false
+    @Value("${discord.enabled:false}")
     private boolean isDiscordEnabled;
 
     private final UserRepository userRepository;
     private final RestTemplate restTemplate = new RestTemplate();
 
-    @Async // 회원가입 로직이 멈추지 않게 비동기로 실행
-    public void sendRegistrationMessage(User user, SocialPlatform platform) {
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT) // 커밋 완료 후 실행
+    public void onUserRegistered(UserRegistrationEvent event) {
         if (!isDiscordEnabled) return;
 
         try {
-            // 1. 가입 시간
-            String joinTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+            var user = event.user();
 
-            // 2. 총 가입자 수 조회 (탈퇴하지 않은 유저만 카운트)
+            String joinTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
             long totalCount = userRepository.countByActiveTrue();
 
             DiscordMessageDto message = DiscordMessageDto.newUser(
-                    "솔플러_" + user.getId(),
-                    user.getEmail(),
-                    platform.name(),
+                    user.getNickname(),
                     joinTime,
                     totalCount
             );
 
             restTemplate.postForEntity(webhookUrl, message, String.class);
         } catch (Exception e) {
-            log.error("디스코드 알림 전송 실패: {}", e.getMessage());
+            log.error("유저 가입 디스코드 알림 전송 실패", e);
         }
     }
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
resolves #308 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- 신규 가입 디코 알림 기능 구현
- 공유된 코스만 조회되도록 수정

<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 본인 소유의 코스인지 체크할때, userId로 getId를 호출할 때 n+1 문제가 발생하게 될지 고민했는데, 
FetchType.LAZY로 설정하면 JPA는 실제 User 엔티티 대신 프록시 객체를 꽂아놓고 userId(FK)를 프록시에 저장해두기 때문에, n+1 문제가 안터진다고 하더라구요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 신규 사용자 가입 시 디스코드를 통한 자동 알림 기능 추가

* **버그 수정**
  * 코스 접근 권한 검증 강화로 공유되지 않은 코스에 대한 비인가 접근 차단
<!-- end of auto-generated comment: release notes by coderabbit.ai -->