### PR TITLE
[FIX] 어드민 api 연결을 위한 도메인 접근 허용

### DIFF
--- a/src/main/java/org/sopt/solply_server/global/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/solply_server/global/config/SecurityConfig.java
@@ -50,12 +50,12 @@ public class SecurityConfig {
     @Order(1)
     public SecurityFilterChain appChain(HttpSecurity http) throws Exception {
         return http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
-                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+
                 .authorizeHttpRequests(auth -> auth
                         // 기존 화이트리스트
                         .requestMatchers(AUTH_WHITELIST).permitAll()
@@ -80,6 +80,7 @@ public class SecurityConfig {
                         // ❌ 나머지 전부 로그인 필요
                         .anyRequest().authenticated()
                 )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 
@@ -91,7 +92,8 @@ public class SecurityConfig {
                 "https://solply.store",
                 "https://www.solply.store",
                 "https://api.solply.store",
-                "https://dev.api.solply.store"
+                "https://dev.api.solply.store",
+                "https://solplyadmin.netlify.app"
         ));
 
         config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
resolves #337 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- SecurityConfig를 해당 도메인으로부터의 접근을 허용하도록 수정해줬습니다.


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 간단한 작업이었습니당

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * CORS 설정을 확대하여 추가 도메인 지원을 추가했습니다.
  * 보안 인증 필터 구성을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->