### PR TITLE
[feat] 어드민 웹 카카오 소셜 로그인

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,14 @@
 ## 개발 워크플로우
 이슈 생성 → 브랜치 생성 → 구현 → 커밋 → PR 오픈
 
+**플랜 승인 후 반드시 아래 순서를 따른다:**
+1. [docs/github-workflow.md](docs/github-workflow.md)를 읽는다.
+2. 이슈 초안(제목·본문)을 작성해 사용자에게 보여주고 확인받는다.
+3. 확인 후 `gh issue create` 실행 → 이슈 번호 확보
+4. `develop`에서 브랜치 생성: `feat/#<number>-<short-description>`
+5. TODO.md에 진행 중인 이슈와 태스크 목록을 추가한다.
+6. 구현 → 커밋 → PR 오픈 (PR도 사용자 확인 후 생성)
+
 ## 스킬
 - `/review-plan` — 현재 플랜을 GPT 추론 모델에 전송하여 리스크·개선점을 검토받고 한국어로 요약 반환 (필수: `OPENAI_API_KEY`)
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -4,6 +4,7 @@
 
 ### API 응답
 모든 API 응답은 `CustomApiResponse<T>` 래퍼를 사용한다.
+단, OAuth 리다이렉트 엔드포인트(302 응답)는 브라우저 리다이렉션 프로토콜 특성상 예외로 허용한다.
 
 ### 예외 처리
 `BusinessException(ErrorCode)`를 던지고, `GlobalExceptionHandler`에서 일괄 처리한다.

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -127,6 +127,7 @@ resolves #<issue-number>
 
 - Assignee: `uykm`
 - Reviewer: `uykm`, `ImHyungsuk`, `88guri`
+- Label: 이슈와 동일한 라벨을 붙인다.
 - 반드시 이슈를 `resolves #<issue-number>`로 연결한다.
 - PR 생성 전 사용자 확인을 받는다.
 - PR 생성 전 빌드 성공 여부를 확인한다.

--- a/src/main/java/org/sopt/solply_server/domain/admin/auth/controller/AdminAuthController.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/auth/controller/AdminAuthController.java
@@ -1,5 +1,6 @@
 package org.sopt.solply_server.domain.admin.auth.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "어드민(로그인) API", description = "어드민 로그인 Admin용 API")
 @RestController
 @RequestMapping("/api/admin/auth")
 @RequiredArgsConstructor

--- a/src/main/java/org/sopt/solply_server/domain/admin/auth/controller/AdminAuthController.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/auth/controller/AdminAuthController.java
@@ -1,0 +1,46 @@
+package org.sopt.solply_server.domain.admin.auth.controller;
+
+import jakarta.validation.Valid;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.sopt.solply_server.domain.admin.auth.dto.request.AdminAuthTokenRequest;
+import org.sopt.solply_server.domain.admin.auth.dto.response.AdminAuthTokenResponse;
+import org.sopt.solply_server.domain.admin.auth.service.AdminAuthService;
+import org.sopt.solply_server.global.dto.CustomApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/auth")
+@RequiredArgsConstructor
+public class AdminAuthController {
+
+    private final AdminAuthService adminAuthService;
+
+    @GetMapping("/kakao")
+    public ResponseEntity<Void> kakaoLogin() {
+        return ResponseEntity.status(302)
+                .location(URI.create(adminAuthService.getKakaoAuthUrl()))
+                .build();
+    }
+
+    @GetMapping("/kakao/callback")
+    public ResponseEntity<Void> kakaoCallback(@RequestParam String code) {
+        String redirectUrl = adminAuthService.processKakaoCallback(code);
+        return ResponseEntity.status(302)
+                .location(URI.create(redirectUrl))
+                .build();
+    }
+
+    @PostMapping("/kakao/token")
+    public ResponseEntity<CustomApiResponse<AdminAuthTokenResponse>> exchangeToken(
+            @Valid @RequestBody AdminAuthTokenRequest request
+    ) {
+        return CustomApiResponse.success("어드민 로그인 성공", adminAuthService.exchangeAuthCode(request.authCode()));
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/admin/auth/controller/AdminAuthController.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/auth/controller/AdminAuthController.java
@@ -32,8 +32,8 @@ public class AdminAuthController {
     }
 
     @GetMapping("/kakao/callback")
-    public ResponseEntity<Void> kakaoCallback(@RequestParam String code) {
-        String redirectUrl = adminAuthService.processKakaoCallback(code);
+    public ResponseEntity<Void> kakaoCallback(@RequestParam String code, @RequestParam String state) {
+        String redirectUrl = adminAuthService.processKakaoCallback(code, state);
         return ResponseEntity.status(302)
                 .location(URI.create(redirectUrl))
                 .build();

--- a/src/main/java/org/sopt/solply_server/domain/admin/auth/controller/AdminAuthController.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/auth/controller/AdminAuthController.java
@@ -1,14 +1,20 @@
 package org.sopt.solply_server.domain.admin.auth.controller;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.sopt.solply_server.domain.admin.auth.dto.request.AdminAuthTokenRequest;
 import org.sopt.solply_server.domain.admin.auth.dto.response.AdminAuthTokenResponse;
+import org.sopt.solply_server.domain.admin.auth.dto.response.KakaoAuthUrlResult;
 import org.sopt.solply_server.domain.admin.auth.service.AdminAuthService;
 import org.sopt.solply_server.global.dto.CustomApiResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,18 +28,44 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AdminAuthController {
 
+    private static final String OAUTH_NONCE_COOKIE = "oauth_nonce";
+
     private final AdminAuthService adminAuthService;
 
     @GetMapping("/kakao")
-    public ResponseEntity<Void> kakaoLogin() {
+    public ResponseEntity<Void> kakaoLogin(HttpServletResponse response) {
+        KakaoAuthUrlResult result = adminAuthService.generateKakaoAuthUrl();
+
+        ResponseCookie nonceCookie = ResponseCookie.from(OAUTH_NONCE_COOKIE, result.nonce())
+                .httpOnly(true)
+                .path("/api/admin/auth/kakao/callback")
+                .maxAge(Duration.ofMinutes(10))
+                .sameSite("Lax")
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, nonceCookie.toString());
+
         return ResponseEntity.status(302)
-                .location(URI.create(adminAuthService.getKakaoAuthUrl()))
+                .location(URI.create(result.url()))
                 .build();
     }
 
     @GetMapping("/kakao/callback")
-    public ResponseEntity<Void> kakaoCallback(@RequestParam String code, @RequestParam String state) {
-        String redirectUrl = adminAuthService.processKakaoCallback(code, state);
+    public ResponseEntity<Void> kakaoCallback(
+            @RequestParam String code,
+            @RequestParam String state,
+            @CookieValue(name = OAUTH_NONCE_COOKIE, required = false) String nonce,
+            HttpServletResponse response
+    ) {
+        String redirectUrl = adminAuthService.processKakaoCallback(code, state, nonce);
+
+        ResponseCookie clearCookie = ResponseCookie.from(OAUTH_NONCE_COOKIE, "")
+                .httpOnly(true)
+                .path("/api/admin/auth/kakao/callback")
+                .maxAge(0)
+                .sameSite("Lax")
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, clearCookie.toString());
+
         return ResponseEntity.status(302)
                 .location(URI.create(redirectUrl))
                 .build();

--- a/src/main/java/org/sopt/solply_server/domain/admin/auth/dto/request/AdminAuthTokenRequest.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/auth/dto/request/AdminAuthTokenRequest.java
@@ -1,0 +1,8 @@
+package org.sopt.solply_server.domain.admin.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AdminAuthTokenRequest(
+        @NotBlank String authCode
+) {
+}

--- a/src/main/java/org/sopt/solply_server/domain/admin/auth/dto/response/AdminAuthTokenResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/auth/dto/response/AdminAuthTokenResponse.java
@@ -1,0 +1,7 @@
+package org.sopt.solply_server.domain.admin.auth.dto.response;
+
+public record AdminAuthTokenResponse(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/org/sopt/solply_server/domain/admin/auth/dto/response/KakaoAuthUrlResult.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/auth/dto/response/KakaoAuthUrlResult.java
@@ -1,0 +1,4 @@
+package org.sopt.solply_server.domain.admin.auth.dto.response;
+
+public record KakaoAuthUrlResult(String url, String nonce) {
+}

--- a/src/main/java/org/sopt/solply_server/domain/admin/auth/repository/AdminAuthCodeRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/auth/repository/AdminAuthCodeRepository.java
@@ -1,0 +1,48 @@
+package org.sopt.solply_server.domain.admin.auth.repository;
+
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.sopt.solply_server.domain.auth.entity.SocialPlatform;
+import org.sopt.solply_server.global.exception.BusinessException;
+import org.sopt.solply_server.global.exception.ErrorCode;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AdminAuthCodeRepository {
+
+    private static final String KEY_PREFIX = "admin:auth:code:";
+    private static final long TTL_MINUTES = 5;
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void save(String authCode, Long userId, SocialPlatform platform) {
+        try {
+            redisTemplate.opsForValue().set(
+                    KEY_PREFIX + authCode,
+                    userId + ":" + platform.name(),
+                    TTL_MINUTES,
+                    TimeUnit.MINUTES
+            );
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.REDIS_OPERATION_FAILED);
+        }
+    }
+
+    /**
+     * 조회 후 즉시 삭제 (일회용 보장)
+     */
+    public String pop(String authCode) {
+        try {
+            String key = KEY_PREFIX + authCode;
+            String value = redisTemplate.opsForValue().get(key);
+            if (value != null) {
+                redisTemplate.delete(key);
+            }
+            return value;
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.REDIS_OPERATION_FAILED);
+        }
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/admin/auth/repository/AdminAuthCodeRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/auth/repository/AdminAuthCodeRepository.java
@@ -31,16 +31,11 @@ public class AdminAuthCodeRepository {
     }
 
     /**
-     * 조회 후 즉시 삭제 (일회용 보장)
+     * 조회 후 즉시 삭제 (일회용 보장, GETDEL로 원자적 처리)
      */
     public String pop(String authCode) {
         try {
-            String key = KEY_PREFIX + authCode;
-            String value = redisTemplate.opsForValue().get(key);
-            if (value != null) {
-                redisTemplate.delete(key);
-            }
-            return value;
+            return redisTemplate.opsForValue().getAndDelete(KEY_PREFIX + authCode);
         } catch (Exception e) {
             throw new BusinessException(ErrorCode.REDIS_OPERATION_FAILED);
         }

--- a/src/main/java/org/sopt/solply_server/domain/admin/auth/repository/AdminOAuthStateRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/auth/repository/AdminOAuthStateRepository.java
@@ -16,11 +16,14 @@ public class AdminOAuthStateRepository {
 
     private final RedisTemplate<String, String> redisTemplate;
 
-    public void save(String state) {
+    /**
+     * state → nonce 매핑 저장. nonce는 요청을 시작한 클라이언트를 식별하는 HttpOnly 쿠키 값.
+     */
+    public void save(String state, String nonce) {
         try {
             redisTemplate.opsForValue().set(
                     KEY_PREFIX + state,
-                    "valid",
+                    nonce,
                     TTL_MINUTES,
                     TimeUnit.MINUTES
             );
@@ -30,11 +33,13 @@ public class AdminOAuthStateRepository {
     }
 
     /**
-     * 존재 여부 확인 후 즉시 삭제 (일회용 보장, GETDEL로 원자적 처리)
+     * state에 저장된 nonce를 원자적으로 조회·삭제 후, 전달받은 nonce와 일치하는지 검증.
+     * nonce 불일치 또는 state 미존재 시 false 반환.
      */
-    public boolean validateAndConsume(String state) {
+    public boolean validateAndConsume(String state, String nonce) {
         try {
-            return redisTemplate.opsForValue().getAndDelete(KEY_PREFIX + state) != null;
+            String stored = redisTemplate.opsForValue().getAndDelete(KEY_PREFIX + state);
+            return stored != null && stored.equals(nonce);
         } catch (Exception e) {
             throw new BusinessException(ErrorCode.REDIS_OPERATION_FAILED);
         }

--- a/src/main/java/org/sopt/solply_server/domain/admin/auth/repository/AdminOAuthStateRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/auth/repository/AdminOAuthStateRepository.java
@@ -1,0 +1,42 @@
+package org.sopt.solply_server.domain.admin.auth.repository;
+
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.sopt.solply_server.global.exception.BusinessException;
+import org.sopt.solply_server.global.exception.ErrorCode;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AdminOAuthStateRepository {
+
+    private static final String KEY_PREFIX = "admin:oauth:state:";
+    private static final long TTL_MINUTES = 10;
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void save(String state) {
+        try {
+            redisTemplate.opsForValue().set(
+                    KEY_PREFIX + state,
+                    "valid",
+                    TTL_MINUTES,
+                    TimeUnit.MINUTES
+            );
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.REDIS_OPERATION_FAILED);
+        }
+    }
+
+    /**
+     * 존재 여부 확인 후 즉시 삭제 (일회용 보장, GETDEL로 원자적 처리)
+     */
+    public boolean validateAndConsume(String state) {
+        try {
+            return redisTemplate.opsForValue().getAndDelete(KEY_PREFIX + state) != null;
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.REDIS_OPERATION_FAILED);
+        }
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/admin/auth/service/AdminAuthService.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/auth/service/AdminAuthService.java
@@ -1,0 +1,114 @@
+package org.sopt.solply_server.domain.admin.auth.service;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.sopt.solply_server.domain.admin.auth.dto.response.AdminAuthTokenResponse;
+import org.sopt.solply_server.domain.admin.auth.repository.AdminAuthCodeRepository;
+import org.sopt.solply_server.domain.auth.entity.SocialPlatform;
+import org.sopt.solply_server.domain.auth.repository.RefreshTokenRepository;
+import org.sopt.solply_server.domain.user.entity.User;
+import org.sopt.solply_server.domain.user.entity.UserRole;
+import org.sopt.solply_server.domain.user.repository.SocialUserInfoRepository;
+import org.sopt.solply_server.domain.user.repository.UserRepository;
+import org.sopt.solply_server.global.config.KakaoOAuthProperties;
+import org.sopt.solply_server.global.exception.BusinessException;
+import org.sopt.solply_server.global.exception.ErrorCode;
+import org.sopt.solply_server.global.feign.oauth.kakao.KakaoAuthClient;
+import org.sopt.solply_server.global.feign.oauth.kakao.KakaoServerClient;
+import org.sopt.solply_server.global.feign.oauth.kakao.dto.KakaoSocialUserProfile;
+import org.sopt.solply_server.global.feign.oauth.kakao.dto.KakaoTokenResponse;
+import org.sopt.solply_server.global.jwt.JwtTokenProvider;
+import org.sopt.solply_server.global.jwt.dto.TokenCollectionDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+@RequiredArgsConstructor
+public class AdminAuthService {
+
+    private static final String GRANT_TYPE = "authorization_code";
+
+    private final KakaoAuthClient kakaoAuthClient;
+    private final KakaoServerClient kakaoServerClient;
+    private final SocialUserInfoRepository socialUserInfoRepository;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final AdminAuthCodeRepository adminAuthCodeRepository;
+    private final KakaoOAuthProperties kakaoOAuthProperties;
+
+    @Value("${admin.redirect-uri}")
+    private String adminRedirectUri;
+
+    public String getKakaoAuthUrl() {
+        return UriComponentsBuilder.fromHttpUrl(kakaoOAuthProperties.getAuthorizationUrl())
+                .queryParam("client_id", kakaoOAuthProperties.getClientId())
+                .queryParam("redirect_uri", kakaoOAuthProperties.getRedirectUri())
+                .queryParam("response_type", "code")
+                .build()
+                .toUriString();
+    }
+
+    public String processKakaoCallback(String code) {
+        KakaoTokenResponse tokenResponse = kakaoAuthClient.getToken(
+                GRANT_TYPE,
+                kakaoOAuthProperties.getClientId(),
+                kakaoOAuthProperties.getRedirectUri(),
+                code,
+                kakaoOAuthProperties.getClientSecret()
+        );
+
+        KakaoSocialUserProfile profile = kakaoServerClient.getUserInformation(
+                "Bearer " + tokenResponse.accessToken()
+        );
+
+        User user = findAdminUser(profile);
+
+        TokenCollectionDto tokens = jwtTokenProvider.createTokenCollection(user.getId(), SocialPlatform.KAKAO);
+        refreshTokenRepository.save(user.getId(), tokens.refreshToken());
+
+        String authCode = UUID.randomUUID().toString();
+        adminAuthCodeRepository.save(authCode, user.getId(), SocialPlatform.KAKAO);
+
+        return UriComponentsBuilder.fromHttpUrl(adminRedirectUri)
+                .queryParam("authCode", authCode)
+                .build()
+                .toUriString();
+    }
+
+    public AdminAuthTokenResponse exchangeAuthCode(String authCode) {
+        String value = adminAuthCodeRepository.pop(authCode);
+        if (value == null) {
+            throw new BusinessException(ErrorCode.INVALID_ADMIN_AUTH_CODE);
+        }
+
+        String[] parts = value.split(":");
+        Long userId = Long.parseLong(parts[0]);
+        SocialPlatform platform = SocialPlatform.valueOf(parts[1]);
+
+        TokenCollectionDto tokens = jwtTokenProvider.createTokenCollection(userId, platform);
+        refreshTokenRepository.save(userId, tokens.refreshToken());
+
+        return new AdminAuthTokenResponse(tokens.accessToken(), tokens.refreshToken());
+    }
+
+    private String buildSocialCode(SocialPlatform platform, String socialId) {
+        return platform.name() + "_" + socialId;
+    }
+
+    private User findAdminUser(KakaoSocialUserProfile profile) {
+        String socialCode = buildSocialCode(SocialPlatform.KAKAO, String.valueOf(profile.getId()));
+
+        User user = socialUserInfoRepository.findAnyUserIdBySocialCode(socialCode)
+                .flatMap(userRepository::findById)
+                .or(() -> userRepository.findAnyByEmail(profile.getEmail()))
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_USER));
+
+        if (user.getRole() != UserRole.ADMIN) {
+            throw new BusinessException(ErrorCode.NOT_ADMIN_USER);
+        }
+
+        return user;
+    }
+}

--- a/src/main/java/org/sopt/solply_server/domain/admin/auth/service/AdminAuthService.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/auth/service/AdminAuthService.java
@@ -65,9 +65,6 @@ public class AdminAuthService {
 
         User user = findAdminUser(profile);
 
-        TokenCollectionDto tokens = jwtTokenProvider.createTokenCollection(user.getId(), SocialPlatform.KAKAO);
-        refreshTokenRepository.save(user.getId(), tokens.refreshToken());
-
         String authCode = UUID.randomUUID().toString();
         adminAuthCodeRepository.save(authCode, user.getId(), SocialPlatform.KAKAO);
 
@@ -84,8 +81,17 @@ public class AdminAuthService {
         }
 
         String[] parts = value.split(":");
-        Long userId = Long.parseLong(parts[0]);
-        SocialPlatform platform = SocialPlatform.valueOf(parts[1]);
+        if (parts.length != 2) {
+            throw new BusinessException(ErrorCode.INVALID_ADMIN_AUTH_CODE);
+        }
+        Long userId;
+        SocialPlatform platform;
+        try {
+            userId = Long.parseLong(parts[0]);
+            platform = SocialPlatform.valueOf(parts[1]);
+        } catch (NumberFormatException | IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.INVALID_ADMIN_AUTH_CODE);
+        }
 
         TokenCollectionDto tokens = jwtTokenProvider.createTokenCollection(userId, platform);
         refreshTokenRepository.save(userId, tokens.refreshToken());

--- a/src/main/java/org/sopt/solply_server/domain/admin/auth/service/AdminAuthService.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/auth/service/AdminAuthService.java
@@ -89,7 +89,7 @@ public class AdminAuthService {
         try {
             userId = Long.parseLong(parts[0]);
             platform = SocialPlatform.valueOf(parts[1]);
-        } catch (NumberFormatException | IllegalArgumentException e) {
+        } catch (IllegalArgumentException e) {
             throw new BusinessException(ErrorCode.INVALID_ADMIN_AUTH_CODE);
         }
 

--- a/src/main/java/org/sopt/solply_server/domain/admin/auth/service/AdminAuthService.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/auth/service/AdminAuthService.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.sopt.solply_server.domain.admin.auth.dto.response.AdminAuthTokenResponse;
+import org.sopt.solply_server.domain.admin.auth.dto.response.KakaoAuthUrlResult;
 import org.sopt.solply_server.domain.admin.auth.repository.AdminAuthCodeRepository;
 import org.sopt.solply_server.domain.admin.auth.repository.AdminOAuthStateRepository;
 import org.sopt.solply_server.domain.auth.entity.SocialPlatform;
@@ -44,21 +45,24 @@ public class AdminAuthService {
     @Value("${admin.redirect-uri}")
     private String adminRedirectUri;
 
-    public String getKakaoAuthUrl() {
+    public KakaoAuthUrlResult generateKakaoAuthUrl() {
         String state = UUID.randomUUID().toString();
-        adminOAuthStateRepository.save(state);
+        String nonce = UUID.randomUUID().toString();
+        adminOAuthStateRepository.save(state, nonce);
 
-        return UriComponentsBuilder.fromHttpUrl(kakaoOAuthProperties.getAuthorizationUrl())
+        String url = UriComponentsBuilder.fromHttpUrl(kakaoOAuthProperties.getAuthorizationUrl())
                 .queryParam("client_id", kakaoOAuthProperties.getClientId())
                 .queryParam("redirect_uri", kakaoOAuthProperties.getRedirectUri())
                 .queryParam("response_type", "code")
                 .queryParam("state", state)
                 .build()
                 .toUriString();
+
+        return new KakaoAuthUrlResult(url, nonce);
     }
 
-    public String processKakaoCallback(String code, String state) {
-        if (!adminOAuthStateRepository.validateAndConsume(state)) {
+    public String processKakaoCallback(String code, String state, String nonce) {
+        if (!adminOAuthStateRepository.validateAndConsume(state, nonce)) {
             throw new BusinessException(ErrorCode.INVALID_OAUTH_STATE);
         }
         KakaoTokenResponse tokenResponse = kakaoAuthClient.getToken(

--- a/src/main/java/org/sopt/solply_server/domain/admin/auth/service/AdminAuthService.java
+++ b/src/main/java/org/sopt/solply_server/domain/admin/auth/service/AdminAuthService.java
@@ -1,9 +1,11 @@
 package org.sopt.solply_server.domain.admin.auth.service;
 
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.sopt.solply_server.domain.admin.auth.dto.response.AdminAuthTokenResponse;
 import org.sopt.solply_server.domain.admin.auth.repository.AdminAuthCodeRepository;
+import org.sopt.solply_server.domain.admin.auth.repository.AdminOAuthStateRepository;
 import org.sopt.solply_server.domain.auth.entity.SocialPlatform;
 import org.sopt.solply_server.domain.auth.repository.RefreshTokenRepository;
 import org.sopt.solply_server.domain.user.entity.User;
@@ -36,21 +38,29 @@ public class AdminAuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
     private final AdminAuthCodeRepository adminAuthCodeRepository;
+    private final AdminOAuthStateRepository adminOAuthStateRepository;
     private final KakaoOAuthProperties kakaoOAuthProperties;
 
     @Value("${admin.redirect-uri}")
     private String adminRedirectUri;
 
     public String getKakaoAuthUrl() {
+        String state = UUID.randomUUID().toString();
+        adminOAuthStateRepository.save(state);
+
         return UriComponentsBuilder.fromHttpUrl(kakaoOAuthProperties.getAuthorizationUrl())
                 .queryParam("client_id", kakaoOAuthProperties.getClientId())
                 .queryParam("redirect_uri", kakaoOAuthProperties.getRedirectUri())
                 .queryParam("response_type", "code")
+                .queryParam("state", state)
                 .build()
                 .toUriString();
     }
 
-    public String processKakaoCallback(String code) {
+    public String processKakaoCallback(String code, String state) {
+        if (!adminOAuthStateRepository.validateAndConsume(state)) {
+            throw new BusinessException(ErrorCode.INVALID_OAUTH_STATE);
+        }
         KakaoTokenResponse tokenResponse = kakaoAuthClient.getToken(
                 GRANT_TYPE,
                 kakaoOAuthProperties.getClientId(),
@@ -106,9 +116,12 @@ public class AdminAuthService {
     private User findAdminUser(KakaoSocialUserProfile profile) {
         String socialCode = buildSocialCode(SocialPlatform.KAKAO, String.valueOf(profile.getId()));
 
+        String email = profile.getEmail();
         User user = socialUserInfoRepository.findAnyUserIdBySocialCode(socialCode)
                 .flatMap(userRepository::findById)
-                .or(() -> userRepository.findAnyByEmail(profile.getEmail()))
+                .or(() -> email != null && !email.isBlank()
+                        ? userRepository.findAnyByEmail(email)
+                        : Optional.empty())
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_USER));
 
         if (user.getRole() != UserRole.ADMIN) {

--- a/src/main/java/org/sopt/solply_server/global/config/KakaoOAuthProperties.java
+++ b/src/main/java/org/sopt/solply_server/global/config/KakaoOAuthProperties.java
@@ -1,0 +1,18 @@
+package org.sopt.solply_server.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties("oauth.kakao")
+public class KakaoOAuthProperties {
+    private String clientId;
+    private String clientSecret;
+    private String redirectUri;
+    private String authorizationUrl;
+    private String tokenUrl;
+}

--- a/src/main/java/org/sopt/solply_server/global/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/solply_server/global/config/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
 
     private static final String[] AUTH_WHITELIST = {
             "/api/auth/**", // 로그인, 회원가입, 토큰 재발급
+            "/api/admin/auth/**", // 어드민 소셜 로그인
             "/swagger-ui/**",
             "/v3/api-docs/**",
             "/api/test/**", // 테스트용 API

--- a/src/main/java/org/sopt/solply_server/global/exception/ErrorCode.java
+++ b/src/main/java/org/sopt/solply_server/global/exception/ErrorCode.java
@@ -37,6 +37,8 @@ public enum ErrorCode {
     FORBIDDEN_RESOURCE(HttpStatus.FORBIDDEN, "AUTH-007", "해당 리소스에 대한 권한이 없습니다."),
     FORBIDDEN_ACTION(HttpStatus.FORBIDDEN, "AUTH-008", "해당 작업을 수행할 권한이 없습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-009", "유효하지 않은 토큰입니다."),
+    NOT_ADMIN_USER(HttpStatus.FORBIDDEN, "AUTH-010", "어드민 권한이 없는 사용자입니다."),
+    INVALID_ADMIN_AUTH_CODE(HttpStatus.UNAUTHORIZED, "AUTH-011", "유효하지 않거나 만료된 인증 코드입니다."),
 
     // 소셜 로그인 관련 (SOCIAL-xxx)
     UNSUPPORTED_OAUTH_PROVIDER(HttpStatus.BAD_REQUEST, "SOCIAL-001", "지원하지 않는 OAuth 플랫폼입니다."),

--- a/src/main/java/org/sopt/solply_server/global/exception/ErrorCode.java
+++ b/src/main/java/org/sopt/solply_server/global/exception/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-009", "유효하지 않은 토큰입니다."),
     NOT_ADMIN_USER(HttpStatus.FORBIDDEN, "AUTH-010", "어드민 권한이 없는 사용자입니다."),
     INVALID_ADMIN_AUTH_CODE(HttpStatus.UNAUTHORIZED, "AUTH-011", "유효하지 않거나 만료된 인증 코드입니다."),
+    INVALID_OAUTH_STATE(HttpStatus.UNAUTHORIZED, "AUTH-012", "유효하지 않거나 만료된 OAuth state 값입니다."),
 
     // 소셜 로그인 관련 (SOCIAL-xxx)
     UNSUPPORTED_OAUTH_PROVIDER(HttpStatus.BAD_REQUEST, "SOCIAL-001", "지원하지 않는 OAuth 플랫폼입니다."),

--- a/src/main/java/org/sopt/solply_server/global/feign/oauth/kakao/KakaoAuthClient.java
+++ b/src/main/java/org/sopt/solply_server/global/feign/oauth/kakao/KakaoAuthClient.java
@@ -1,0 +1,20 @@
+package org.sopt.solply_server.global.feign.oauth.kakao;
+
+import org.sopt.solply_server.global.feign.oauth.kakao.dto.KakaoTokenResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "kakaoAuthClient", url = "${oauth.kakao.token-url}")
+public interface KakaoAuthClient {
+
+    @PostMapping(value = "/oauth/token", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    KakaoTokenResponse getToken(
+            @RequestParam("grant_type") String grantType,
+            @RequestParam("client_id") String clientId,
+            @RequestParam("redirect_uri") String redirectUri,
+            @RequestParam("code") String code,
+            @RequestParam("client_secret") String clientSecret
+    );
+}

--- a/src/main/java/org/sopt/solply_server/global/feign/oauth/kakao/dto/KakaoTokenResponse.java
+++ b/src/main/java/org/sopt/solply_server/global/feign/oauth/kakao/dto/KakaoTokenResponse.java
@@ -1,0 +1,16 @@
+package org.sopt.solply_server.global.feign.oauth.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KakaoTokenResponse(
+        String accessToken,
+        String tokenType,
+        String refreshToken,
+        Long expiresIn,
+        Long refreshTokenExpiresIn
+) {
+}


### PR DESCRIPTION
## 🌳이슈 번호
resolves #347

---

## ☀️어떻게 이슈를 해결했나요?
앱 SDK 기반 로그인과 달리 브라우저 리다이렉트 기반의 OAuth Authorization Code Flow로 구현했습니다.

- `GET /api/admin/auth/kakao` → Kakao OAuth 인증 페이지로 리다이렉트
- `GET /api/admin/auth/kakao/callback` → code로 access_token 교환 → 유저 조회 및 어드민 권한 검증 → JWT 발급 → 일회용 authCode(Redis, TTL 5분) 저장 → 어드민 프론트로 리다이렉트
- `POST /api/admin/auth/kakao/token` → authCode 교환 → JWT 반환

URL에 JWT를 직접 노출하지 않고 일회용 authCode를 통해 교환하는 2단계 방식으로 보안을 강화했습니다.

---

## 🗯️ PR 포인트
- `AdminAuthCodeRepository`: Redis 장애 시 `REDIS_OPERATION_FAILED`로 명확한 에러 반환
- 어드민 유저 조회 시 신규 생성 없이 기존 ADMIN 계정만 허용 (socialCode → email 순 조회)
- Kakao 관련 URL(authorization, token)을 환경변수로 관리해 코드 하드코딩 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 카카오 기반 관리자 소셜 로그인 추가(로그인, 콜백, 인증 코드 → 토큰 교환)
  * 관리자 전용 액세스·리프레시 토큰 발급 및 일회성 인증 코드 흐름 지원

* **문서**
  * 플랜 승인 이후 개발 절차에 사용자 확인 등을 포함한 6단계 순서 지침 추가
  * PR 생성 시 이슈와 동일한 라벨 적용 안내 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->