### PR TITLE
[refactor] 장소 상세 api에 리뷰 추가

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/place/dto/PlaceLatestReviewDto.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/dto/PlaceLatestReviewDto.java
@@ -1,0 +1,33 @@
+package org.sopt.solply_server.domain.place.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.sopt.solply_server.domain.review.entity.PlaceReview;
+import org.sopt.solply_server.domain.review.entity.VisitTime;
+import org.sopt.solply_server.global.util.s3.ImageUrlProvider;
+
+public record PlaceLatestReviewDto(
+    Long reviewId,
+    Long userId,
+    String nickname,
+    String profileImageUrl,
+    String content,
+    LocalDate visitedAt,
+    VisitTime visitTimeSlot,
+    List<String> imageUrls
+) {
+  public static PlaceLatestReviewDto from(PlaceReview placeReview, ImageUrlProvider imageUrlProvider) {
+    return new PlaceLatestReviewDto(
+        placeReview.getId(),
+        placeReview.getUser().getId(),
+        placeReview.getUser().getNickname(),
+        imageUrlProvider.getImageUrl(placeReview.getUser().getProfileImageFileKey()),
+        placeReview.getContent(),
+        placeReview.getVisitedAt(),
+        placeReview.getVisitTimeSlot(),
+        placeReview.getPlaceReviewImages().stream()
+            .map(image -> imageUrlProvider.getImageUrl(image.getImageUrl()))
+            .toList()
+    );
+  }
+}

--- a/src/main/java/org/sopt/solply_server/domain/place/dto/response/PlaceDetailsGetResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/dto/response/PlaceDetailsGetResponse.java
@@ -3,49 +3,53 @@ package org.sopt.solply_server.domain.place.dto.response;
 import java.util.List;
 import lombok.Builder;
 import org.sopt.solply_server.domain.place.dto.PlaceImageInfoDto;
+import org.sopt.solply_server.domain.place.dto.PlaceLatestReviewDto;
 import org.sopt.solply_server.domain.place.dto.SnsLinkDto;
 import org.sopt.solply_server.domain.place.entity.Place;
 import org.sopt.solply_server.domain.town.entity.Town;
 
 @Builder
 public record PlaceDetailsGetResponse(
-        long placeId,
-        String placeName,
-        String mainTag,
-        List<String> optionTags,
-        String introduction,
-        List<PlaceImageInfoDto> imageInfos,
-        String address,
-        String latitude,
-        String longitude,
-        String contactNumber,
-        String openingHours,
-        List<SnsLinkDto> snsLinks,
-        List<String> placeCheckpoints,
-        boolean isBookmarked,
-        long townId,
-        String townName
+    long placeId,
+    String placeName,
+    String mainTag,
+    List<String> optionTags,
+    String introduction,
+    List<PlaceImageInfoDto> imageInfos,
+    String address,
+    String latitude,
+    String longitude,
+    String contactNumber,
+    String openingHours,
+    List<SnsLinkDto> snsLinks,
+    List<String> placeCheckpoints,
+    boolean isBookmarked,
+    long townId,
+    String townName,
+    List<PlaceLatestReviewDto> latestReviews
 ) {
 
-    public static PlaceDetailsGetResponse of(Place place, String mainTag, List<String> optionTags,
-            List<PlaceImageInfoDto> placeImageInfos, boolean isBookmarked, Town town) {
-        return PlaceDetailsGetResponse.builder()
-                .placeId(place.getId())
-                .placeName(place.getName())
-                .mainTag(mainTag)
-                .optionTags(optionTags)
-                .introduction(place.getIntroduction())
-                .imageInfos(placeImageInfos)
-                .address(place.getAddress())
-                .latitude(String.valueOf(place.getLatitude()))
-                .longitude(String.valueOf(place.getLongitude()))
-                .contactNumber(place.getContactNumber())
-                .openingHours(place.getOpeningHours())
-                .snsLinks(SnsLinkDto.toList(place.getSnsLinks()))
-                .placeCheckpoints(place.getCheckpoints())
-                .isBookmarked(isBookmarked)
-                .townId(town.getId())
-                .townName(town.getName())
-                .build();
-    }
+  public static PlaceDetailsGetResponse of(Place place, String mainTag, List<String> optionTags,
+      List<PlaceImageInfoDto> placeImageInfos, boolean isBookmarked, Town town,
+      List<PlaceLatestReviewDto> latestReviews) {
+    return PlaceDetailsGetResponse.builder()
+        .placeId(place.getId())
+        .placeName(place.getName())
+        .mainTag(mainTag)
+        .optionTags(optionTags)
+        .introduction(place.getIntroduction())
+        .imageInfos(placeImageInfos)
+        .address(place.getAddress())
+        .latitude(String.valueOf(place.getLatitude()))
+        .longitude(String.valueOf(place.getLongitude()))
+        .contactNumber(place.getContactNumber())
+        .openingHours(place.getOpeningHours())
+        .snsLinks(SnsLinkDto.toList(place.getSnsLinks()))
+        .placeCheckpoints(place.getCheckpoints())
+        .isBookmarked(isBookmarked)
+        .townId(town.getId())
+        .townName(town.getName())
+        .latestReviews(latestReviews)
+        .build();
+  }
 }

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
@@ -88,9 +88,8 @@ public class PlaceService {
     boolean isBookmarked = placeBookmarkFacade.isBookmarked(
         userId, placeId, place.getTown().getId());
     List<PlaceLatestReviewDto> latestReviews = placeReviewRepository
-        .findAllByPlaceIdOrderByCreatedAtDesc(placeId)
+        .findTop3ByPlaceIdOrderByCreatedAtDesc(placeId)
         .stream()
-        .limit(3)
         .map(review -> PlaceLatestReviewDto.from(review, imageUrlProvider))
         .toList();
     Town town = place.getTown();

--- a/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
+++ b/src/main/java/org/sopt/solply_server/domain/place/service/PlaceService.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.solply_server.domain.place.dto.PlaceFolderPreviewDto;
 import org.sopt.solply_server.domain.place.dto.PlaceImageInfoDto;
+import org.sopt.solply_server.domain.place.dto.PlaceLatestReviewDto;
 import org.sopt.solply_server.domain.place.dto.PlaceSearchConditionDto;
 import org.sopt.solply_server.domain.place.dto.PlacePreviewDto;
 import org.sopt.solply_server.domain.place.dto.PlaceSearchResultDto;
@@ -25,6 +26,7 @@ import org.sopt.solply_server.domain.place.entity.PlaceTag;
 import org.sopt.solply_server.domain.place.repository.PlaceRepository;
 import org.sopt.solply_server.domain.place.repository.PlaceTagRepository;
 import org.sopt.solply_server.domain.place.service.facade.PlaceBookmarkFacade;
+import org.sopt.solply_server.domain.review.repository.PlaceReviewRepository;
 import org.sopt.solply_server.domain.tag.entity.Tag;
 import org.sopt.solply_server.domain.tag.entity.TagType;
 import org.sopt.solply_server.domain.tag.util.TagValidator;
@@ -46,214 +48,229 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class PlaceService {
 
-    private final PlaceRepository placeRepository;
-    private final PlaceTagRepository placeTagRepository;
-    private final ImageUrlProvider imageUrlProvider;
-    private final TagValidator tagValidator;
-    private final PlaceBookmarkFacade placeBookmarkFacade;
-    private final TownValidator townValidator;
-    private final EntityLoader entityLoader;
+  private final PlaceRepository placeRepository;
+  private final PlaceTagRepository placeTagRepository;
+  private final ImageUrlProvider imageUrlProvider;
+  private final TagValidator tagValidator;
+  private final PlaceBookmarkFacade placeBookmarkFacade;
+  private final TownValidator townValidator;
+  private final EntityLoader entityLoader;
+  private final PlaceReviewRepository placeReviewRepository;
 
-    /**
-     * 장소 상세 정보 조회
-     */
-    public PlaceDetailsGetResponse getPlaceDetailsById(final Long userId, final Long placeId) {
-        Place place = entityLoader.getActivePlaceWithTownAndCheckpoints(placeId);
+  /**
+   * 장소 상세 정보 조회
+   */
+  public PlaceDetailsGetResponse getPlaceDetailsById(final Long userId, final Long placeId) {
+    Place place = entityLoader.getActivePlaceWithTownAndCheckpoints(placeId);
 
-        List<PlaceImageInfoDto> imageInfos = place.getPlaceImageInfos().stream()
-                .map(info -> PlaceImageInfoDto.of(
-                        info.getDisplayOrder(),
-                        imageUrlProvider.getImageUrl(info.getImageFileKey())
-                ))
-                .toList();
+    List<PlaceImageInfoDto> imageInfos = place.getPlaceImageInfos().stream()
+        .map(info -> PlaceImageInfoDto.of(
+            info.getDisplayOrder(),
+            imageUrlProvider.getImageUrl(info.getImageFileKey())
+        ))
+        .toList();
 
-        List<Tag> tags = placeTagRepository.findAllByPlaceId(placeId).stream()
-                .map(PlaceTag::getTag)
-                .toList();
+    List<Tag> tags = placeTagRepository.findAllByPlaceId(placeId).stream()
+        .map(PlaceTag::getTag)
+        .toList();
 
-        String mainTag = tags.stream()
-                .filter(t -> t.getType() == TagType.MAIN)
-                .map(Tag::getName)
-                .findFirst()
-                .orElse(null);
+    String mainTag = tags.stream()
+        .filter(t -> t.getType() == TagType.MAIN)
+        .map(Tag::getName)
+        .findFirst()
+        .orElse(null);
 
-        List<String> optionTags = tags.stream()
-                .filter(t -> t.getType() != TagType.MAIN)
-                .map(Tag::getName)
-                .toList();
+    List<String> optionTags = tags.stream()
+        .filter(t -> t.getType() != TagType.MAIN)
+        .map(Tag::getName)
+        .toList();
 
-        boolean isBookmarked = placeBookmarkFacade.isBookmarked(
-                userId, placeId, place.getTown().getId());
+    boolean isBookmarked = placeBookmarkFacade.isBookmarked(
+        userId, placeId, place.getTown().getId());
+    List<PlaceLatestReviewDto> latestReviews = placeReviewRepository
+        .findAllByPlaceIdOrderByCreatedAtDesc(placeId)
+        .stream()
+        .limit(3)
+        .map(review -> PlaceLatestReviewDto.from(review, imageUrlProvider))
+        .toList();
+    Town town = place.getTown();
 
-        Town town = place.getTown();
+    return PlaceDetailsGetResponse.of(
+        place,
+        mainTag,
+        optionTags,
+        imageInfos,
+        isBookmarked,
+        town,
+        latestReviews
+    );
+  }
 
-        return PlaceDetailsGetResponse.of(
-                place,
-                mainTag,
-                optionTags,
-                imageInfos,
-                isBookmarked,
-                town
-        );
+  /**
+   * 동네와 태그 조건에 따른 장소 조회
+   */
+  public PlaceFilterGetResponse getPlacesByTownAndTag(
+      final Long userId, final Long townId, final Boolean isBookmarkSearch, final Long mainTagId,
+      final List<Long> subTagAIdList, final List<Long> subTagBIdList) {
+
+    if (userId == null && Boolean.TRUE.equals(isBookmarkSearch)) {
+      throw new JwtTokenException(ErrorCode.UNAUTHORIZED_USER);
     }
 
-    /**
-     * 동네와 태그 조건에 따른 장소 조회
-     */
-    public PlaceFilterGetResponse getPlacesByTownAndTag(
-            final Long userId, final Long townId, final Boolean isBookmarkSearch, final Long mainTagId,
-            final List<Long> subTagAIdList, final List<Long> subTagBIdList) {
+    townValidator.validateTownId(townId);
 
-        if (userId == null && Boolean.TRUE.equals(isBookmarkSearch)) {
-            throw new JwtTokenException(ErrorCode.UNAUTHORIZED_USER);
-        }
+    boolean isOnlyBookmarkSearch = Boolean.TRUE.equals(isBookmarkSearch);
 
-        townValidator.validateTownId(townId);
+    // isBookmarkSearch=true 시 orderedIds를 한 번만 조회해서 장소 목록 필터링과 북마크 Set에 재사용
+    // (기존에는 getBookmarkedPlacesByLatest()와 북마크 Set 생성 시 각각 1회씩, 총 2회 호출했음)
+    List<Long> bookmarkedOrderedIds = (isOnlyBookmarkSearch && userId != null)
+        ? placeBookmarkFacade.getBookmarkedPlaceIdsForTown(userId, townId)
+        : null;
 
-        boolean isOnlyBookmarkSearch = Boolean.TRUE.equals(isBookmarkSearch);
+    // 북마크 검색 시 orderedIds를 함께 전달 → 내부에서 북마크 최신순으로 재정렬
+    List<Place> places = getPlacesByCondition(townId, isOnlyBookmarkSearch, mainTagId,
+        subTagAIdList, subTagBIdList, bookmarkedOrderedIds);
 
-        // isBookmarkSearch=true 시 orderedIds를 한 번만 조회해서 장소 목록 필터링과 북마크 Set에 재사용
-        // (기존에는 getBookmarkedPlacesByLatest()와 북마크 Set 생성 시 각각 1회씩, 총 2회 호출했음)
-        List<Long> bookmarkedOrderedIds = (isOnlyBookmarkSearch && userId != null)
-                ? placeBookmarkFacade.getBookmarkedPlaceIdsForTown(userId, townId)
-                : null;
-
-        // 북마크 검색 시 orderedIds를 함께 전달 → 내부에서 북마크 최신순으로 재정렬
-        List<Place> places = getPlacesByCondition(townId, isOnlyBookmarkSearch, mainTagId, subTagAIdList, subTagBIdList, bookmarkedOrderedIds);
-
-        Set<Long> bookmarkedIds;
-        if (bookmarkedOrderedIds != null) {
-            // 북마크 검색: 이미 조회한 orderedIds를 Set으로 변환해서 재사용
-            bookmarkedIds = new HashSet<>(bookmarkedOrderedIds);
-        } else if (userId != null) {
-            // 일반 장소 목록 + 로그인 상태: 각 장소 카드의 북마크 여부(하트) 표시를 위해 조회
-            bookmarkedIds = new HashSet<>(placeBookmarkFacade.getBookmarkedPlaceIdsForTown(userId, townId));
-        } else {
-            // 비로그인: 북마크 여부 불필요
-            bookmarkedIds = Collections.emptySet();
-        }
-
-        List<PlacePreviewDto> placePreviewDtoList = places.stream()
-                .map(place -> PlacePreviewDto.of(
-                        place.getId(),
-                        place.getName(),
-                        imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
-                        TagViewUtils.getActiveNameOrNull(place.getMainTag().orElse(null)),
-                        bookmarkedIds.contains(place.getId()),
-                        townId
-                ))
-                .toList();
-
-        return PlaceFilterGetResponse.from(placePreviewDtoList);
+    Set<Long> bookmarkedIds;
+    if (bookmarkedOrderedIds != null) {
+      // 북마크 검색: 이미 조회한 orderedIds를 Set으로 변환해서 재사용
+      bookmarkedIds = new HashSet<>(bookmarkedOrderedIds);
+    } else if (userId != null) {
+      // 일반 장소 목록 + 로그인 상태: 각 장소 카드의 북마크 여부(하트) 표시를 위해 조회
+      bookmarkedIds = new HashSet<>(
+          placeBookmarkFacade.getBookmarkedPlaceIdsForTown(userId, townId));
+    } else {
+      // 비로그인: 북마크 여부 불필요
+      bookmarkedIds = Collections.emptySet();
     }
 
+    List<PlacePreviewDto> placePreviewDtoList = places.stream()
+        .map(place -> PlacePreviewDto.of(
+            place.getId(),
+            place.getName(),
+            imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
+            TagViewUtils.getActiveNameOrNull(place.getMainTag().orElse(null)),
+            bookmarkedIds.contains(place.getId()),
+            townId
+        ))
+        .toList();
 
-    /**
-     * 사용자가 북마크한 장소의 썸네일 리스트 조회 (동네별 최신 1개)
-     */
-    public PlaceFolderPreviewListGetResponse getBookmarkedPlaceFolderPreviewList(final Long userId) {
-        // 동네별 최신 placeId 맵 (ZREVRANGE 0 0 per town)
-        Map<Long, Long> latestPlaceIdByTown = placeBookmarkFacade.getLatestBookmarkedPlaceIdPerTown(userId);
+    return PlaceFilterGetResponse.from(placePreviewDtoList);
+  }
 
-        if (latestPlaceIdByTown.isEmpty()) {
-            return PlaceFolderPreviewListGetResponse.from(List.of());
-        }
 
-        List<Long> placeIds = new ArrayList<>(latestPlaceIdByTown.values());
-        List<Place> places = entityLoader.getPlacesWithTown(placeIds);
+  /**
+   * 사용자가 북마크한 장소의 썸네일 리스트 조회 (동네별 최신 1개)
+   */
+  public PlaceFolderPreviewListGetResponse getBookmarkedPlaceFolderPreviewList(final Long userId) {
+    // 동네별 최신 placeId 맵 (ZREVRANGE 0 0 per town)
+    Map<Long, Long> latestPlaceIdByTown = placeBookmarkFacade.getLatestBookmarkedPlaceIdPerTown(
+        userId);
 
-        if (places.isEmpty()) {
-            return PlaceFolderPreviewListGetResponse.from(List.of());
-        }
-
-        List<PlaceFolderPreviewDto> dtos = places.stream()
-                .map(place -> {
-                    Town town = place.getTown();
-                    return PlaceFolderPreviewDto.of(
-                            town.getId(),
-                            town.getName(),
-                            imageUrlProvider.getImageUrl(place.getThumbnailFileKey())
-                    );
-                })
-                .toList();
-
-        return PlaceFolderPreviewListGetResponse.from(dtos);
+    if (latestPlaceIdByTown.isEmpty()) {
+      return PlaceFolderPreviewListGetResponse.from(List.of());
     }
 
-    public PlaceSearchResponse searchPlaces(final String keyword) {
-        if (InputValidator.isBlank(keyword) || keyword.length() < 2) {
-            throw new BusinessException(ErrorCode.INVALID_KEYWORD);
-        }
-        var places = placeRepository.findPlacesWithTownByKeyword(keyword);
-        List<PlaceSearchResultDto> placePreviews = places.stream()
-                .map(place -> {
-                        Town town = place.getTown();
-                        return PlaceSearchResultDto.of(
-                            place.getId(),
-                            place.getName(),
-                            imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
-                                TagViewUtils.getActiveNameOrNull(place.getMainTag().orElse(null)),
-                            place.getAddress(),
-                            false,
-                            town.getId()
-                        );
-                    }
-                )
-                .toList();
+    List<Long> placeIds = new ArrayList<>(latestPlaceIdByTown.values());
+    List<Place> places = entityLoader.getPlacesWithTown(placeIds);
 
-        return new PlaceSearchResponse(placePreviews);
+    if (places.isEmpty()) {
+      return PlaceFolderPreviewListGetResponse.from(List.of());
     }
 
+    List<PlaceFolderPreviewDto> dtos = places.stream()
+        .map(place -> {
+          Town town = place.getTown();
+          return PlaceFolderPreviewDto.of(
+              town.getId(),
+              town.getName(),
+              imageUrlProvider.getImageUrl(place.getThumbnailFileKey())
+          );
+        })
+        .toList();
 
-    //=== Private Methods ===//
+    return PlaceFolderPreviewListGetResponse.from(dtos);
+  }
 
-    private List<Place> getPlacesByCondition(final Long selectedTownId, final boolean isOnlyBookmarkSearch,
-            final Long mainTagId, final List<Long> subTagAIdList, final List<Long> subTagBIdList,
-            final List<Long> bookmarkedOrderedIds) {
-        if (mainTagId != null) {
-            tagValidator.validatePlaceTagConditions(mainTagId, subTagAIdList, subTagBIdList);
-        }
+  public PlaceSearchResponse searchPlaces(final String keyword) {
+    if (InputValidator.isBlank(keyword) || keyword.length() < 2) {
+      throw new BusinessException(ErrorCode.INVALID_KEYWORD);
+    }
+    var places = placeRepository.findPlacesWithTownByKeyword(keyword);
+    List<PlaceSearchResultDto> placePreviews = places.stream()
+        .map(place -> {
+              Town town = place.getTown();
+              return PlaceSearchResultDto.of(
+                  place.getId(),
+                  place.getName(),
+                  imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
+                  TagViewUtils.getActiveNameOrNull(place.getMainTag().orElse(null)),
+                  place.getAddress(),
+                  false,
+                  town.getId()
+              );
+            }
+        )
+        .toList();
 
-        if (isOnlyBookmarkSearch) {
-            return getBookmarkedPlacesByLatest(selectedTownId, mainTagId, subTagAIdList, subTagBIdList, bookmarkedOrderedIds);
-        }
+    return new PlaceSearchResponse(placePreviews);
+  }
 
-        return placeRepository.findPlacesByConditions(
-                PlaceSearchConditionDto.of(selectedTownId, false, null, mainTagId, subTagAIdList, subTagBIdList)
-        );
+  //=== Private Methods ===//
+
+  private List<Place> getPlacesByCondition(final Long selectedTownId,
+      final boolean isOnlyBookmarkSearch,
+      final Long mainTagId, final List<Long> subTagAIdList, final List<Long> subTagBIdList,
+      final List<Long> bookmarkedOrderedIds) {
+    if (mainTagId != null) {
+      tagValidator.validatePlaceTagConditions(mainTagId, subTagAIdList, subTagBIdList);
     }
 
-    /**
-     * 북마크 장소 최신순 조회.
-     * 상위에서 조회한 orderedIds(ZSET 최신순) → DB에서 태그 조건 필터링 → ZSET 순서 복원.
-     */
-    private List<Place> getBookmarkedPlacesByLatest(
-            final Long selectedTownId,
-            final Long mainTagId,
-            final List<Long> subTagAIdList,
-            final List<Long> subTagBIdList,
-            final List<Long> orderedIds
-    ) {
-        if (orderedIds == null || orderedIds.isEmpty()) return List.of();
-
-        List<Place> filtered = placeRepository.findPlacesByConditions(
-                PlaceSearchConditionDto.of(
-                        selectedTownId,
-                        true,
-                        orderedIds,
-                        mainTagId,
-                        subTagAIdList,
-                        subTagBIdList
-                )
-        );
-        if (filtered.isEmpty()) return List.of();
-
-        // DB 결과를 ZSET 순서(북마크 최신순)로 재정렬
-        Map<Long, Place> placeMap = filtered.stream()
-                .collect(Collectors.toMap(Place::getId, Function.identity()));
-        return orderedIds.stream()
-                .map(placeMap::get)
-                .filter(Objects::nonNull)
-                .toList();
+    if (isOnlyBookmarkSearch) {
+      return getBookmarkedPlacesByLatest(selectedTownId, mainTagId, subTagAIdList, subTagBIdList,
+          bookmarkedOrderedIds);
     }
+
+    return placeRepository.findPlacesByConditions(
+        PlaceSearchConditionDto.of(selectedTownId, false, null, mainTagId, subTagAIdList,
+            subTagBIdList)
+    );
+  }
+
+  /**
+   * 북마크 장소 최신순 조회. 상위에서 조회한 orderedIds(ZSET 최신순) → DB에서 태그 조건 필터링 → ZSET 순서 복원.
+   */
+  private List<Place> getBookmarkedPlacesByLatest(
+      final Long selectedTownId,
+      final Long mainTagId,
+      final List<Long> subTagAIdList,
+      final List<Long> subTagBIdList,
+      final List<Long> orderedIds
+  ) {
+    if (orderedIds == null || orderedIds.isEmpty()) {
+      return List.of();
+    }
+
+    List<Place> filtered = placeRepository.findPlacesByConditions(
+        PlaceSearchConditionDto.of(
+            selectedTownId,
+            true,
+            orderedIds,
+            mainTagId,
+            subTagAIdList,
+            subTagBIdList
+        )
+    );
+    if (filtered.isEmpty()) {
+      return List.of();
+    }
+
+    // DB 결과를 ZSET 순서(북마크 최신순)로 재정렬
+    Map<Long, Place> placeMap = filtered.stream()
+        .collect(Collectors.toMap(Place::getId, Function.identity()));
+    return orderedIds.stream()
+        .map(placeMap::get)
+        .filter(Objects::nonNull)
+        .toList();
+  }
 }

--- a/src/main/java/org/sopt/solply_server/domain/review/controller/PlaceReviewController.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/controller/PlaceReviewController.java
@@ -1,5 +1,8 @@
 package org.sopt.solply_server.domain.review.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.sopt.solply_server.domain.review.dto.request.CreatePlaceReviewRequest;
@@ -13,11 +16,16 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "리뷰 API", description = "장소 리뷰 관련 API")
 @RequestMapping("/api/places/reviews")
 public class PlaceReviewController {
 
   private final PlaceReviewService placeReviewService;
 
+  @Operation(
+      summary = "장소 리뷰 작성",
+      description = "특정 장소에 대한 리뷰를 작성합니다."
+  )
   @PostMapping
   public ResponseEntity<CustomApiResponse<CreatePlaceReviewResponse>> createRecord(
       @CurrentUserId Long userId,
@@ -27,6 +35,13 @@ public class PlaceReviewController {
     return CustomApiResponse.success("혼놀 기록 작성이 완료되었습니다.", response);
   }
 
+  @Operation(
+      summary = "장소 리뷰 리스트 조회",
+      description = "특정 장소 ID에 대한 전체 리뷰 리스트를 조회합니다.",
+      parameters = {
+          @Parameter(name = "placeId", description = "조회할 장소 ID", required = true, example = "1")
+      }
+  )
   @GetMapping("/{placeId}/reviews")
   public ResponseEntity<CustomApiResponse<GetPlaceReviewListResponse>> getPlaceReviews(
       @CurrentUserId Long userId,

--- a/src/main/java/org/sopt/solply_server/domain/review/repository/PlaceReviewRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/repository/PlaceReviewRepository.java
@@ -17,4 +17,5 @@ public interface PlaceReviewRepository extends JpaRepository<PlaceReview, Long> 
       order by pr.createdAt desc
       """)
   List<PlaceReview> findAllByPlaceIdOrderByCreatedAtDesc(@Param("placeId") Long placeId);
+  List<PlaceReview> findTop3ByPlaceIdOrderByCreatedAtDesc(Long placeId);
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
resolves #358 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- 장소 상세 API에서 리뷰 데이터를 함께 내려주기 위해 PlaceReviewRepository를 활용하여 최신순 리뷰를 조회
- Service 레이어에서 Stream API의 .limit(3)을 사용해 최신 3개만 추출
- 각 리뷰는 PlaceLatestReviewDto.from()을 통해 응답 DTO로 변환
- 변환된 리스트를 PlaceDetailsGetResponse에 포함시켜 프론트에서 바로 사용할 수 있도록 구성


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
-

## 테스팅 화면
<img width="2088" height="685" alt="image" src="https://github.com/user-attachments/assets/80cba071-8861-4c92-ba63-ac0491b8038e" />
<img width="1325" height="592" alt="image" src="https://github.com/user-attachments/assets/eb938de6-078a-47f8-ab6f-92954039cfc1" />
<img width="1090" height="595" alt="image" src="https://github.com/user-attachments/assets/12f8fc80-5d6a-46f6-af87-9239bec26625" />
<img width="1066" height="596" alt="image" src="https://github.com/user-attachments/assets/e45d8f02-0506-46e3-9d1f-2208efcaa5c0" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 장소 상세에 최신 리뷰 최대 3개 노출: 리뷰어 닉네임·프로필 이미지, 방문 일자·시간대, 내용 및 이미지가 표시됩니다.
  * 장소 상세 조회 시 최신 리뷰를 함께 제공하도록 서비스 응답이 확장되었습니다.

* **문서**
  * 리뷰 관련 API에 OpenAPI/Swagger 주석이 추가되어 API 문서화가 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->