### PR TITLE
[feat] 임베딩 장소 추천 응답에 썸네일 이미지 URL 추가

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/recommend/dto/RecommendedPlaceDto.java
+++ b/src/main/java/org/sopt/solply_server/domain/recommend/dto/RecommendedPlaceDto.java
@@ -5,6 +5,7 @@ import java.util.List;
 public record RecommendedPlaceDto(
         Long placeId,
         String placeName,
+        String thumbnailImageUrl,
         String mainTag,
         List<String> optionTags,
         String townName,

--- a/src/main/java/org/sopt/solply_server/domain/recommend/service/EmbeddingRecommendService.java
+++ b/src/main/java/org/sopt/solply_server/domain/recommend/service/EmbeddingRecommendService.java
@@ -19,6 +19,7 @@ import org.sopt.solply_server.global.ai.EmbeddingService;
 import org.sopt.solply_server.global.ai.ReasonGenerationService;
 import org.sopt.solply_server.global.ai.ReasonGenerationService.PlaceContext;
 import org.sopt.solply_server.global.util.EntityLoader;
+import org.sopt.solply_server.global.util.s3.ImageUrlProvider;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,6 +35,7 @@ public class EmbeddingRecommendService {
     private final EmbeddingService embeddingService;
     private final ReasonGenerationService reasonGenerationService;
     private final EntityLoader entityLoader;
+    private final ImageUrlProvider imageUrlProvider;
 
     public EmbeddingPlaceRecommendGetResponse recommendByQuery(String query, Long townId, Long userId) {
         User user = entityLoader.getUser(userId);
@@ -107,6 +109,7 @@ public class EmbeddingRecommendService {
         return new RecommendedPlaceDto(
                 place.getId(),
                 place.getName(),
+                imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
                 mainTag,
                 optionTags,
                 place.getTown().getName(),


### PR DESCRIPTION
## 🌳이슈 번호
resolves #363

---

## ☀️어떻게 이슈를 해결했나요?
- `RecommendedPlaceDto`에 `thumbnailImageUrl` 필드를 추가했습니다.
- `EmbeddingRecommendService`에 `ImageUrlProvider`를 주입하여, `toDto`에서 `place.getThumbnailFileKey()`를 CloudFront URL로 변환해 응답에 포함시켰습니다.
- 다른 장소 조회/추천 API(`/api/recommend/places`, `/api/places`)에서 이미 사용 중인 패턴을 그대로 재사용했습니다.

---

## 🗯️ PR 포인트
- `placeImageInfos`는 `@ElementCollection(LAZY)` + `@BatchSize(20)`이고 임베딩 추천은 `TOP_K = 3`이라 별도 fetch join은 추가하지 않았습니다. 의견 환영합니다.
- 썸네일이 없는 장소는 `ImageUrlProvider`가 `null`을 반환하므로 응답의 `thumbnailImageUrl`도 `null`로 내려갑니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 추천 장소 목록에 썸네일 이미지가 추가되어 더욱 시각적인 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->