### PR TITLE
[FEAT] 리뷰 삭제 api 구현

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/review/controller/PlaceReviewController.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/controller/PlaceReviewController.java
@@ -50,4 +50,17 @@ public class PlaceReviewController {
     GetPlaceReviewListResponse response = placeReviewService.getPlaceReviews(placeId);
     return CustomApiResponse.success("장소 리뷰 리스트 조회에 성공했습니다.", response);
   }
+
+  @Operation(
+      summary = "내 장소 리뷰 삭제",
+      description = "로그인한 사용자가 본인이 작성한 장소 리뷰를 삭제합니다."
+  )
+  @DeleteMapping("/{reviewId}")
+  public ResponseEntity<CustomApiResponse<Void>> deleteMyReview(
+      @CurrentUserId Long userId,
+      @PathVariable Long reviewId
+  ) {
+    placeReviewService.deleteMyReview(userId, reviewId);
+    return CustomApiResponse.success("내 리뷰 삭제에 성공했습니다.", null);
+  }
 }

--- a/src/main/java/org/sopt/solply_server/domain/review/service/PlaceReviewService.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/service/PlaceReviewService.java
@@ -7,4 +7,5 @@ import org.sopt.solply_server.domain.review.dto.response.GetPlaceReviewListRespo
 public interface PlaceReviewService {
   CreatePlaceReviewResponse createReview(Long userId, CreatePlaceReviewRequest request);
   GetPlaceReviewListResponse getPlaceReviews(Long placeId);
+  void deleteMyReview(Long userId, Long reviewId);
 }

--- a/src/main/java/org/sopt/solply_server/domain/review/service/PlaceReviewServiceImpl.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/service/PlaceReviewServiceImpl.java
@@ -11,6 +11,7 @@ import org.sopt.solply_server.domain.review.dto.response.CreatePlaceReviewRespon
 import org.sopt.solply_server.domain.review.dto.response.GetPlaceReviewListResponse;
 import org.sopt.solply_server.domain.review.dto.response.PlaceReviewListItem;
 import org.sopt.solply_server.domain.review.entity.PlaceReview;
+import org.sopt.solply_server.domain.review.entity.PlaceReviewImage;
 import org.sopt.solply_server.domain.review.repository.PlaceReviewRepository;
 import org.sopt.solply_server.domain.user.entity.User;
 import org.sopt.solply_server.domain.user.repository.UserRepository;
@@ -18,6 +19,7 @@ import org.sopt.solply_server.global.exception.BusinessValidationException;
 import org.sopt.solply_server.global.exception.EntityNotFoundException;
 import org.sopt.solply_server.global.exception.ErrorCode;
 import org.sopt.solply_server.global.util.s3.FileTransferMode;
+import org.sopt.solply_server.global.util.s3.ImageFileDeleteEvent;
 import org.sopt.solply_server.global.util.s3.ImageFileKeyUpdateEvent;
 import org.sopt.solply_server.global.util.s3.ImageUrlProvider;
 import org.sopt.solply_server.global.util.s3.TargetDir;
@@ -136,6 +138,14 @@ public class PlaceReviewServiceImpl implements PlaceReviewService {
       throw new BusinessValidationException(ErrorCode.FORBIDDEN_PLACE_REVIEW_DELETE);
     }
 
+    List<String> imageKeys = placeReview.getPlaceReviewImages().stream()
+        .map(PlaceReviewImage::getImageUrl)
+        .toList();
+
     placeReviewRepository.delete(placeReview);
+
+    if (!imageKeys.isEmpty()) {
+      eventPublisher.publishEvent(new ImageFileDeleteEvent(imageKeys));
+    }
   }
 }

--- a/src/main/java/org/sopt/solply_server/domain/review/service/PlaceReviewServiceImpl.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/service/PlaceReviewServiceImpl.java
@@ -125,4 +125,17 @@ public class PlaceReviewServiceImpl implements PlaceReviewService {
       throw new BusinessValidationException(ErrorCode.PLACE_REVIEW_IMAGE_LIMIT_EXCEEDED);
     }
   }
+
+  @Override
+  @Transactional
+  public void deleteMyReview(Long userId, Long reviewId) {
+    PlaceReview placeReview = placeReviewRepository.findById(reviewId)
+        .orElseThrow(() -> new EntityNotFoundException(ErrorCode.PLACE_REVIEW_NOT_FOUND));
+
+    if (!placeReview.getUser().getId().equals(userId)) {
+      throw new BusinessValidationException(ErrorCode.FORBIDDEN_PLACE_REVIEW_DELETE);
+    }
+
+    placeReviewRepository.delete(placeReview);
+  }
 }

--- a/src/main/java/org/sopt/solply_server/global/exception/ErrorCode.java
+++ b/src/main/java/org/sopt/solply_server/global/exception/ErrorCode.java
@@ -118,13 +118,13 @@ public enum ErrorCode {
     NOT_FOUND_PLACE_REQUEST(HttpStatus.NOT_FOUND, "PLACE_REQUEST-001", "존재하지 않는 장소 등록 요청입니다." ),
     INVALID_REQUEST_STATE(HttpStatus.BAD_REQUEST, "PLACE_REQUEST-002", "승인할 수 없는 장소 등록 요청입니다." ),
 
-  // 장소 리뷰 관련 (PLACE_REVIEW-xxx)
-  PLACE_REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE_REVIEW_001", "해당 기록을 찾을 수 없습니다."),
-  PLACE_REVIEW_CONTENT_BLANK(HttpStatus.BAD_REQUEST, "PLACE_REVIEW_002", "기록 내용은 공백일 수 없습니다."),
-  INVALID_PLACE_REVIEW_CONTENT_LENGTH(HttpStatus.BAD_REQUEST, "PLACE_REVIEW_003", "기록 내용은 10자 이상 500자 이하여야 합니다."),
-  INVALID_VISIT_DATE(HttpStatus.BAD_REQUEST, "PLACE_REVIEW_004", "방문 날짜는 오늘 또는 이전 날짜만 선택할 수 있습니다."),
-  PLACE_REVIEW_IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "PLACE_REVIEW_005", "사진은 최대 5장까지 업로드할 수 있습니다."),
-  FORBIDDEN_PLACE_REVIEW_DELETE(HttpStatus.FORBIDDEN, "PLACE_REVIEW_006", "본인이 작성한 리뷰만 삭제할 수 있습니다."),
+   // 장소 리뷰 관련 (PLACE_REVIEW-xxx)
+   PLACE_REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE-REVIEW-001", "해당 기록을 찾을 수 없습니다."),
+   PLACE_REVIEW_CONTENT_BLANK(HttpStatus.BAD_REQUEST, "PLACE-REVIEW-002", "기록 내용은 공백일 수 없습니다."),
+   INVALID_PLACE_REVIEW_CONTENT_LENGTH(HttpStatus.BAD_REQUEST, "PLACE-REVIEW-003", "기록 내용은 10자 이상 500자 이하여야 합니다."),
+   INVALID_VISIT_DATE(HttpStatus.BAD_REQUEST, "PLACE-REVIEW-004", "방문 날짜는 오늘 또는 이전 날짜만 선택할 수 있습니다."),
+   PLACE_REVIEW_IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "PLACE-REVIEW-005", "사진은 최대 5장까지 업로드할 수 있습니다."),
+   FORBIDDEN_PLACE_REVIEW_DELETE(HttpStatus.FORBIDDEN, "PLACE-REVIEW-006", "본인이 작성한 리뷰만 삭제할 수 있습니다."),
     ;
 
 

--- a/src/main/java/org/sopt/solply_server/global/exception/ErrorCode.java
+++ b/src/main/java/org/sopt/solply_server/global/exception/ErrorCode.java
@@ -118,12 +118,13 @@ public enum ErrorCode {
     NOT_FOUND_PLACE_REQUEST(HttpStatus.NOT_FOUND, "PLACE_REQUEST-001", "존재하지 않는 장소 등록 요청입니다." ),
     INVALID_REQUEST_STATE(HttpStatus.BAD_REQUEST, "PLACE_REQUEST-002", "승인할 수 없는 장소 등록 요청입니다." ),
 
-    //장소 리뷰 관련 (PLACE_REVIEW-xxx)
-    PLACE_REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE_REVIEW_001", "해당 기록을 찾을 수 없습니다."),
-    PLACE_REVIEW_CONTENT_BLANK(HttpStatus.BAD_REQUEST, "PLACE_REVIEW_002", "기록 내용은 공백일 수 없습니다."),
-    INVALID_PLACE_REVIEW_CONTENT_LENGTH(HttpStatus.BAD_REQUEST, "PLACE_REVIEW_003", "기록 내용은 10자 이상 500자 이하여야 합니다."),
-    INVALID_VISIT_DATE(HttpStatus.BAD_REQUEST, "PLACE_REVIEW_004", "방문 날짜는 오늘 또는 이전 날짜만 선택할 수 있습니다."),
-    PLACE_REVIEW_IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "PLACE_REVIEW_005", "사진은 최대 5장까지 업로드할 수 있습니다."),
+  // 장소 리뷰 관련 (PLACE_REVIEW-xxx)
+  PLACE_REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE_REVIEW_001", "해당 기록을 찾을 수 없습니다."),
+  PLACE_REVIEW_CONTENT_BLANK(HttpStatus.BAD_REQUEST, "PLACE_REVIEW_002", "기록 내용은 공백일 수 없습니다."),
+  INVALID_PLACE_REVIEW_CONTENT_LENGTH(HttpStatus.BAD_REQUEST, "PLACE_REVIEW_003", "기록 내용은 10자 이상 500자 이하여야 합니다."),
+  INVALID_VISIT_DATE(HttpStatus.BAD_REQUEST, "PLACE_REVIEW_004", "방문 날짜는 오늘 또는 이전 날짜만 선택할 수 있습니다."),
+  PLACE_REVIEW_IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "PLACE_REVIEW_005", "사진은 최대 5장까지 업로드할 수 있습니다."),
+  FORBIDDEN_PLACE_REVIEW_DELETE(HttpStatus.FORBIDDEN, "PLACE_REVIEW_006", "본인이 작성한 리뷰만 삭제할 수 있습니다."),
     ;
 
 

--- a/src/main/java/org/sopt/solply_server/global/listener/ImageFileDeleteListener.java
+++ b/src/main/java/org/sopt/solply_server/global/listener/ImageFileDeleteListener.java
@@ -1,0 +1,30 @@
+package org.sopt.solply_server.global.listener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.solply_server.global.util.s3.ImageFileDeleteEvent;
+import org.sopt.solply_server.global.util.s3.S3FileService;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ImageFileDeleteListener {
+
+  private final S3FileService s3FileService;
+
+  @Async
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void onDeleted(ImageFileDeleteEvent event) {
+    for (String imageKey : event.imageKeys()) {
+      try {
+        s3FileService.deleteFile(imageKey);
+      } catch (Exception e) {
+        log.warn("S3 파일 삭제 실패 imageKey={}", imageKey, e);
+      }
+    }
+  }
+}

--- a/src/main/java/org/sopt/solply_server/global/util/s3/ImageFileDeleteEvent.java
+++ b/src/main/java/org/sopt/solply_server/global/util/s3/ImageFileDeleteEvent.java
@@ -1,0 +1,8 @@
+package org.sopt.solply_server.global.util.s3;
+
+import java.util.List;
+
+public record ImageFileDeleteEvent(
+    List<String> imageKeys
+) {
+}

--- a/src/main/java/org/sopt/solply_server/global/util/s3/S3FileService.java
+++ b/src/main/java/org/sopt/solply_server/global/util/s3/S3FileService.java
@@ -82,6 +82,17 @@ public class S3FileService {
 
         return destKey;
     }
+
+    public void deleteFile(final String fileKey) {
+      if (fileKey == null || fileKey.isBlank()) {
+        return;
+      }
+
+      s3Client.deleteObject(DeleteObjectRequest.builder()
+        .bucket(bucketName)
+        .key(fileKey)
+        .build());
+  }
 }
 
 


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
resolves #366 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

- 로그인 사용자 기준으로 리뷰 작성자 검증 로직 추가
- reviewId로 리뷰 조회 후, 작성자(userId)와 비교하여 본인 여부 확인
- 본인이 아닌 경우 FORBIDDEN_PLACE_REVIEW_DELETE 예외 처리 (403)
- 본인일 경우 placeReviewRepository.delete()로 리뷰 삭제 처리
- CascadeType.ALL + orphanRemoval 설정으로 리뷰 이미지도 함께 삭제되도록 처리
- 존재하지 않는 리뷰는 PLACE_REVIEW_NOT_FOUND 예외 처리


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자가 자신이 작성한 장소 리뷰를 삭제할 수 있는 기능이 추가되었습니다. 리뷰 소유자만 삭제 권한을 가집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->