### PR TITLE
[FEAT] 내 리뷰 리스트 GET , 내 리뷰 미리보기 구현

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/review/controller/PlaceReviewController.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/controller/PlaceReviewController.java
@@ -76,6 +76,6 @@ public class PlaceReviewController {
     GetMyReviewPreviewResponse response =
         placeReviewService.getMyReviewPreview(userId);
 
-    return CustomApiResponse.success("내 리뷰 미리보기 조회 성공", response);
+    return CustomApiResponse.success("내 리뷰 미리보기 조회에 성공했습니다.", response);
   }
 }

--- a/src/main/java/org/sopt/solply_server/domain/review/controller/PlaceReviewController.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/controller/PlaceReviewController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.solply_server.domain.review.dto.request.CreatePlaceReviewRequest;
 import org.sopt.solply_server.domain.review.dto.response.CreatePlaceReviewResponse;
 import org.sopt.solply_server.domain.review.dto.response.GetMyReviewListResponse;
+import org.sopt.solply_server.domain.review.dto.response.GetMyReviewPreviewResponse;
 import org.sopt.solply_server.domain.review.dto.response.GetPlaceReviewListResponse;
 import org.sopt.solply_server.domain.review.service.PlaceReviewService;
 import org.sopt.solply_server.global.annotation.CurrentUserId;
@@ -62,5 +63,19 @@ public class PlaceReviewController {
   ) {
     GetMyReviewListResponse response = placeReviewService.getMyReviews(userId);
     return CustomApiResponse.success("내 리뷰 리스트 조회에 성공했습니다.", response);
+  }
+
+  @Operation(
+      summary = "내 리뷰 미리보기 조회",
+      description = "마이페이지에서 보여줄 최근 리뷰 3개를 조회합니다."
+  )
+  @GetMapping("/me/preview")
+  public ResponseEntity<CustomApiResponse<GetMyReviewPreviewResponse>> getMyReviewPreview(
+      @CurrentUserId Long userId
+  ) {
+    GetMyReviewPreviewResponse response =
+        placeReviewService.getMyReviewPreview(userId);
+
+    return CustomApiResponse.success("내 리뷰 미리보기 조회 성공", response);
   }
 }

--- a/src/main/java/org/sopt/solply_server/domain/review/controller/PlaceReviewController.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/controller/PlaceReviewController.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.sopt.solply_server.domain.review.dto.request.CreatePlaceReviewRequest;
 import org.sopt.solply_server.domain.review.dto.response.CreatePlaceReviewResponse;
+import org.sopt.solply_server.domain.review.dto.response.GetMyReviewListResponse;
 import org.sopt.solply_server.domain.review.dto.response.GetPlaceReviewListResponse;
 import org.sopt.solply_server.domain.review.service.PlaceReviewService;
 import org.sopt.solply_server.global.annotation.CurrentUserId;
@@ -49,5 +50,17 @@ public class PlaceReviewController {
   ) {
     GetPlaceReviewListResponse response = placeReviewService.getPlaceReviews(placeId);
     return CustomApiResponse.success("장소 리뷰 리스트 조회에 성공했습니다.", response);
+  }
+
+  @Operation(
+      summary = "내 리뷰 리스트 조회",
+      description = "로그인한 사용자가 작성한 리뷰 목록을 조회합니다."
+  )
+  @GetMapping("/me")
+  public ResponseEntity<CustomApiResponse<GetMyReviewListResponse>> getMyReviews(
+      @CurrentUserId Long userId
+  ) {
+    GetMyReviewListResponse response = placeReviewService.getMyReviews(userId);
+    return CustomApiResponse.success("내 리뷰 리스트 조회에 성공했습니다.", response);
   }
 }

--- a/src/main/java/org/sopt/solply_server/domain/review/dto/response/GetMyReviewListResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/dto/response/GetMyReviewListResponse.java
@@ -1,0 +1,12 @@
+package org.sopt.solply_server.domain.review.dto.response;
+
+import java.util.List;
+
+public record GetMyReviewListResponse(
+    int reviewCount,
+    List<MyReviewListItem> reviews
+) {
+  public static GetMyReviewListResponse of(List<MyReviewListItem> reviews) {
+    return new GetMyReviewListResponse(reviews.size(), reviews);
+  }
+}

--- a/src/main/java/org/sopt/solply_server/domain/review/dto/response/GetMyReviewPreviewResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/dto/response/GetMyReviewPreviewResponse.java
@@ -1,0 +1,15 @@
+package org.sopt.solply_server.domain.review.dto.response;
+
+import java.util.List;
+
+public record GetMyReviewPreviewResponse(
+    List<MyReviewPreviewItem> reviews,
+    boolean hasMoreReviews
+) {
+  public static GetMyReviewPreviewResponse of(
+      List<MyReviewPreviewItem> reviews,
+      boolean hasMoreReviews
+  ) {
+    return new GetMyReviewPreviewResponse(reviews, hasMoreReviews);
+  }
+}

--- a/src/main/java/org/sopt/solply_server/domain/review/dto/response/MyReviewListItem.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/dto/response/MyReviewListItem.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.sopt.solply_server.domain.review.entity.PlaceReview;
 import org.sopt.solply_server.domain.review.entity.VisitTime;
 import org.sopt.solply_server.global.util.s3.ImageUrlProvider;
+import java.util.Objects;
 
 public record MyReviewListItem(
     Long reviewId,
@@ -28,6 +29,7 @@ public record MyReviewListItem(
         placeReview.getVisitTimeSlot(),
         placeReview.getPlaceReviewImages().stream()
             .map(image -> imageUrlProvider.getImageUrl(image.getImageUrl()))
+            .filter(Objects::nonNull)
             .toList()
     );
   }

--- a/src/main/java/org/sopt/solply_server/domain/review/dto/response/MyReviewListItem.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/dto/response/MyReviewListItem.java
@@ -1,0 +1,34 @@
+package org.sopt.solply_server.domain.review.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.sopt.solply_server.domain.review.entity.PlaceReview;
+import org.sopt.solply_server.domain.review.entity.VisitTime;
+import org.sopt.solply_server.global.util.s3.ImageUrlProvider;
+
+public record MyReviewListItem(
+    Long reviewId,
+    Long placeId,
+    String placeName,
+    String content,
+    LocalDate visitedAt,
+    VisitTime visitTimeSlot,
+    List<String> imageUrls
+) {
+  public static MyReviewListItem from(
+      PlaceReview placeReview,
+      ImageUrlProvider imageUrlProvider
+  ) {
+    return new MyReviewListItem(
+        placeReview.getId(),
+        placeReview.getPlace().getId(),
+        placeReview.getPlace().getName(),
+        placeReview.getContent(),
+        placeReview.getVisitedAt(),
+        placeReview.getVisitTimeSlot(),
+        placeReview.getPlaceReviewImages().stream()
+            .map(image -> imageUrlProvider.getImageUrl(image.getImageUrl()))
+            .toList()
+    );
+  }
+}

--- a/src/main/java/org/sopt/solply_server/domain/review/dto/response/MyReviewPreviewItem.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/dto/response/MyReviewPreviewItem.java
@@ -1,0 +1,29 @@
+package org.sopt.solply_server.domain.review.dto.response;
+
+import org.sopt.solply_server.domain.review.entity.PlaceReview;
+import org.sopt.solply_server.global.util.s3.ImageUrlProvider;
+
+public record MyReviewPreviewItem(
+    Long reviewId,
+    String placeName,
+    String previewImageUrl,
+    String content
+) {
+  public static MyReviewPreviewItem from(
+      PlaceReview review,
+      ImageUrlProvider imageUrlProvider
+  ) {
+    String previewImage = review.getPlaceReviewImages().isEmpty()
+        ? null
+        : imageUrlProvider.getImageUrl(
+            review.getPlaceReviewImages().get(0).getImageUrl()
+        );
+
+    return new MyReviewPreviewItem(
+        review.getId(),
+        review.getPlace().getName(),
+        previewImage,
+        review.getContent()
+    );
+  }
+}

--- a/src/main/java/org/sopt/solply_server/domain/review/repository/PlaceReviewRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/repository/PlaceReviewRepository.java
@@ -29,18 +29,27 @@ public interface PlaceReviewRepository extends JpaRepository<PlaceReview, Long> 
     order by pr.createdAt desc
     """)
   List<PlaceReview> findAllByUserIdOrderByCreatedAtDesc(@Param("userId") Long userId);
-  List<PlaceReview> findTop4ByUserIdOrderByCreatedAtDesc(Long userId);
+
+  @Query("""
+    select pr.id
+    from PlaceReview pr
+    where pr.user.id = :userId
+    order by pr.createdAt desc
+    """)
+  List<Long> findMyReviewIds(
+      @Param("userId") Long userId,
+      Pageable pageable
+  );
 
   @Query("""
     select distinct pr
     from PlaceReview pr
     join fetch pr.place p
     left join fetch pr.placeReviewImages pri
-    where pr.user.id = :userId
+    where pr.id in :reviewIds
     order by pr.createdAt desc
     """)
-  List<PlaceReview> findMyReviewsWithFetchJoin(
-      @Param("userId") Long userId,
-      Pageable pageable
+  List<PlaceReview> findAllByIdInWithFetchJoin(
+      @Param("reviewIds") List<Long> reviewIds
   );
 }

--- a/src/main/java/org/sopt/solply_server/domain/review/repository/PlaceReviewRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/repository/PlaceReviewRepository.java
@@ -28,4 +28,5 @@ public interface PlaceReviewRepository extends JpaRepository<PlaceReview, Long> 
     order by pr.createdAt desc
     """)
   List<PlaceReview> findAllByUserIdOrderByCreatedAtDesc(@Param("userId") Long userId);
+  List<PlaceReview> findTop4ByUserIdOrderByCreatedAtDesc(Long userId);
 }

--- a/src/main/java/org/sopt/solply_server/domain/review/repository/PlaceReviewRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/repository/PlaceReviewRepository.java
@@ -18,4 +18,14 @@ public interface PlaceReviewRepository extends JpaRepository<PlaceReview, Long> 
       """)
   List<PlaceReview> findAllByPlaceIdOrderByCreatedAtDesc(@Param("placeId") Long placeId);
   List<PlaceReview> findTop4ByPlaceIdOrderByCreatedAtDesc(Long placeId);
+
+  @Query("""
+    select distinct pr
+    from PlaceReview pr
+    join fetch pr.place p
+    left join fetch pr.placeReviewImages pri
+    where pr.user.id = :userId
+    order by pr.createdAt desc
+    """)
+  List<PlaceReview> findAllByUserIdOrderByCreatedAtDesc(@Param("userId") Long userId);
 }

--- a/src/main/java/org/sopt/solply_server/domain/review/repository/PlaceReviewRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/repository/PlaceReviewRepository.java
@@ -5,6 +5,7 @@ import org.sopt.solply_server.domain.review.entity.PlaceReview;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.data.domain.Pageable;
 
 public interface PlaceReviewRepository extends JpaRepository<PlaceReview, Long> {
 
@@ -29,4 +30,17 @@ public interface PlaceReviewRepository extends JpaRepository<PlaceReview, Long> 
     """)
   List<PlaceReview> findAllByUserIdOrderByCreatedAtDesc(@Param("userId") Long userId);
   List<PlaceReview> findTop4ByUserIdOrderByCreatedAtDesc(Long userId);
+
+  @Query("""
+    select distinct pr
+    from PlaceReview pr
+    join fetch pr.place p
+    left join fetch pr.placeReviewImages pri
+    where pr.user.id = :userId
+    order by pr.createdAt desc
+    """)
+  List<PlaceReview> findMyReviewsWithFetchJoin(
+      @Param("userId") Long userId,
+      Pageable pageable
+  );
 }

--- a/src/main/java/org/sopt/solply_server/domain/review/service/PlaceReviewService.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/service/PlaceReviewService.java
@@ -3,10 +3,12 @@ package org.sopt.solply_server.domain.review.service;
 import org.sopt.solply_server.domain.review.dto.request.CreatePlaceReviewRequest;
 import org.sopt.solply_server.domain.review.dto.response.CreatePlaceReviewResponse;
 import org.sopt.solply_server.domain.review.dto.response.GetMyReviewListResponse;
+import org.sopt.solply_server.domain.review.dto.response.GetMyReviewPreviewResponse;
 import org.sopt.solply_server.domain.review.dto.response.GetPlaceReviewListResponse;
 
 public interface PlaceReviewService {
   CreatePlaceReviewResponse createReview(Long userId, CreatePlaceReviewRequest request);
   GetPlaceReviewListResponse getPlaceReviews(Long placeId);
   GetMyReviewListResponse getMyReviews(Long userId);
+  GetMyReviewPreviewResponse getMyReviewPreview(Long userId);
 }

--- a/src/main/java/org/sopt/solply_server/domain/review/service/PlaceReviewService.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/service/PlaceReviewService.java
@@ -2,9 +2,11 @@ package org.sopt.solply_server.domain.review.service;
 
 import org.sopt.solply_server.domain.review.dto.request.CreatePlaceReviewRequest;
 import org.sopt.solply_server.domain.review.dto.response.CreatePlaceReviewResponse;
+import org.sopt.solply_server.domain.review.dto.response.GetMyReviewListResponse;
 import org.sopt.solply_server.domain.review.dto.response.GetPlaceReviewListResponse;
 
 public interface PlaceReviewService {
   CreatePlaceReviewResponse createReview(Long userId, CreatePlaceReviewRequest request);
   GetPlaceReviewListResponse getPlaceReviews(Long placeId);
+  GetMyReviewListResponse getMyReviews(Long userId);
 }

--- a/src/main/java/org/sopt/solply_server/domain/review/service/PlaceReviewServiceImpl.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/service/PlaceReviewServiceImpl.java
@@ -26,6 +26,7 @@ import org.sopt.solply_server.global.util.s3.ImageFileKeyUpdateEvent;
 import org.sopt.solply_server.global.util.s3.ImageUrlProvider;
 import org.sopt.solply_server.global.util.s3.TargetDir;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -151,7 +152,7 @@ public class PlaceReviewServiceImpl implements PlaceReviewService {
         .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_USER));
 
     List<PlaceReview> reviews = placeReviewRepository
-        .findTop4ByUserIdOrderByCreatedAtDesc(userId);
+        .findMyReviewsWithFetchJoin(userId, PageRequest.of(0, 4));
 
     boolean hasMore = reviews.size() > 3;
 

--- a/src/main/java/org/sopt/solply_server/domain/review/service/PlaceReviewServiceImpl.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/service/PlaceReviewServiceImpl.java
@@ -9,8 +9,10 @@ import org.sopt.solply_server.domain.place.repository.PlaceRepository;
 import org.sopt.solply_server.domain.review.dto.request.CreatePlaceReviewRequest;
 import org.sopt.solply_server.domain.review.dto.response.CreatePlaceReviewResponse;
 import org.sopt.solply_server.domain.review.dto.response.GetMyReviewListResponse;
+import org.sopt.solply_server.domain.review.dto.response.GetMyReviewPreviewResponse;
 import org.sopt.solply_server.domain.review.dto.response.GetPlaceReviewListResponse;
 import org.sopt.solply_server.domain.review.dto.response.MyReviewListItem;
+import org.sopt.solply_server.domain.review.dto.response.MyReviewPreviewItem;
 import org.sopt.solply_server.domain.review.dto.response.PlaceReviewListItem;
 import org.sopt.solply_server.domain.review.entity.PlaceReview;
 import org.sopt.solply_server.domain.review.repository.PlaceReviewRepository;
@@ -140,5 +142,24 @@ public class PlaceReviewServiceImpl implements PlaceReviewService {
         .toList();
 
     return GetMyReviewListResponse.of(reviews);
+  }
+
+  @Override
+  public GetMyReviewPreviewResponse getMyReviewPreview(Long userId) {
+
+    userRepository.findById(userId)
+        .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_USER));
+
+    List<PlaceReview> reviews = placeReviewRepository
+        .findTop4ByUserIdOrderByCreatedAtDesc(userId);
+
+    boolean hasMore = reviews.size() > 3;
+
+    List<MyReviewPreviewItem> result = reviews.stream()
+        .limit(3)
+        .map(review -> MyReviewPreviewItem.from(review, imageUrlProvider))
+        .toList();
+
+    return GetMyReviewPreviewResponse.of(result, hasMore);
   }
 }

--- a/src/main/java/org/sopt/solply_server/domain/review/service/PlaceReviewServiceImpl.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/service/PlaceReviewServiceImpl.java
@@ -8,7 +8,9 @@ import org.sopt.solply_server.domain.place.entity.Place;
 import org.sopt.solply_server.domain.place.repository.PlaceRepository;
 import org.sopt.solply_server.domain.review.dto.request.CreatePlaceReviewRequest;
 import org.sopt.solply_server.domain.review.dto.response.CreatePlaceReviewResponse;
+import org.sopt.solply_server.domain.review.dto.response.GetMyReviewListResponse;
 import org.sopt.solply_server.domain.review.dto.response.GetPlaceReviewListResponse;
+import org.sopt.solply_server.domain.review.dto.response.MyReviewListItem;
 import org.sopt.solply_server.domain.review.dto.response.PlaceReviewListItem;
 import org.sopt.solply_server.domain.review.entity.PlaceReview;
 import org.sopt.solply_server.domain.review.repository.PlaceReviewRepository;
@@ -124,5 +126,19 @@ public class PlaceReviewServiceImpl implements PlaceReviewService {
     if (imageKeys.size() > MAX_IMAGE_COUNT) {
       throw new BusinessValidationException(ErrorCode.PLACE_REVIEW_IMAGE_LIMIT_EXCEEDED);
     }
+  }
+  @Override
+  public GetMyReviewListResponse getMyReviews(Long userId) {
+
+    userRepository.findById(userId)
+        .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_USER));
+
+    List<MyReviewListItem> reviews = placeReviewRepository
+        .findAllByUserIdOrderByCreatedAtDesc(userId)
+        .stream()
+        .map(review -> MyReviewListItem.from(review, imageUrlProvider))
+        .toList();
+
+    return GetMyReviewListResponse.of(reviews);
   }
 }

--- a/src/main/java/org/sopt/solply_server/domain/review/service/PlaceReviewServiceImpl.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/service/PlaceReviewServiceImpl.java
@@ -130,6 +130,7 @@ public class PlaceReviewServiceImpl implements PlaceReviewService {
       throw new BusinessValidationException(ErrorCode.PLACE_REVIEW_IMAGE_LIMIT_EXCEEDED);
     }
   }
+
   @Override
   public GetMyReviewListResponse getMyReviews(Long userId) {
 
@@ -151,8 +152,12 @@ public class PlaceReviewServiceImpl implements PlaceReviewService {
     userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_USER));
 
-    List<PlaceReview> reviews = placeReviewRepository
-        .findMyReviewsWithFetchJoin(userId, PageRequest.of(0, 4));
+    List<Long> reviewIds = placeReviewRepository
+        .findMyReviewIds(userId, PageRequest.of(0, 4));
+
+    List<PlaceReview> reviews = reviewIds.isEmpty()
+        ? List.of()
+        : placeReviewRepository.findAllByIdInWithFetchJoin(reviewIds);
 
     boolean hasMore = reviews.size() > 3;
 


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->
## 🌳이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
resolves #365 


<br/>

## ☀️어떻게 이슈를 해결했나요?

---
<!-- 실제로 구현한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->

##내 리뷰 리스트 조회 API 추가
- 로그인한 사용자가 작성한 리뷰를 최신순으로 조회
- 장소 정보(이름) 및 리뷰 이미지 리스트 포함하여 반환

## 내 리뷰 미리보기 API 추가
- 마이페이지용 최근 리뷰 3개 조회 기능 구현
- 3개 초과 시 hasMoreReviews 필드로 추가 리뷰 존재 여부 제공
- 리뷰 이미지 존재 시 첫 번째 이미지를 preview로 제공, 없을 경우 null 반환


<br/>

## 🗯️ PR 포인트

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

---
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
-
## 테스팅 화면
<img width="1182" height="647" alt="image" src="https://github.com/user-attachments/assets/311ae01c-1595-49d8-aef6-1f056258ad8a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자가 작성한 전체 리뷰 목록을 조회할 수 있는 엔드포인트 추가
  * 사용자의 최근 리뷰 미리보기를 조회할 수 있는 엔드포인트 추가 (최대 3개 항목 + 추가 리뷰 여부 표시)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->