### PR TITLE
[feat] 리뷰 신고 API 추가 및 자연어 추천 응답에 townId 포함

### DIFF
--- a/src/main/java/org/sopt/solply_server/domain/recommend/dto/RecommendedCourseDto.java
+++ b/src/main/java/org/sopt/solply_server/domain/recommend/dto/RecommendedCourseDto.java
@@ -7,6 +7,7 @@ public record RecommendedCourseDto(
         String courseName,
         String thumbnailImageUrl,
         String courseTag,
+        Long townId,
         String townName,
         String reason,
         List<String> placeMainTags

--- a/src/main/java/org/sopt/solply_server/domain/recommend/dto/RecommendedPlaceDto.java
+++ b/src/main/java/org/sopt/solply_server/domain/recommend/dto/RecommendedPlaceDto.java
@@ -8,6 +8,7 @@ public record RecommendedPlaceDto(
         String thumbnailImageUrl,
         String mainTag,
         List<String> optionTags,
+        Long townId,
         String townName,
         String reason
 ) {

--- a/src/main/java/org/sopt/solply_server/domain/recommend/service/CourseEmbeddingRecommendService.java
+++ b/src/main/java/org/sopt/solply_server/domain/recommend/service/CourseEmbeddingRecommendService.java
@@ -113,6 +113,7 @@ public class CourseEmbeddingRecommendService {
 
     private RecommendedCourseDto toDto(Course course, String reason) {
         String courseTag = TagViewUtils.getActiveNameOrNull(course.getTag());
+        Long townId = course.getTown().getId();
         String townName = course.getTown().getName();
         String thumbnailImageUrl = courseUtils.getCourseThumbnailUrl(course);
 
@@ -127,6 +128,7 @@ public class CourseEmbeddingRecommendService {
                 course.getName(),
                 thumbnailImageUrl,
                 courseTag,
+                townId,
                 townName,
                 reason,
                 placeMainTags

--- a/src/main/java/org/sopt/solply_server/domain/recommend/service/EmbeddingRecommendService.java
+++ b/src/main/java/org/sopt/solply_server/domain/recommend/service/EmbeddingRecommendService.java
@@ -112,6 +112,7 @@ public class EmbeddingRecommendService {
                 imageUrlProvider.getImageUrl(place.getThumbnailFileKey()),
                 mainTag,
                 optionTags,
+                place.getTown().getId(),
                 place.getTown().getName(),
                 reason
         );

--- a/src/main/java/org/sopt/solply_server/domain/review/controller/PlaceReviewController.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/controller/PlaceReviewController.java
@@ -5,11 +5,14 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.sopt.solply_server.domain.review.dto.request.CreatePlaceReviewReportRequest;
 import org.sopt.solply_server.domain.review.dto.request.CreatePlaceReviewRequest;
+import org.sopt.solply_server.domain.review.dto.response.CreatePlaceReviewReportResponse;
 import org.sopt.solply_server.domain.review.dto.response.CreatePlaceReviewResponse;
 import org.sopt.solply_server.domain.review.dto.response.GetMyReviewListResponse;
 import org.sopt.solply_server.domain.review.dto.response.GetMyReviewPreviewResponse;
 import org.sopt.solply_server.domain.review.dto.response.GetPlaceReviewListResponse;
+import org.sopt.solply_server.domain.review.service.PlaceReviewReportService;
 import org.sopt.solply_server.domain.review.service.PlaceReviewService;
 import org.sopt.solply_server.global.annotation.CurrentUserId;
 import org.sopt.solply_server.global.dto.CustomApiResponse;
@@ -23,6 +26,7 @@ import org.springframework.web.bind.annotation.*;
 public class PlaceReviewController {
 
   private final PlaceReviewService placeReviewService;
+  private final PlaceReviewReportService placeReviewReportService;
 
   @Operation(
       summary = "장소 리뷰 작성",
@@ -90,5 +94,23 @@ public class PlaceReviewController {
         placeReviewService.getMyReviewPreview(userId);
 
     return CustomApiResponse.success("내 리뷰 미리보기 조회에 성공했습니다.", response);
+  }
+
+  @Operation(
+      summary = "장소 리뷰 신고",
+      description = "특정 장소 리뷰를 신고합니다. 본인이 작성한 리뷰는 신고할 수 없으며, 같은 리뷰를 중복 신고할 수 없습니다.",
+      parameters = {
+          @Parameter(name = "reviewId", description = "신고할 리뷰 ID", required = true, example = "1")
+      }
+  )
+  @PostMapping("/{reviewId}/reports")
+  public ResponseEntity<CustomApiResponse<CreatePlaceReviewReportResponse>> reportReview(
+      @CurrentUserId Long userId,
+      @PathVariable Long reviewId,
+      @Valid @RequestBody CreatePlaceReviewReportRequest request
+  ) {
+    CreatePlaceReviewReportResponse response =
+        placeReviewReportService.createReviewReport(userId, reviewId, request);
+    return CustomApiResponse.success("리뷰 신고가 접수되었습니다.", response);
   }
 }

--- a/src/main/java/org/sopt/solply_server/domain/review/dto/request/CreatePlaceReviewReportRequest.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/dto/request/CreatePlaceReviewReportRequest.java
@@ -1,0 +1,10 @@
+package org.sopt.solply_server.domain.review.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import org.sopt.solply_server.domain.review.entity.PlaceReviewReportType;
+
+public record CreatePlaceReviewReportRequest(
+    @NotNull(message = "신고 유형을 선택해주세요.")
+    PlaceReviewReportType reportType
+) {
+}

--- a/src/main/java/org/sopt/solply_server/domain/review/dto/response/CreatePlaceReviewReportResponse.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/dto/response/CreatePlaceReviewReportResponse.java
@@ -1,0 +1,22 @@
+package org.sopt.solply_server.domain.review.dto.response;
+
+import org.sopt.solply_server.domain.review.entity.PlaceReviewReport;
+import org.sopt.solply_server.domain.review.entity.PlaceReviewReportStatus;
+import org.sopt.solply_server.domain.review.entity.PlaceReviewReportType;
+
+public record CreatePlaceReviewReportResponse(
+    Long reportId,
+    Long reviewId,
+    PlaceReviewReportType reportType,
+    PlaceReviewReportStatus status
+) {
+
+  public static CreatePlaceReviewReportResponse from(PlaceReviewReport report) {
+    return new CreatePlaceReviewReportResponse(
+        report.getId(),
+        report.getPlaceReview().getId(),
+        report.getReportType(),
+        report.getStatus()
+    );
+  }
+}

--- a/src/main/java/org/sopt/solply_server/domain/review/entity/PlaceReviewReport.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/entity/PlaceReviewReport.java
@@ -1,0 +1,60 @@
+package org.sopt.solply_server.domain.review.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.solply_server.domain.user.entity.User;
+import org.sopt.solply_server.global.entity.BaseTimeEntity;
+
+@Entity
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(
+    name = "place_review_reports",
+    indexes = {
+        @Index(name = "idx_place_review_reports_place_review_id", columnList = "place_review_id"),
+        @Index(name = "idx_place_review_reports_status", columnList = "status"),
+        @Index(name = "idx_place_review_reports_created_at", columnList = "created_at"),
+        @Index(name = "uq_place_review_reports_user_review", columnList = "user_id, place_review_id", unique = true)
+    }
+)
+public class PlaceReviewReport extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "place_review_id", nullable = false)
+  private PlaceReview placeReview;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "report_type", nullable = false, length = 50)
+  private PlaceReviewReportType reportType;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false, length = 50)
+  private PlaceReviewReportStatus status;
+
+  public static PlaceReviewReport create(PlaceReview placeReview, User user, PlaceReviewReportType reportType) {
+    return PlaceReviewReport.builder()
+        .placeReview(placeReview)
+        .user(user)
+        .reportType(reportType)
+        .status(PlaceReviewReportStatus.PENDING)
+        .build();
+  }
+
+  public void updateStatus(PlaceReviewReportStatus status) {
+    this.status = status;
+  }
+}

--- a/src/main/java/org/sopt/solply_server/domain/review/entity/PlaceReviewReportStatus.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/entity/PlaceReviewReportStatus.java
@@ -1,0 +1,13 @@
+package org.sopt.solply_server.domain.review.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PlaceReviewReportStatus {
+  PENDING("검토 대기"),
+  RESOLVED("해결됨");
+
+  private final String description;
+}

--- a/src/main/java/org/sopt/solply_server/domain/review/entity/PlaceReviewReportType.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/entity/PlaceReviewReportType.java
@@ -1,0 +1,16 @@
+package org.sopt.solply_server.domain.review.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PlaceReviewReportType {
+  IRRELEVANT_TO_PLACE("장소와 무관한 내용이에요"),
+  ABUSIVE_LANGUAGE("욕설 / 비방이 포함되어 있어요"),
+  PRIVACY_VIOLATION("타인의 얼굴 / 개인정보가 노출되었어요"),
+  FALSE_INFORMATION("허위 정보가 포함되어 있어요"),
+  OTHER("기타");
+
+  private final String description;
+}

--- a/src/main/java/org/sopt/solply_server/domain/review/repository/PlaceReviewReportRepository.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/repository/PlaceReviewReportRepository.java
@@ -1,0 +1,9 @@
+package org.sopt.solply_server.domain.review.repository;
+
+import org.sopt.solply_server.domain.review.entity.PlaceReviewReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlaceReviewReportRepository extends JpaRepository<PlaceReviewReport, Long> {
+
+  boolean existsByUserIdAndPlaceReviewId(Long userId, Long placeReviewId);
+}

--- a/src/main/java/org/sopt/solply_server/domain/review/service/PlaceReviewReportService.java
+++ b/src/main/java/org/sopt/solply_server/domain/review/service/PlaceReviewReportService.java
@@ -1,0 +1,56 @@
+package org.sopt.solply_server.domain.review.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.solply_server.domain.review.dto.request.CreatePlaceReviewReportRequest;
+import org.sopt.solply_server.domain.review.dto.response.CreatePlaceReviewReportResponse;
+import org.sopt.solply_server.domain.review.entity.PlaceReview;
+import org.sopt.solply_server.domain.review.entity.PlaceReviewReport;
+import org.sopt.solply_server.domain.review.repository.PlaceReviewReportRepository;
+import org.sopt.solply_server.domain.review.repository.PlaceReviewRepository;
+import org.sopt.solply_server.domain.user.entity.User;
+import org.sopt.solply_server.global.exception.BusinessValidationException;
+import org.sopt.solply_server.global.exception.EntityNotFoundException;
+import org.sopt.solply_server.global.exception.ErrorCode;
+import org.sopt.solply_server.global.util.EntityLoader;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PlaceReviewReportService {
+
+  private final PlaceReviewReportRepository placeReviewReportRepository;
+  private final PlaceReviewRepository placeReviewRepository;
+  private final EntityLoader entityLoader;
+
+  @Transactional
+  public CreatePlaceReviewReportResponse createReviewReport(
+      final Long userId,
+      final Long reviewId,
+      final CreatePlaceReviewReportRequest request
+  ) {
+    User user = entityLoader.getUser(userId);
+    PlaceReview placeReview = placeReviewRepository.findById(reviewId)
+        .orElseThrow(() -> new EntityNotFoundException(ErrorCode.PLACE_REVIEW_NOT_FOUND));
+
+    if (placeReview.getUser().getId().equals(userId)) {
+      throw new BusinessValidationException(ErrorCode.FORBIDDEN_SELF_REVIEW_REPORT);
+    }
+
+    if (placeReviewReportRepository.existsByUserIdAndPlaceReviewId(userId, reviewId)) {
+      throw new BusinessValidationException(ErrorCode.ALREADY_REPORTED_REVIEW);
+    }
+
+    PlaceReviewReport saved = placeReviewReportRepository.save(
+        PlaceReviewReport.create(placeReview, user, request.reportType())
+    );
+
+    log.info("리뷰 신고 접수 완료 - userId: {}, reviewId: {}, reportId: {}, reportType: {}",
+        userId, reviewId, saved.getId(), request.reportType());
+
+    return CreatePlaceReviewReportResponse.from(saved);
+  }
+}

--- a/src/main/java/org/sopt/solply_server/global/exception/ErrorCode.java
+++ b/src/main/java/org/sopt/solply_server/global/exception/ErrorCode.java
@@ -125,6 +125,8 @@ public enum ErrorCode {
    INVALID_VISIT_DATE(HttpStatus.BAD_REQUEST, "PLACE-REVIEW-004", "방문 날짜는 오늘 또는 이전 날짜만 선택할 수 있습니다."),
    PLACE_REVIEW_IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "PLACE-REVIEW-005", "사진은 최대 5장까지 업로드할 수 있습니다."),
    FORBIDDEN_PLACE_REVIEW_DELETE(HttpStatus.FORBIDDEN, "PLACE-REVIEW-006", "본인이 작성한 리뷰만 삭제할 수 있습니다."),
+   FORBIDDEN_SELF_REVIEW_REPORT(HttpStatus.FORBIDDEN, "PLACE-REVIEW-007", "본인이 작성한 리뷰는 신고할 수 없습니다."),
+   ALREADY_REPORTED_REVIEW(HttpStatus.CONFLICT, "PLACE-REVIEW-008", "이미 신고한 리뷰입니다."),
     ;
 
 

--- a/src/main/resources/db/migration/V17__create_place_review_reports.sql
+++ b/src/main/resources/db/migration/V17__create_place_review_reports.sql
@@ -1,0 +1,26 @@
+-- 장소 리뷰 신고 테이블
+CREATE TABLE place_review_reports
+(
+    id              BIGINT AUTO_INCREMENT PRIMARY KEY,
+    place_review_id BIGINT      NOT NULL,
+    user_id         BIGINT      NOT NULL,
+    report_type     VARCHAR(50) NOT NULL,
+    status          VARCHAR(50) NOT NULL,
+
+    created_at      DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at      DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+
+    CONSTRAINT fk_place_review_reports_review
+        FOREIGN KEY (place_review_id) REFERENCES place_reviews (id) ON DELETE CASCADE,
+    CONSTRAINT fk_place_review_reports_user
+        FOREIGN KEY (user_id) REFERENCES users (id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4;
+
+CREATE INDEX idx_place_review_reports_place_review_id ON place_review_reports (place_review_id);
+CREATE INDEX idx_place_review_reports_status ON place_review_reports (status);
+CREATE INDEX idx_place_review_reports_created_at ON place_review_reports (created_at);
+
+-- 동일 사용자가 같은 리뷰를 중복 신고하지 못하도록 유니크 제약
+CREATE UNIQUE INDEX uq_place_review_reports_user_review
+    ON place_review_reports (user_id, place_review_id);


### PR DESCRIPTION
## 🌳이슈 번호
resolves #369

---

## ☀️어떻게 이슈를 해결했나요?

### 1. 자연어 추천 응답에 townId 추가 (place / course)
- `RecommendedPlaceDto`, `RecommendedCourseDto`에 `Long townId` 필드 추가
- `EmbeddingRecommendService.toDto`, `CourseEmbeddingRecommendService.toDto`에서 `town.getId()` 매핑
- 기존 `townName` 필드는 유지 (응답 키 추가만 발생, 클라이언트 비파괴적)

### 2. 장소 리뷰 신고 API
- 엔드포인트: `POST /api/places/reviews/{reviewId}/reports`
- Request body: `{ "reportType": "ABUSIVE_LANGUAGE" }` (5종 enum)
  - `IRRELEVANT_TO_PLACE` / `ABUSIVE_LANGUAGE` / `PRIVACY_VIOLATION` / `FALSE_INFORMATION` / `OTHER`
- 비즈니스 룰
  - 본인이 작성한 리뷰는 신고 불가 → `FORBIDDEN_SELF_REVIEW_REPORT` (403)
  - 동일 사용자가 같은 리뷰를 중복 신고 불가 → `ALREADY_REPORTED_REVIEW` (409)
- DB
  - `place_review_reports` 테이블 신설 (Flyway **V17**)
  - `(user_id, place_review_id)` 유니크 인덱스로 중복 신고 1차 방지
  - `place_reviews` 삭제 시 신고도 CASCADE 제거
- 신규 enum: `PlaceReviewReportType`, `PlaceReviewReportStatus`(PENDING/RESOLVED) — 추후 어드민 화면 확장 대비

---

## 🗯️ PR 포인트
- Flyway 버전을 **V17**로 사용했습니다. (다른 PR에서 V15, V16이 진행 중이라 충돌 방지)
- 기존 `PlaceReport` 도메인 패턴을 그대로 따라 `domain/review` 패키지 안에 신고 도메인을 구성했습니다. 별도 `domain/review-report` 패키지로 분리하지 않은 이유는 PlaceReview에 강하게 종속된 보조 도메인이라 판단했기 때문입니다.
- 신고 엔드포인트는 `PlaceReviewController`에 추가했습니다. 신고 전용 컨트롤러를 분리할지에 대한 의견 환영합니다.
- 리뷰 신고 시 `content`/`이미지`는 받지 않는 방향으로 단순화했습니다. (추후 필요 시 컬럼 추가)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 부정확하거나 부적절한 장소 리뷰를 신고할 수 있는 기능이 추가되었습니다. 사용자는 관련성 없음, 욕설, 개인정보 침해, 허위 정보, 기타 등의 사유로 리뷰를 신고할 수 있으며, 신고 현황을 추적할 수 있습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SOLPLY/SOLPLY-SERVER/pull/371)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->